### PR TITLE
ci: use nix flake for environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,61 +12,34 @@ jobs:
       - uses: actions/checkout@v4
       - uses: wagoid/commitlint-github-action@v6
 
-  fmt:
-    name: Format
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2.7.1
-      - name: Rust setup
-        # FIXME: Once rustup adds a command to install a toolchain from rust-toolchain.toml, we can remove this.
-        run: rustup toolchain add 1.73.0 --profile minimal
-
-      - uses: luisnquin/setup-alejandra@v1.0.0
-
-      - name: Format (rustfmt)
-        run: make fmt-rust-check
-
-      - name: Format (prettier)
-        run: npx prettier --check .
-
-      - name: Format (Nix)
-        run: make fmt-nix-check
-
   # FIXME(https://linear.app/tezos/issue/JSTZ-49):
   # Add build and tests for LIGO contracts
 
-  build-rust:
-    name: Build (Cargo)
-    runs-on: ubuntu-latest
-    needs: [commitlint, fmt]
+  build:
+    name: Build
+    runs-on: [x86_64, linux, nix]
+    needs: [commitlint]
     steps:
       - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2.7.1
-      - name: Rust setup
-        # FIXME: Once rustup adds a command to install a toolchain from rust-toolchain.toml, we can remove this.
-        run: rustup toolchain add 1.73.0 --profile minimal --component llvm-tools-preview
-      - uses: taiki-e/install-action@cargo-llvm-cov
-      - uses: taiki-e/install-action@nextest
-
+      - run: nix --version
+      - name: Format
+        run: nix --accept-flake-config fmt -- --fail-on-change
       - name: Lint
-        run: make lint
-
+        run: nix --accept-flake-config develop -j auto --command make lint
       - name: Prevent blst
-        run: sh -c '[ -z "$(cargo tree | grep blst)" ]'
-
-      - name: Build all packages
-        # PROFILE=dev is used to build the dev profile, which is used for testing
-        # (to avoid building both a release and a debug profile in CI).
-        run: PROFILE=dev make build
-
-      - name: Run unit tests (and generate coverage)
-        run: make ci-cov
-
+        run: nix --accept-flake-config develop -j auto --command sh -c '[ -z "$(cargo tree | grep blst)" ]'
+      - name: Build
+        run: nix --accept-flake-config --log-format raw -L build -j auto .#{all,js_jstz}
+      - name: Flake check
+        run: nix --accept-flake-config --log-format raw -L flake check -j auto
+      # Coverage is part of nix flake check, but we want to upload it to Codecov
+      # So we run it again (it's cached) and upload the result
+      - name: Coverage
+        run: nix --accept-flake-config --log-format raw -L build .#checks.x86_64-linux.cargo-llvm-cov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4.2.0
         with:
-          files: codecov.json
+          files: result
           fail_ci_if_error: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -74,7 +47,7 @@ jobs:
   build-docs:
     name: Build Documentation
     runs-on: ubuntu-latest
-    needs: [commitlint, fmt]
+    needs: [commitlint]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -98,51 +71,3 @@ jobs:
 
       - name: Build with VitePress
         run: npm run docs:build
-
-  build-sdk:
-    name: Build TypeScript SDK
-    runs-on: ubuntu-latest
-    needs: [commitlint, fmt]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18
-          cache: npm
-      - name: Get npm cache directory
-        id: npm-cache-dir
-        shell: bash
-        run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
-      - name: Configure npm cache
-        uses: actions/cache@v4
-        id: npm-cache
-        with:
-          path: ${{ steps.npm-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - run: npm ci
-
-      - name: Build
-        run: cd packages/jstz && npm run build
-
-  build-nix:
-    name: Build (Nix)
-    runs-on: ubuntu-latest
-    needs: [build-rust, build-sdk, build-docs]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@V27
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@v15
-        with:
-          name: trilitech-jstz
-          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-
-      - name: Build Shell
-        run: nix develop --command bash -c "echo 'Hello World'"
-
-      - name: Build
-        run: nix build -j auto

--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,9 @@
 {
+  nixConfig = {
+    extra-trusted-public-keys = "trilitech-jstz.cachix.org-1:+ShRijHoxI9xAIZRP6Mov3aFui5FvgMHJ2M360OEYTo=";
+    extra-substituters = "https://trilitech-jstz.cachix.org";
+  };
+
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
**Related Tasks**: [jstz-66](https://linear.app/tezos/issue/JSTZ-66/update-ci-to-use-nix-flake-instead-of-actions-environment)

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
**Dependencies**: #543 #542 

Does what it says on the tin. 

Future work includes:
- Building docs using Nix
- Linting Rust code using Nix (currently we rely on `make lint` which will pull its own dependencies)
- Using self-hosted runners for better cache locality + exposing the cache to devs (for local environments). `magic-nix-cache` isn't very good and will often drop cached dependencies in favour of space

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

Green CI 🚀 