### PR TITLE
fix(crypto): prevent panic in `Signature::verify` due to invalid signatures

### DIFF
--- a/crates/jstz_crypto/src/signature.rs
+++ b/crates/jstz_crypto/src/signature.rs
@@ -20,7 +20,7 @@ impl Signature {
     pub fn verify(&self, public_key: &PublicKey, message: &[u8]) -> Result<()> {
         match (self, public_key) {
             (Signature::Ed25519(sig), PublicKey::Ed25519(pk)) => {
-                let result = pk.verify_signature(sig, message).unwrap();
+                let result = pk.verify_signature(sig, message)?;
                 if result {
                     Ok(())
                 } else {


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

I experienced a kernel panic when testing out a smart function locally. 
The offending line was an `.unwrap()` when verifying signatures, due to an invalid signature.

Note: I'm not too sure how an invalid signature occurred, I suspect a mismatch between serde versions on the CLI and 
built WASM kernel used in the sandbox. 

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

I haven't been able to reproduce the panic 😔 So no tests, but the improvement is clear
