### PR TITLE
fix(octez): properly drop octez threads when done

### DIFF
--- a/crates/jstz_rollup/src/main.rs
+++ b/crates/jstz_rollup/src/main.rs
@@ -398,9 +398,9 @@ fn run(
         &addr,
         port,
     )?;
-    let thread = OctezThread::from_child(child);
+    let mut thread = OctezThread::from_child(child);
 
-    OctezThread::join(vec![thread])?;
+    OctezThread::join(&mut vec![&mut thread])?;
 
     Ok(())
 }

--- a/crates/octez/src/thread.rs
+++ b/crates/octez/src/thread.rs
@@ -13,7 +13,7 @@ use signal_hook::{
 
 pub struct OctezThread {
     shutdown_tx: Sender<()>,
-    thread_handle: JoinHandle<Result<()>>,
+    thread_handle: Option<JoinHandle<Result<()>>>,
 }
 
 impl OctezThread {
@@ -40,7 +40,7 @@ impl OctezThread {
 
         Self {
             shutdown_tx,
-            thread_handle,
+            thread_handle: Some(thread_handle),
         }
     }
 
@@ -66,26 +66,23 @@ impl OctezThread {
 
         Self {
             shutdown_tx,
-            thread_handle,
+            thread_handle: Some(thread_handle),
         }
     }
 
-    pub fn is_running(&self) -> bool {
-        !self.thread_handle.is_finished()
+    fn is_running(&self) -> bool {
+        self.thread_handle.is_some()
     }
 
-    pub fn shutdown(self) -> Result<()> {
-        self.shutdown_tx.send(())?;
-        match self.thread_handle.join() {
-            Ok(result) => result?,
-            Err(_) => {
-                // thread panicked
-            }
-        };
+    pub fn shutdown(&mut self) -> Result<()> {
+        if let Some(handle) = self.thread_handle.take() {
+            self.shutdown_tx.send(())?;
+            handle.join().unwrap().unwrap()
+        }
         Ok(())
     }
 
-    pub fn join(threads: Vec<Self>) -> Result<()> {
+    pub fn join(threads: &mut Vec<&mut Self>) -> Result<()> {
         let mut signals = Signals::new([SIGINT, SIGTERM])?;
 
         // Loop until 1 of the threads fails
@@ -109,11 +106,15 @@ impl OctezThread {
 
         // Shutdown all running threads
         for thread in threads {
-            if thread.is_running() {
-                thread.shutdown()?;
-            }
+            thread.shutdown()?;
         }
 
         Ok(())
+    }
+}
+
+impl Drop for OctezThread {
+    fn drop(&mut self) {
+        self.shutdown().unwrap();
     }
 }


### PR DESCRIPTION
# Context
This PR kills zombie octez processes started by the sandbox if the sandbox errors out or is killed before it reaches the main' `handle.join()`

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
Introduces a `Sandbox` struct that is responsible for performing the clean up of octez threads and reverting the config file in the event of error.  FWIW, there is definitely more that can be done to come up with a better solution but I have restrained myself from refactoring everything.


<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
1. Apply the following patch to `main` branch to introduce a panic after the octez processes have started. 
```rust
diff --git a/crates/jstz_cli/src/sandbox/daemon.rs b/crates/jstz_cli/src/sandbox/daemon.rs
index 2962a9d..a9dc52b 100644
--- a/crates/jstz_cli/src/sandbox/daemon.rs
+++ b/crates/jstz_cli/src/sandbox/daemon.rs
@@ -573,6 +573,7 @@ pub async fn run_sandbox(cfg: &mut Config) -> Result<()> {
     debug!(log_file, "Saving sandbox config");
     cfg.save()?;
     // 4. Wait for the sandbox or jstz-node to shutdown (either by the user or by an error)
+    panic!();
     run_jstz_node(cfg).await?;
     sandbox.join()?;
     Ok(())
```

2. Observe that octez processes have been killed
`ps -ae | grep octez`
3. `cat ~/.jstz/config.json` show no remnants of sandbox configurations

<!-- Describe how reviewers and approvers can test this PR. -->
