### PR TITLE
feat: support for using docker for Octez

### DIFF
--- a/crates/jstz_cli/src/config.rs
+++ b/crates/jstz_cli/src/config.rs
@@ -9,7 +9,7 @@ use derive_more::{From, TryInto};
 use jstz_crypto::{public_key::PublicKey, secret_key::SecretKey};
 use jstz_proto::context::account::Address;
 use log::debug;
-use octez::{OctezClient, OctezNode, OctezRollupNode};
+use octez::{OctezClient, OctezNode, OctezRollupNode, OctezSetup};
 use serde::{Deserialize, Serialize};
 use serde_with::{DeserializeFromStr, SerializeDisplay};
 
@@ -189,9 +189,9 @@ impl<'a> Iterator for AccountsIter<'a> {
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct Config {
-    /// Path to octez installation
+    /// Octez setup configuration: Process path or Docker container
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub octez_path: Option<PathBuf>,
+    pub octez_setup: Option<OctezSetup>,
     /// Sandbox config (None if sandbox is not running)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sandbox: Option<SandboxConfig>,
@@ -328,10 +328,7 @@ impl Config {
         let network = self.network(network_name)?;
 
         Ok(OctezClient {
-            octez_client_bin: self
-                .octez_path
-                .as_ref()
-                .map(|path| path.join("octez-client")),
+            octez_setup: self.octez_setup.clone(),
             octez_client_dir: self.octez_client_dir(network_name)?,
             endpoint: network.octez_node_rpc_endpoint,
             disable_disclaimer: true,
@@ -352,7 +349,7 @@ impl Config {
         let sandbox = self.sandbox()?;
 
         Ok(OctezNode {
-            octez_node_bin: self.octez_path.as_ref().map(|path| path.join("octez-node")),
+            octez_setup: self.octez_setup.clone(),
             octez_node_dir: sandbox.octez_node_dir.clone(),
         })
     }
@@ -366,10 +363,7 @@ impl Config {
         let network = self.network(network_name)?;
 
         Ok(OctezRollupNode {
-            octez_rollup_node_bin: self
-                .octez_path
-                .as_ref()
-                .map(|path| path.join("octez-smart-rollup-node")),
+            octez_setup: self.octez_setup.clone(),
             octez_rollup_node_dir: sandbox.octez_rollup_node_dir.clone(),
             octez_client_dir: self.octez_client_dir(network_name)?,
             endpoint: network.octez_node_rpc_endpoint,

--- a/crates/jstz_cli/src/sandbox/consts.rs
+++ b/crates/jstz_cli/src/sandbox/consts.rs
@@ -1,5 +1,6 @@
 use crate::sandbox::daemon::SandboxBootstrapAccount;
 
+pub const SANDBOX_LOCAL_HOST_LISTENING_ADDR: &str = "0.0.0.0";
 pub const SANDBOX_LOCAL_HOST_ADDR: &str = "127.0.0.1";
 pub const SANDBOX_OCTEZ_NODE_PORT: u16 = 18731;
 pub const SANDBOX_OCTEZ_NODE_RPC_PORT: u16 = 18730;

--- a/crates/jstz_rollup/src/main.rs
+++ b/crates/jstz_rollup/src/main.rs
@@ -10,7 +10,7 @@ use figment::{
 use jstz_rollup::{
     deploy_ctez_contract, rollup, BootstrapAccount, BridgeContract, JstzRollup,
 };
-use octez::{OctezClient, OctezRollupNode, OctezThread};
+use octez::{OctezClient, OctezRollupNode, OctezSetup, OctezThread};
 use serde::{Deserialize, Serialize};
 use tezos_crypto_rs::hash::{ContractKt1Hash, ContractTz1Hash, SmartRollupHash};
 
@@ -18,17 +18,16 @@ const JSTZ_ROLLUP_OPERATOR_ALIAS: &str = "jstz_rollup_operator";
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Config {
-    octez_client_bin: Option<PathBuf>,
+    octez_setup: Option<OctezSetup>,
     octez_client_dir: Option<PathBuf>,
     octez_node_endpoint: String,
-    octez_rollup_node_bin: Option<PathBuf>,
     octez_rollup_node_dir: PathBuf,
 }
 
 impl Config {
     fn octez_client(&self) -> OctezClient {
         OctezClient {
-            octez_client_bin: self.octez_client_bin.clone(),
+            octez_setup: self.octez_setup.clone(),
             octez_client_dir: self.octez_client_dir.clone(),
             endpoint: self.octez_node_endpoint.clone(),
             disable_disclaimer: true,
@@ -37,7 +36,7 @@ impl Config {
 
     fn octez_rollup_node(&self) -> OctezRollupNode {
         OctezRollupNode {
-            octez_rollup_node_bin: self.octez_rollup_node_bin.clone(),
+            octez_setup: self.octez_setup.clone(),
             octez_rollup_node_dir: self.octez_rollup_node_dir.clone(),
             octez_client_dir: self.octez_client_dir.clone(),
             endpoint: self.octez_node_endpoint.clone(),

--- a/crates/octez/src/lib.rs
+++ b/crates/octez/src/lib.rs
@@ -10,13 +10,49 @@ mod thread;
 pub use client::*;
 pub use node::*;
 pub use rollup::*;
+use serde::{Deserialize, Serialize};
 pub use thread::*;
 
-pub(crate) fn path_or_default<'a>(
-    path: Option<&'a PathBuf>,
-    default: &'a str,
-) -> &'a str {
-    path.and_then(|bin| bin.to_str()).unwrap_or(default)
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum OctezSetup {
+    /// Process path to Octez installation
+    Process(PathBuf),
+    /// Docker image tag for Octez
+    Docker(String),
+}
+
+impl OctezSetup {
+    pub fn command(
+        &self,
+        binary: &str,
+        mounts: impl IntoIterator<Item = impl AsRef<str>>,
+    ) -> Command {
+        match self {
+            Self::Process(path) => Command::new(path.join(binary)),
+            Self::Docker(image_tag) => {
+                let mut command = Command::new("docker");
+
+                command.args([
+                    "run",
+                    "--network=host",
+                    &format!("--entrypoint=/usr/local/bin/{}", binary),
+                    "-v",
+                    "/var:/var",
+                    "-v",
+                    "/tmp:/tmp",
+                ]);
+
+                for path in mounts {
+                    command.arg("-v");
+                    command.arg(format!("{0}:{0}", path.as_ref()));
+                }
+
+                command.arg(format!("tezos/tezos:{}", image_tag));
+
+                command
+            }
+        }
+    }
 }
 
 pub(crate) fn run_command_with_output(command: &mut Command) -> Result<String> {


### PR DESCRIPTION
# Context

This PR adds support for using Docker to run the octez-client, octez-node and octez-smart-rollup-node. 

# Description

The changes mainly focus around the introduction of `OctezSetup`, an enum that either allows one to use an installed version of octez or a docker image (e.g. `tezos/tezos:v20.0-rc1`). The enum has a method called `command` which will either return a command for the installed binary or a docker command that will start a container running the binary. 

# Manually Testing

With:
```
{
  "octez_setup": {
    "Docker": "v20.0-rc1"
  }
 ...
}
```

Run
```
jstz sandbox start
```