### PR TITLE
Handle jstz client 404 error

### DIFF
--- a/crates/jstz_cli/src/jstz.rs
+++ b/crates/jstz_cli/src/jstz.rs
@@ -81,6 +81,9 @@ impl JstzClient {
                 let code = response.json::<Option<String>>().await?;
                 Ok(code)
             }
+            StatusCode::NOT_FOUND => {
+                bail!("Account '{}' not found", address.to_base58())
+            }
             // For any other status, return a generic error
             _ => bail!("Failed to get the code"),
         }
@@ -95,6 +98,9 @@ impl JstzClient {
             StatusCode::OK => {
                 let balance = response.json::<u64>().await?;
                 Ok(balance)
+            }
+            StatusCode::NOT_FOUND => {
+                bail!("Account '{}' not found", address.to_base58())
             }
             _ => bail!("Failed to get the balance"),
         }


### PR DESCRIPTION
# Context

CLI should be able to handle 404 error
[Task](https://app.asana.com/0/1205770721173531/1206703424649696/f)

# Description

The get_code function didn't handle the case for 404 response. I've added an error message for this. 
Additionally, I noticed `get_balance` didn't handle this as well so i fixed that too.

# Manually testing the PR

<!-- Desc
<img width="565" alt="Screenshot 2024-03-20 at 13 57 05" src="https://github.com/trilitech/jstz/assets/128799322/341c2efe-c5b1-4a67-acf8-ea267991066e">
ribe how reviewers and approvers can test this PR. -->
