### PR TITLE
feat: add support for `null` or `undefined` bodies in `new Response` constructor

### DIFF
--- a/crates/jstz_api/src/http/response.rs
+++ b/crates/jstz_api/src/http/response.rs
@@ -535,8 +535,8 @@ impl NativeClass for ResponseClass {
         context: &mut Context<'_>,
     ) -> JsResult<Self::Instance> {
         let body: BodyWithType = match args.get(0) {
+            None | Some(JsValue::Undefined | JsValue::Null) => BodyWithType::default(),
             Some(value) => value.try_js_into(context)?,
-            None => Default::default(),
         };
 
         let options: ResponseOptions = match args.get(1) {


### PR DESCRIPTION
# Description

<!-- Please be sure to link the associated Runtime API task here. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

<!-- Describe your changes in detail. -->

Currently when creating a response object, you _must_ give non-null body, despite the prototype of the constructor being:
```
  new (body?: BodyInit | null, init?: ResponseInit): Response;
```

If `null` is given for `body`, then the following error is reported:
```
>> new Response(null)
✕  ERROR  Uncaught TypeError: value is not an ArrayBuffer object
```

# Manual testing

<!-- Describe how reviewers and approvers can manually test this PR. -->

```sh
cargo run --bin jstz -- repl
>> new Response(null)
{

}
```

# Checklist

- [x] Changes follow the existing code style (use `make fmt-check` to check)
- [ ] Tests for changes have been added
- [ ] Internal documentation has been added (if appropriate)
- [x] Testing instructions have been added to PR
