### PR TITLE
fix(sandbox): fix sandbox not shutting down on ctrl+c

### DIFF
--- a/crates/jstz_node/src/lib.rs
+++ b/crates/jstz_node/src/lib.rs
@@ -1,5 +1,5 @@
 use std::io::{self, ErrorKind::Other};
-use std::path::Path;
+use std::path::PathBuf;
 
 use actix_cors::Cors;
 use actix_web::{middleware::Logger, web::Data, App, HttpServer};
@@ -16,15 +16,15 @@ pub use services::{AccountsService, LogsService, OperationsService, Service};
 pub async fn run(
     addr: &str,
     port: u16,
-    rollup_endpoint: &str,
-    kernel_log_path: &Path,
+    rollup_endpoint: String,
+    kernel_log_path: PathBuf,
 ) -> anyhow::Result<()> {
     let rollup_client = Data::new(OctezRollupClient::new(rollup_endpoint.to_string()));
 
     let cancellation_token = CancellationToken::new();
 
     let (broadcaster, db, tail_file_handle) =
-        LogsService::init(kernel_log_path, &cancellation_token)
+        LogsService::init(&kernel_log_path, &cancellation_token)
             .await
             .map_err(|e| io::Error::new(Other, e.to_string()))?;
 

--- a/crates/jstz_node/src/main.rs
+++ b/crates/jstz_node/src/main.rs
@@ -43,11 +43,5 @@ async fn main() -> anyhow::Result<()> {
         args.rollup_node_rpc_addr, args.rollup_node_rpc_port
     ));
 
-    jstz_node::run(
-        &args.addr,
-        args.port,
-        &rollup_endpoint,
-        &args.kernel_log_path,
-    )
-    .await
+    jstz_node::run(&args.addr, args.port, rollup_endpoint, args.kernel_log_path).await
 }

--- a/crates/octez/src/thread.rs
+++ b/crates/octez/src/thread.rs
@@ -70,14 +70,18 @@ impl OctezThread {
         }
     }
 
-    fn is_running(&self) -> bool {
-        self.thread_handle.is_some()
+    pub fn is_running(&self) -> bool {
+        if let Some(thread_handle) = &self.thread_handle {
+            !thread_handle.is_finished()
+        } else {
+            false
+        }
     }
 
     pub fn shutdown(&mut self) -> Result<()> {
-        if let Some(handle) = self.thread_handle.take() {
-            self.shutdown_tx.send(())?;
-            handle.join().unwrap().unwrap()
+        if self.is_running() {
+            let _ = self.shutdown_tx.send(());
+            self.thread_handle.take().unwrap().join().unwrap()?;
         }
         Ok(())
     }


### PR DESCRIPTION
# Context
<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->
Fix bug introduced in the https://github.com/jstz-dev/jstz/pull/525 . The octez threads were not shutting down. When jstz node is shutdown, we should terminate the sandbox.

Additionally, this PR ensures that all processes are killed when any one process is killed.

# Description


<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
1. Start sandbox then kill it after it is fully loaded.
2. Start sanbox then kill octez or jstz processes via `kill <pid>`
<!-- Describe how reviewers and approvers can test this PR. -->
