### PR TITLE
feat(fa-deposit): handle fa deposit execution in proto

### DIFF
--- a/crates/jstz_kernel/src/inbox.rs
+++ b/crates/jstz_kernel/src/inbox.rs
@@ -1,7 +1,6 @@
 use jstz_crypto::public_key_hash::PublicKeyHash;
 use jstz_proto::operation::{external::Deposit, ExternalOperation, SignedOperation};
 use num_traits::ToPrimitive;
-use serde::{Deserialize, Serialize};
 use tezos_crypto_rs::hash::ContractKt1Hash;
 use tezos_smart_rollup::inbox::ExternalMessageFrame;
 use tezos_smart_rollup::michelson::ticket::FA2_1Ticket;
@@ -18,7 +17,7 @@ use tezos_smart_rollup::{
 pub type ExternalMessage = SignedOperation;
 pub type InternalMessage = ExternalOperation;
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Message {
     External(ExternalMessage),
     Internal(InternalMessage),

--- a/crates/jstz_mock/src/mock.rs
+++ b/crates/jstz_mock/src/mock.rs
@@ -1,12 +1,12 @@
 use std::io::empty;
 
 use jstz_core::{host::HostRuntime, kv::Storage};
-use jstz_crypto::hash::Blake2b;
 use tezos_crypto_rs::hash::ContractKt1Hash;
 use tezos_smart_rollup::{
     michelson::{
-        ticket::{FA2_1Ticket, Ticket},
+        ticket::{FA2_1Ticket, Ticket, TicketHash, UnitTicket},
         MichelsonBytes, MichelsonContract, MichelsonNat, MichelsonOption, MichelsonPair,
+        MichelsonUnit,
     },
     storage::path::RefPath,
     types::{Contract, PublicKeyHash, SmartRollupAddress},
@@ -118,7 +118,19 @@ pub fn account1() -> jstz_crypto::public_key_hash::PublicKeyHash {
     .unwrap()
 }
 
-pub fn ticket_hash1() -> Blake2b {
-    let data = vec![b'0', b'0', b'0'];
-    Blake2b::from(&data)
+pub fn account2() -> jstz_crypto::public_key_hash::PublicKeyHash {
+    jstz_crypto::public_key_hash::PublicKeyHash::from_base58(
+        "tz1QcqnzZ8pa6VuE4MSeMjsJkiW94wNrPbgX",
+    )
+    .unwrap()
+}
+
+pub fn ticket_hash1() -> TicketHash {
+    let ticket = UnitTicket::new(
+        Contract::from_b58check("tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx").unwrap(),
+        MichelsonUnit,
+        10,
+    )
+    .unwrap();
+    ticket.hash().unwrap()
 }

--- a/crates/jstz_proto/src/error.rs
+++ b/crates/jstz_proto/src/error.rs
@@ -1,7 +1,7 @@
 use boa_engine::{JsError, JsNativeError};
 use derive_more::{Display, Error, From};
 
-use crate::context::ticket_table;
+use crate::{context::ticket_table, executor::fa_deposit};
 
 #[derive(Display, Debug, Error, From)]
 pub enum Error {
@@ -19,6 +19,9 @@ pub enum Error {
     InvalidHttpRequest,
     TicketTableError {
         source: ticket_table::TicketTableError,
+    },
+    FaDepositError {
+        source: fa_deposit::FaDepositError,
     },
 }
 pub type Result<T> = std::result::Result<T, Error>;
@@ -50,6 +53,9 @@ impl From<Error> for JsError {
                 .into(),
             Error::TicketTableError { source } => JsNativeError::eval()
                 .with_message(format!("TicketTableError: {}", source))
+                .into(),
+            Error::FaDepositError { source } => JsNativeError::eval()
+                .with_message(format!("FaDepositError: {}", source))
                 .into(),
         }
     }

--- a/crates/jstz_proto/src/executor/fa_deposit.rs
+++ b/crates/jstz_proto/src/executor/fa_deposit.rs
@@ -1,0 +1,418 @@
+use crate::{
+    context::{account::Amount, ticket_table::TicketTable},
+    executor::smart_function,
+    operation::{external::FaDeposit, RunFunction},
+    receipt::Receipt,
+    Result,
+};
+use derive_more::{Display, Error, From};
+use http::{header::CONTENT_TYPE, HeaderMap, Method, Uri};
+use jstz_api::http::body::HttpBody;
+use jstz_core::{host::HostRuntime, kv::Transaction};
+use jstz_crypto::public_key_hash::PublicKeyHash;
+use serde::{Deserialize, Serialize};
+use tezos_smart_rollup::{michelson::ticket::TicketHash, prelude::debug_msg};
+
+const FA_DEPOSIT_GAS_LIMIT: usize = usize::MAX;
+
+// TODO: https://linear.app/tezos/issue/JSTZ-36/use-cryptos-from-tezos-crypto
+// Properly represent the null address
+const NULL_ADDRESS: &str = "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx";
+const DEPOSIT_URI: &str = "/-/deposit";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FaDepositReceiptContent {
+    pub receiver: PublicKeyHash,
+    pub ticket_balance: Amount,
+    pub run_function: Option<crate::receipt::RunFunction>,
+}
+
+#[derive(Display, Debug, Error, From)]
+pub enum FaDepositError {
+    InvalidHeaderValue,
+    InvalidUri,
+}
+
+fn deposit_to_receiver(
+    rt: &mut impl HostRuntime,
+    tx: &mut Transaction,
+    receiver: &PublicKeyHash,
+    ticket_hash: &TicketHash,
+    amount: Amount,
+) -> Result<FaDepositReceiptContent> {
+    let final_balance = TicketTable::add(rt, tx, receiver, ticket_hash, amount)?;
+    Ok(FaDepositReceiptContent {
+        receiver: receiver.clone(),
+        ticket_balance: final_balance,
+        run_function: None,
+    })
+}
+
+fn new_run_function(
+    http_body: HttpBody,
+    proxy_contract: &PublicKeyHash,
+) -> Result<RunFunction> {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        CONTENT_TYPE,
+        "application/json; charset=utf-8"
+            .parse()
+            .map_err(|_| FaDepositError::InvalidHeaderValue)?,
+    );
+    Ok(RunFunction {
+        uri: Uri::builder()
+            .scheme("tezos")
+            .authority(proxy_contract.to_string())
+            .path_and_query(DEPOSIT_URI)
+            .build()
+            .map_err(|_| FaDepositError::InvalidUri)?,
+        method: Method::POST,
+        headers,
+        body: http_body,
+        gas_limit: FA_DEPOSIT_GAS_LIMIT,
+    })
+}
+
+fn deposit_to_proxy_contract(
+    rt: &mut impl HostRuntime,
+    tx: &mut Transaction,
+    deposit: &FaDeposit,
+    proxy_contract: &PublicKeyHash,
+) -> Result<FaDepositReceiptContent> {
+    let run = new_run_function(deposit.to_http_body(), proxy_contract)?;
+    let source = PublicKeyHash::from_base58(NULL_ADDRESS)?;
+    let result = smart_function::run::execute(rt, tx, &source, run, deposit.hash());
+    match result {
+        Ok(run_receipt) => {
+            if run_receipt.status_code.is_success() {
+                let final_balance = TicketTable::add(
+                    rt,
+                    tx,
+                    proxy_contract,
+                    &deposit.ticket_hash,
+                    deposit.amount,
+                )?;
+                Ok(FaDepositReceiptContent {
+                    receiver: proxy_contract.clone(),
+                    ticket_balance: final_balance,
+                    run_function: Some(run_receipt),
+                })
+            } else {
+                let mut result = deposit_to_receiver(
+                    rt,
+                    tx,
+                    &deposit.receiver,
+                    &deposit.ticket_hash,
+                    deposit.amount,
+                )?;
+                result.run_function = Some(run_receipt);
+                Ok(result)
+            }
+        }
+        Err(error) => {
+            debug_msg!(
+                rt,
+                "Failed to execute proxy function when performing fa deposit: {error:?}\n"
+            );
+            let result = deposit_to_receiver(
+                rt,
+                tx,
+                &deposit.receiver,
+                &deposit.ticket_hash,
+                deposit.amount,
+            )?;
+            Ok(result)
+        }
+    }
+}
+
+fn execute_inner(
+    rt: &mut impl HostRuntime,
+    tx: &mut Transaction,
+    deposit: &FaDeposit,
+) -> Result<FaDepositReceiptContent> {
+    match &deposit.proxy_smart_function {
+        None => deposit_to_receiver(
+            rt,
+            tx,
+            &deposit.receiver,
+            &deposit.ticket_hash,
+            deposit.amount,
+        ),
+        Some(proxy_contract) => {
+            deposit_to_proxy_contract(rt, tx, deposit, proxy_contract)
+        }
+    }
+}
+
+pub fn execute(
+    rt: &mut impl HostRuntime,
+    tx: &mut Transaction,
+    deposit: FaDeposit,
+) -> Receipt {
+    let content = execute_inner(rt, tx, &deposit)
+        .expect("Unreachable: Failed to execute fa deposit!\n");
+    let operation_hash = deposit.hash();
+    Receipt::new(
+        operation_hash,
+        Ok(crate::receipt::Content::FaDeposit(content)),
+    )
+}
+
+#[cfg(test)]
+mod test {
+
+    use std::io::empty;
+
+    use jstz_core::kv::Transaction;
+    use jstz_crypto::public_key_hash::PublicKeyHash;
+    use jstz_mock::mock;
+    use tezos_smart_rollup_mock::MockHost;
+
+    use crate::{
+        context::{account::ParsedCode, ticket_table::TicketTable},
+        executor::fa_deposit::{FaDeposit, FaDepositReceiptContent},
+        receipt::{Content, Receipt},
+    };
+
+    fn mock_fa_deposit(proxy: Option<PublicKeyHash>) -> FaDeposit {
+        FaDeposit {
+            inbox_id: 34,
+            amount: 42,
+            receiver: mock::account2(),
+            proxy_smart_function: proxy,
+            ticket_hash: mock::ticket_hash1(),
+        }
+    }
+
+    #[test]
+    fn execute_fa_deposit_into_account_succeeds() {
+        let fa_deposit = mock_fa_deposit(None);
+        let expected_receiver = fa_deposit.receiver.clone();
+        let ticket_hash = fa_deposit.ticket_hash.clone();
+        let expected_balance = fa_deposit.amount;
+        let expected_hash = fa_deposit.hash();
+        let mut host = MockHost::default();
+        let mut tx = Transaction::default();
+        tx.begin();
+        let receipt = super::execute(&mut host, &mut tx, fa_deposit);
+
+        assert_eq!(expected_hash, *receipt.hash());
+
+        match receipt.inner {
+            Ok(Content::FaDeposit(FaDepositReceiptContent {
+                receiver,
+                ticket_balance,
+                run_function,
+            })) => {
+                assert_eq!(expected_receiver, receiver);
+                assert_eq!(expected_balance, ticket_balance);
+                assert!(run_function.is_none());
+
+                let balance = TicketTable::get_balance(
+                    &mut host,
+                    &mut tx,
+                    &expected_receiver,
+                    &ticket_hash,
+                )
+                .unwrap();
+                assert_eq!(expected_balance, balance);
+            }
+            _ => panic!("Expected success"),
+        }
+    }
+
+    #[test]
+    fn execute_multiple_fa_deposit_into_account_succeeds() {
+        let fa_deposit1 = mock_fa_deposit(None);
+        let fa_deposit2 = mock_fa_deposit(None);
+        let expected_receiver = fa_deposit2.receiver.clone();
+        let ticket_hash = fa_deposit2.ticket_hash.clone();
+        let expected_hash = fa_deposit2.hash();
+        let mut host = MockHost::default();
+        let mut tx = Transaction::default();
+        tx.begin();
+
+        let _ = super::execute(&mut host, &mut tx, fa_deposit1);
+        let receipt = super::execute(&mut host, &mut tx, fa_deposit2);
+
+        assert_eq!(expected_hash, *receipt.hash());
+
+        match receipt.inner {
+            Ok(Content::FaDeposit(FaDepositReceiptContent {
+                receiver,
+                ticket_balance,
+                run_function,
+            })) => {
+                assert_eq!(84, ticket_balance);
+                assert_eq!(expected_receiver, receiver);
+                assert!(run_function.is_none());
+                let balance = TicketTable::get_balance(
+                    &mut host,
+                    &mut tx,
+                    &expected_receiver,
+                    &ticket_hash,
+                )
+                .unwrap();
+                assert_eq!(84, balance);
+            }
+            _ => panic!("Expected success"),
+        }
+    }
+
+    #[test]
+    fn execute_fa_deposit_into_proxy_succeeds() {
+        let mut host = MockHost::default();
+        host.set_debug_handler(empty());
+        let mut tx = Transaction::default();
+        let source = mock::account1();
+        let code = r#"
+        export default (request) => {
+            const url = new URL(request.url)
+            if (url.pathname === "/-/deposit") {
+                return new Response();
+            }
+            return Response.error();
+        }
+        "#;
+        let parsed_code = ParsedCode::try_from(code.to_string()).unwrap();
+        tx.begin();
+        let proxy = crate::executor::smart_function::Script::deploy(
+            &mut host,
+            &mut tx,
+            &source,
+            parsed_code,
+            100,
+        )
+        .unwrap();
+        let fa_deposit = mock_fa_deposit(Some(proxy.clone()));
+        let ticket_hash = fa_deposit.ticket_hash.clone();
+
+        let Receipt { inner, .. } = super::execute(&mut host, &mut tx, fa_deposit);
+
+        match inner {
+            Ok(Content::FaDeposit(FaDepositReceiptContent {
+                receiver,
+                ticket_balance,
+                run_function,
+            })) => {
+                assert_eq!(42, ticket_balance);
+                assert_eq!(proxy, receiver);
+                assert!(run_function.is_some());
+                let balance =
+                    TicketTable::get_balance(&mut host, &mut tx, &proxy, &ticket_hash)
+                        .unwrap();
+                assert_eq!(42, balance);
+            }
+            _ => panic!("Expected success"),
+        }
+    }
+
+    #[test]
+    fn execute_multiple_fa_deposit_into_proxy_succeeds() {
+        let mut host = MockHost::default();
+        host.set_debug_handler(empty());
+        let mut tx = Transaction::default();
+        let source = mock::account1();
+        let code = r#"
+        export default (request) => {
+            const url = new URL(request.url)
+            if (url.pathname === "/-/deposit") {
+                return new Response();
+            }
+            return Response.error();
+        }
+        "#;
+        let parsed_code = ParsedCode::try_from(code.to_string()).unwrap();
+        tx.begin();
+        let proxy = crate::executor::smart_function::Script::deploy(
+            &mut host,
+            &mut tx,
+            &source,
+            parsed_code,
+            100,
+        )
+        .unwrap();
+        let fa_deposit1 = mock_fa_deposit(Some(proxy.clone()));
+        let ticket_hash = fa_deposit1.ticket_hash.clone();
+
+        let _ = super::execute(&mut host, &mut tx, fa_deposit1);
+
+        let fa_deposit2 = mock_fa_deposit(Some(proxy.clone()));
+
+        let Receipt { inner, .. } = super::execute(&mut host, &mut tx, fa_deposit2);
+
+        match inner {
+            Ok(Content::FaDeposit(FaDepositReceiptContent {
+                receiver,
+                ticket_balance,
+                run_function,
+            })) => {
+                assert_eq!(84, ticket_balance);
+                assert_eq!(proxy, receiver);
+                assert!(run_function.is_some());
+                let balance =
+                    TicketTable::get_balance(&mut host, &mut tx, &proxy, &ticket_hash)
+                        .unwrap();
+                assert_eq!(84, balance);
+            }
+            _ => panic!("Expected success"),
+        }
+    }
+
+    #[test]
+    fn execute_fa_deposit_fails_when_proxy_contract_fails() {
+        let mut host = MockHost::default();
+        host.set_debug_handler(empty());
+        let mut tx = Transaction::default();
+        tx.begin();
+        let source = mock::account1();
+        let code = r#"
+        export default (request) => {
+            const url = new URL(request.url)
+            return Response.error();
+        }
+        "#;
+        let parsed_code = ParsedCode::try_from(code.to_string()).unwrap();
+        let proxy = crate::executor::smart_function::Script::deploy(
+            &mut host,
+            &mut tx,
+            &source,
+            parsed_code,
+            100,
+        )
+        .unwrap();
+
+        let fa_deposit = mock_fa_deposit(Some(proxy.clone()));
+        let expected_receiver = fa_deposit.receiver.clone();
+        let ticket_hash = fa_deposit.ticket_hash.clone();
+
+        let Receipt { inner, .. } = super::execute(&mut host, &mut tx, fa_deposit);
+
+        match inner {
+            Ok(Content::FaDeposit(FaDepositReceiptContent {
+                receiver,
+                ticket_balance,
+                run_function,
+            })) => {
+                assert_eq!(500, run_function.unwrap().status_code);
+                assert_eq!(expected_receiver, receiver);
+                assert_eq!(42, ticket_balance);
+                let proxy_balance =
+                    TicketTable::get_balance(&mut host, &mut tx, &proxy, &ticket_hash)
+                        .unwrap();
+                assert_eq!(0, proxy_balance);
+
+                let receiver_balance = TicketTable::get_balance(
+                    &mut host,
+                    &mut tx,
+                    &expected_receiver,
+                    &ticket_hash,
+                )
+                .unwrap();
+                assert_eq!(42, receiver_balance);
+            }
+            _ => panic!("Expected success"),
+        }
+    }
+}

--- a/crates/jstz_proto/src/executor/mod.rs
+++ b/crates/jstz_proto/src/executor/mod.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 
 pub mod deposit;
+pub mod fa_deposit;
 pub mod smart_function;
 
 fn execute_operation_inner(

--- a/crates/jstz_proto/src/receipt.rs
+++ b/crates/jstz_proto/src/receipt.rs
@@ -2,7 +2,10 @@ use http::{HeaderMap, StatusCode};
 use jstz_api::http::body::HttpBody;
 use serde::{Deserialize, Serialize};
 
-use crate::{context::account::Address, operation::OperationHash, Result};
+use crate::{
+    context::account::Address, executor::fa_deposit::FaDepositReceiptContent,
+    operation::OperationHash, Result,
+};
 
 pub type ReceiptResult<T> = std::result::Result<T, String>;
 
@@ -41,4 +44,5 @@ pub struct RunFunction {
 pub enum Content {
     DeployFunction(DeployFunction),
     RunFunction(RunFunction),
+    FaDeposit(FaDepositReceiptContent),
 }


### PR DESCRIPTION
# Context
Handles the execution of an `FaDeposit` operation within the protocol. This PR does not "plug" the execution into the kernel yet but the tests should provide enough confidence of its correctness,. The plugging will be done in a follow up PR.

# Description
The `execute` handler takes an `FaDeposit` as input and produces a `Receipt` as output where the content type is `FaDepositReceiptContent`.  

When executing an FA deposit, the deposit could either be routed to user account or a proxy smart function. 
1. If the former, tickets will be added directly to the user account. 
2. If the latter, the proxy smart function is first executed, targeting the endpoint `POST /-/deposit` with body `{  receiver: ..., amount: ... , ticketHash: ... }` as described in the [Ticket Transport API](https://gitlab.com/baking-bad/tzip/-/blob/wip/029-etherlink-token-bridge/drafts/current/draft-etherlink-token-bridge/etherlink-token-bridge.md#ticket-transport-api) where the proxy should, in turn, mint the respective amount of fa tokens into the user's account. If the proxy succeeds, the kernel deposits the tickets into the proxy function's address. If it fails, tickets are deposited into the receiver's address. It will be the user's responsibility to submit a withdrawal operation of failed deposits.



<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
`cargo test -p jstz_proto --lib fa_deposit`
<!-- Describe how reviewers and approvers can test this PR. -->
