### PR TITLE
feat(ticket-table): implement ticket table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2349,6 +2349,7 @@ name = "jstz_mock"
 version = "0.1.0-alpha.0"
 dependencies = [
  "jstz_core",
+ "jstz_crypto",
  "tezos-smart-rollup",
  "tezos-smart-rollup-mock",
  "tezos_crypto_rs 0.6.0",
@@ -2405,6 +2406,7 @@ dependencies = [
  "jstz_api",
  "jstz_core",
  "jstz_crypto",
+ "jstz_mock",
  "serde",
  "serde_json",
  "tezos-smart-rollup",

--- a/crates/jstz_mock/Cargo.toml
+++ b/crates/jstz_mock/Cargo.toml
@@ -10,3 +10,4 @@ tezos-smart-rollup.workspace = true
 tezos-smart-rollup-mock.workspace = true 
 tezos_crypto_rs.workspace = true
 jstz_core.workspace = true
+jstz_crypto.workspace = true

--- a/crates/jstz_mock/src/mock.rs
+++ b/crates/jstz_mock/src/mock.rs
@@ -1,6 +1,7 @@
 use std::io::empty;
 
 use jstz_core::{host::HostRuntime, kv::Storage};
+use jstz_crypto::hash::Blake2b;
 use tezos_crypto_rs::hash::ContractKt1Hash;
 use tezos_smart_rollup::{
     michelson::{
@@ -108,4 +109,16 @@ impl Default for MockNativeDeposit {
             smart_rollup: None,
         }
     }
+}
+
+pub fn account1() -> jstz_crypto::public_key_hash::PublicKeyHash {
+    jstz_crypto::public_key_hash::PublicKeyHash::from_base58(
+        "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx",
+    )
+    .unwrap()
+}
+
+pub fn ticket_hash1() -> Blake2b {
+    let data = vec![b'0', b'0', b'0'];
+    Blake2b::from(&data)
 }

--- a/crates/jstz_proto/Cargo.toml
+++ b/crates/jstz_proto/Cargo.toml
@@ -27,3 +27,4 @@ either = "1.9.0"
 
 [dev-dependencies]
 tezos-smart-rollup-mock.workspace = true
+jstz_mock.workspace = true

--- a/crates/jstz_proto/src/context/mod.rs
+++ b/crates/jstz_proto/src/context/mod.rs
@@ -1,2 +1,3 @@
 pub mod account;
 pub mod receipt;
+pub mod ticket_table;

--- a/crates/jstz_proto/src/context/ticket_table.rs
+++ b/crates/jstz_proto/src/context/ticket_table.rs
@@ -1,0 +1,221 @@
+use crate::error::Result;
+use derive_more::{Display, Error, From};
+use jstz_core::kv::Transaction;
+use jstz_crypto::{hash::Blake2b, public_key_hash::PublicKeyHash};
+use tezos_smart_rollup::{
+    host::Runtime,
+    storage::path::{self, OwnedPath, RefPath},
+};
+
+use super::account::Amount;
+
+#[derive(Display, Debug, Error, From)]
+pub enum TicketTableError {
+    InsufficientFunds,
+    AccountNotFound,
+    TicketHashNotFound,
+}
+
+const TICKET_TABLE_PATH: RefPath = RefPath::assert_from(b"/ticket_table");
+
+pub struct TicketTable;
+
+impl TicketTable {
+    fn path(suffix: &OwnedPath) -> Result<OwnedPath> {
+        Ok(path::concat(&TICKET_TABLE_PATH, suffix)?)
+    }
+
+    pub fn balance_add(
+        rt: &mut impl Runtime,
+        tx: &mut Transaction,
+        owner: &PublicKeyHash,
+        ticket_hash: &Blake2b,
+        amount: Amount, // TODO: check if its the correct size
+    ) -> Result<Amount> {
+        let ticket_hash_path =
+            OwnedPath::try_from(format!("/{}", ticket_hash.to_string()))?;
+        let owner_path = OwnedPath::try_from(format!("/{}", owner))?;
+        let path = Self::path(&path::concat(&ticket_hash_path, &owner_path)?)?;
+
+        match tx.get::<Amount>(rt, path.clone())? {
+            None => {
+                tx.insert(path, amount)?;
+                Ok(amount)
+            }
+            Some(balance) => {
+                let checked_balance = balance
+                    .checked_add(amount)
+                    .ok_or(crate::error::Error::BalanceOverflow)?;
+                tx.insert(path, checked_balance)?;
+                Ok(checked_balance)
+            }
+        }
+    }
+
+    pub fn balance_sub(
+        rt: &mut impl Runtime,
+        tx: &mut Transaction,
+        owner: &PublicKeyHash,
+        ticket_hash: &Blake2b,
+        amount: u64,
+    ) -> Result<Amount> {
+        let ticket_hash_path =
+            OwnedPath::try_from(format!("/{}", ticket_hash.to_string()))?;
+        let owner_path = OwnedPath::try_from(format!("/{}", owner))?;
+        let path = Self::path(&path::concat(&ticket_hash_path, &owner_path)?)?;
+
+        match tx.get::<Amount>(rt, path.clone())? {
+            None => Err(TicketTableError::AccountNotFound)?,
+            Some(balance) => {
+                if *balance < amount {
+                    return Err(TicketTableError::InsufficientFunds)?;
+                }
+                let final_balance = balance - amount;
+                tx.insert(path, final_balance)?;
+                Ok(final_balance)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use jstz_core::kv::{Storage, Transaction};
+    use jstz_crypto::{hash::Blake2b, public_key_hash::PublicKeyHash};
+    use jstz_mock::mock::{self, JstzMockHost};
+    use tezos_smart_rollup::{host::Runtime, storage::path::OwnedPath};
+    use tezos_smart_rollup_mock::MockHost;
+
+    use super::TicketTable;
+
+    fn get_ticket_value(
+        rt: &mut impl Runtime,
+        ticket_hash: &Blake2b,
+        owner: &PublicKeyHash,
+    ) -> Option<u64> {
+        let path = TicketTable::path(
+            &OwnedPath::try_from(format!("/{}/{}", ticket_hash.to_string(), owner))
+                .unwrap(),
+        )
+        .unwrap();
+
+        Storage::get::<u64>(rt, &path).unwrap()
+    }
+
+    #[test]
+    fn add_tickets_succeeds() {
+        let mut host = JstzMockHost::default();
+        let mut tx = Transaction::default();
+
+        tx.begin();
+        let owner = mock::account1();
+        let ticket_hash = mock::ticket_hash1();
+        let amount = 100;
+        TicketTable::balance_add(host.rt(), &mut tx, &owner, &ticket_hash, amount)
+            .unwrap();
+        tx.commit(host.rt()).unwrap();
+        let balance = get_ticket_value(host.rt(), &ticket_hash, &owner).unwrap();
+        assert_eq!(100, balance);
+
+        tx.begin();
+        let another_amount = 50;
+        TicketTable::balance_add(
+            host.rt(),
+            &mut tx,
+            &owner,
+            &ticket_hash,
+            another_amount,
+        )
+        .unwrap();
+        tx.commit(host.rt()).unwrap();
+        let balance = get_ticket_value(host.rt(), &ticket_hash, &owner).unwrap();
+        assert_eq!(150, balance);
+    }
+
+    #[test]
+    fn add_tickets_overflow_fails() {
+        let mut host = JstzMockHost::default();
+        let mut tx = Transaction::default();
+
+        tx.begin();
+        let owner = mock::account1();
+        let ticket_hash = mock::ticket_hash1();
+        let amount = u64::MAX;
+        TicketTable::balance_add(host.rt(), &mut tx, &owner, &ticket_hash, amount)
+            .unwrap();
+        let err = TicketTable::balance_add(host.rt(), &mut tx, &owner, &ticket_hash, 1)
+            .expect_err("Expected error");
+        assert_eq!("BalanceOverflow", err.to_string());
+    }
+
+    #[test]
+    fn sub_tickets_succeeds() {
+        let mut host = JstzMockHost::default();
+        let mut tx = Transaction::default();
+
+        tx.begin();
+        let owner = mock::account1();
+        let ticket_hash = mock::ticket_hash1();
+        let amount = 100;
+        TicketTable::balance_add(host.rt(), &mut tx, &owner, &ticket_hash, amount)
+            .unwrap();
+        let another_amount = 70;
+        TicketTable::balance_sub(
+            host.rt(),
+            &mut tx,
+            &owner,
+            &ticket_hash,
+            another_amount,
+        )
+        .unwrap();
+        tx.commit(host.rt()).unwrap();
+        let balance = get_ticket_value(host.rt(), &ticket_hash, &owner).unwrap();
+        assert_eq!(30, balance);
+    }
+
+    #[test]
+    fn sub_tickets_account_not_found_fails() {
+        let mut host = JstzMockHost::default();
+        let mut tx = Transaction::default();
+
+        tx.begin();
+        let owner = mock::account1();
+        let ticket_hash = mock::ticket_hash1();
+        let amount = 100;
+        let err =
+            TicketTable::balance_sub(host.rt(), &mut tx, &owner, &ticket_hash, amount)
+                .expect_err("Expected error");
+        assert_eq!(err.to_string(), "AccountNotFound");
+        let balance = get_ticket_value(host.rt(), &ticket_hash, &owner);
+        assert_eq!(None, balance);
+    }
+
+    #[test]
+    fn update_tickets_in_succession() {
+        let mut rt = MockHost::default();
+        let mut tx = Transaction::default();
+        let owner = mock::account1();
+        let ticket_hash = mock::ticket_hash1();
+
+        let add_100 = 100;
+        let sub_30 = 30;
+        let add_25 = 25;
+        let sub_25 = 25;
+        let add_60 = 60;
+
+        tx.begin();
+        TicketTable::balance_add(&mut rt, &mut tx, &owner, &ticket_hash, add_100)
+            .unwrap();
+        tx.commit(&mut rt).unwrap();
+        tx.begin();
+        TicketTable::balance_sub(&mut rt, &mut tx, &owner, &ticket_hash, sub_30).unwrap();
+        TicketTable::balance_add(&mut rt, &mut tx, &owner, &ticket_hash, add_25).unwrap();
+        tx.begin();
+        TicketTable::balance_sub(&mut rt, &mut tx, &owner, &ticket_hash, sub_25).unwrap();
+        TicketTable::balance_add(&mut rt, &mut tx, &owner, &ticket_hash, add_60).unwrap();
+        tx.commit(&mut rt).unwrap();
+        tx.commit(&mut rt).unwrap();
+        let result = get_ticket_value(&mut rt, &ticket_hash, &owner).unwrap();
+        assert_eq!(130, result)
+    }
+}

--- a/crates/jstz_proto/src/error.rs
+++ b/crates/jstz_proto/src/error.rs
@@ -1,16 +1,25 @@
 use boa_engine::{JsError, JsNativeError};
 use derive_more::{Display, Error, From};
 
+use crate::context::ticket_table;
+
 #[derive(Display, Debug, Error, From)]
 pub enum Error {
-    CoreError { source: jstz_core::Error },
-    CryptoError { source: jstz_crypto::Error },
+    CoreError {
+        source: jstz_core::Error,
+    },
+    CryptoError {
+        source: jstz_crypto::Error,
+    },
     BalanceOverflow,
     InvalidNonce,
     InvalidAddress,
     RefererShouldNotBeSet,
     GasLimitExceeded,
     InvalidHttpRequest,
+    TicketTableError {
+        source: ticket_table::TicketTableError,
+    },
 }
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -38,6 +47,9 @@ impl From<Error> for JsError {
                 .into(),
             Error::InvalidHttpRequest => JsNativeError::eval()
                 .with_message("InvalidHttpRequest")
+                .into(),
+            Error::TicketTableError { source } => JsNativeError::eval()
+                .with_message(format!("TicketTableError: {}", source))
                 .into(),
         }
     }


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->
The TicketTable keeps track of tickets (except the tez ticket) sent to the jstz rollup to facilitate permissionless deposit/withdrawal of bridged assets to/from jstz. Unlike L1, tickets can only be added or removed and not created or transferred between accounts. This means that tickets can only be used to bridge assets created on L1 to jstz, and not vice versa.

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
`cargo test -p jstz_proto ticket`
<!-- Describe how reviewers and approvers can test this PR. -->
