### PR TITLE
test(cov): add llvm-cov

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,23 @@ build-sdk-wasm-pkg:
 	@cd crates/jstz_sdk && wasm-pack build --target bundler --release
 
 .PHONY: test
-test:
-	@cargo test
+test: test-unit test-int
+
+.PHONY: test-unit
+test-unit:
+# --lib only runs unit tests in library crates
+# --bins only runs unit tests in binary crates
+	@cargo test --lib --bins 
+
+.PHONY: test-int
+test-int:
+# --test only runs a specified integration test (a test in /tests).
+#        the glob pattern is used to match all integration tests
+# 
+# FIXME(https://linear.app/tezos/issue/JSTZ-46): 
+# Currently this runs the test for `test_nested_transactions`. This test should 
+# be moved to an inline-test in the `jstz_core` crate to avoid this.  
+	@cargo test --test "*"
 
 .PHONY: check
 check: lint fmt

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,13 @@ test-int:
 # be moved to an inline-test in the `jstz_core` crate to avoid this.  
 	@cargo test --test "*"
 
+.PHONY: cov 
+cov:
+# TODO(https://linear.app/tezos/issue/JSTZ-47): 
+# This will only generate a coverage report for unit tests. We should add coverage 
+# for integration tests as well.
+	@cargo llvm-cov --lib --bins --html --open 
+
 .PHONY: check
 check: lint fmt
 

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
         system: let
           pkgs = import nixpkgs {
             inherit system;
-            overlays = [(import rust-overlay)];
+            overlays = [(import ./nix/overlay.nix) (import rust-overlay)];
           };
 
           makeFrameworkFlags = frameworks:
@@ -94,8 +94,12 @@
             buildInputs = with pkgs;
               [
                 llvmPackages_16.clangNoLibc
-                (rust-bin.stable."1.73.0".default.override {
+                # FIXME(https://linear.app/tezos/issue/JSTZ-48):
+                # This is almost a copy of rust-toolchain.toml We should find a way to
+                # share this configuration.
+                (pkgs.rust-bin.stable."1.73.0".default.override {
                   targets = ["wasm32-unknown-unknown"];
+                  extensions = ["rustfmt" "clippy" "llvm-tools-preview"];
                 })
                 rust-analyzer
                 wabt
@@ -109,6 +113,9 @@
                 jq
 
                 sqlite
+
+                # Code coverage
+                cargo-llvm-cov
               ]
               ++ lib.optionals stdenv.isLinux [pkg-config openssl.dev];
           };

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,14 @@
+final: prev: {
+  cargo-llvm-cov = prev.cargo-llvm-cov.overrideAttrs (old: {
+    doCheck = false;
+
+    meta =
+      old.meta
+      // {
+        # Nixpkgs currently marks the `cargo-llvm-cov` package as broken on Darwin.
+        # This is however not the case :) It appears to work just fine (only the tests
+        # are broken, but we disable them anyway).
+        broken = with prev; old.meta.broken && !stdenv.isDarwin;
+      };
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6096,12 +6096,14 @@
       "extraneous": true
     },
     "packages/sdk": {
+      "name": "@jstz-dev/sdk",
       "version": "0.0.0",
       "dependencies": {
         "jstz_sdk": "file:../../crates/jstz_sdk/pkg"
       }
     },
     "packages/types": {
+      "name": "@jstz-dev/types",
       "version": "0.0.0"
     }
   }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 channel = "1.73.0"
 profile = "minimal"
-components = ["rustfmt", "clippy"]
+components = ["rustfmt", "clippy", "llvm-tools-preview"]
 targets = ["wasm32-unknown-unknown", "riscv64gc-unknown-hermit"]


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
**Related Tasks**: [jstz-42](https://linear.app/tezos/issue/JSTZ-42/code-coverage-infrastructure-local)

We want to track code coverage as a metric. This task is the first of many to achieve this. 

Future work includes:
- Enabling unit tests on our CI
- Integrating the coverage report output with CodeCov
- Enabling integration tests on our CI (w/ coverage reports as well)

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

This PR integrates with `cargo-llvm-cov` to add code coverage to jstz's crates. The coverage report
is only generated based on data from _unit tests_ (we will add support for integration tests later). 

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

Reload your nix shell and run:
```sh
make cov
```
