### PR TITLE
feat(withdrawal): implement fa withdrawal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2309,6 +2309,7 @@ dependencies = [
  "tezos-smart-rollup",
  "tezos-smart-rollup-host",
  "tezos-smart-rollup-mock",
+ "tezos_crypto_rs 0.6.0",
  "tezos_data_encoding 0.6.0",
  "tokio",
 ]
@@ -2415,6 +2416,7 @@ dependencies = [
  "tezos-smart-rollup",
  "tezos-smart-rollup-mock",
  "tezos_crypto_rs 0.6.0",
+ "tezos_data_encoding 0.6.0",
 ]
 
 [[package]]

--- a/crates/jstz_core/Cargo.toml
+++ b/crates/jstz_core/Cargo.toml
@@ -19,11 +19,12 @@ derive_more.workspace = true
 erased-serde.workspace = true
 getrandom.workspace = true
 jstz_crypto = { path = "../jstz_crypto" }
+nom.workspace = true
 serde.workspace = true
+tezos_crypto_rs.workspace = true
+tezos_data_encoding.workspace = true
 tezos-smart-rollup-host.workspace = true
 tezos-smart-rollup.workspace = true
-tezos_data_encoding.workspace = true
-nom.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true 

--- a/crates/jstz_mock/src/lib.rs
+++ b/crates/jstz_mock/src/lib.rs
@@ -37,6 +37,10 @@ pub fn account2() -> jstz_crypto::public_key_hash::PublicKeyHash {
     .unwrap()
 }
 
+pub fn kt1_account1() -> ContractKt1Hash {
+    ContractKt1Hash::try_from("KT1QgfSE4C1dX9UqrPAXjUaFQ36F9eB4nNkV").unwrap()
+}
+
 pub fn ticket_hash1() -> TicketHash {
     let ticket = UnitTicket::new(
         Contract::from_b58check("tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx").unwrap(),

--- a/crates/jstz_proto/Cargo.toml
+++ b/crates/jstz_proto/Cargo.toml
@@ -24,6 +24,7 @@ jstz_crypto = { path = "../jstz_crypto" }
 serde.workspace = true
 serde_json.workspace = true
 tezos_crypto_rs.workspace = true
+tezos_data_encoding.workspace = true
 tezos-smart-rollup.workspace = true
 
 [dev-dependencies]

--- a/crates/jstz_proto/src/context/ticket_table.rs
+++ b/crates/jstz_proto/src/context/ticket_table.rs
@@ -46,6 +46,10 @@ impl TicketTable {
         }
     }
 
+    /// Adds the given `amount` from the ticket balance of `owner`
+    /// for the ticket `ticket_hash` and returns the account's new balance.
+    /// Creates the account if it doesn't exist. Fails if the addition causes
+    /// an overflow.
     pub fn add(
         rt: &mut impl Runtime,
         tx: &mut Transaction,
@@ -70,6 +74,9 @@ impl TicketTable {
         }
     }
 
+    /// Subtracts the given `amount` from the ticket balance of `owner`
+    /// for the ticket `ticket_hash` and returns the account's new balance.
+    /// Fails if the account doesn't exist or the account has insufficient funds.
     pub fn sub(
         rt: &mut impl Runtime,
         tx: &mut Transaction,

--- a/crates/jstz_proto/src/executor/fa_withdraw.rs
+++ b/crates/jstz_proto/src/executor/fa_withdraw.rs
@@ -1,0 +1,346 @@
+use crate::context::{
+    account::{Address, Amount},
+    ticket_table::TicketTable,
+};
+
+use crate::{Error, Result};
+use derive_more::{Display, Error, From};
+use jstz_api::http::body::HttpBody;
+use jstz_core::{
+    host::HostRuntime,
+    kv::{outbox::OutboxMessage, Transaction},
+};
+use jstz_crypto::public_key_hash::PublicKeyHash;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tezos_crypto_rs::hash::ContractKt1Hash;
+use tezos_smart_rollup::{
+    michelson::{
+        ticket::{FA2_1Ticket, TicketHash},
+        MichelsonBytes, MichelsonOption, MichelsonPair,
+    },
+    types::Contract,
+};
+
+const WITHDRAW_ENTRYPOINT: &str = "withdraw";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FaWithdrawal {
+    pub amount: Amount,
+    pub routing_info: RoutingInfo,
+    pub ticket_info: TicketInfo,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoutingInfo {
+    pub receiver: Address,
+    pub proxy_l1_contract: ContractKt1Hash,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TicketInfo {
+    pub id: u32,
+    pub content: Option<Vec<u8>>,
+    pub ticketer: ContractKt1Hash,
+}
+
+impl TicketInfo {
+    pub(super) fn to_ticket(&self, amount: Amount) -> Result<Ticket> {
+        FA2_1Ticket::new(
+            Contract::Originated(self.ticketer.clone()),
+            MichelsonPair(
+                self.id.into(),
+                MichelsonOption(self.content.clone().map(MichelsonBytes)),
+            ),
+            amount,
+        )
+        .map_err(|_| Error::InvalidTicketType)?
+        .try_into()
+    }
+}
+
+// Internal wrapper over FA2_1Ticket with the hash field cached.
+// Computing the hash requires copying ticket content into a new
+// buffer which can be costly for large contents. Exposed to super
+// for use in test
+pub(super) struct Ticket {
+    pub value: FA2_1Ticket,
+    pub hash: TicketHash,
+}
+
+impl TryFrom<FA2_1Ticket> for Ticket {
+    type Error = crate::Error;
+
+    fn try_from(value: FA2_1Ticket) -> Result<Self> {
+        let hash = value.hash().map_err(|_| Error::InvalidTicketType)?;
+        Ok(Self { value, hash })
+    }
+}
+
+type OutboxMessageId = String;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FaWithdrawalReceiptContent {
+    pub source: PublicKeyHash,
+    pub outbox_message_id: OutboxMessageId,
+}
+
+impl FaWithdrawalReceiptContent {
+    pub fn to_http_body(&self) -> HttpBody {
+        Some(String::as_bytes(&json!(&self).to_string()).to_vec())
+    }
+}
+
+#[derive(Display, Debug, Error, From)]
+pub enum FaWithdrawError {
+    InvalidTicketInfo,
+    ProxySmartFunctionCannotBeSource,
+}
+
+fn create_fa_withdrawal_message(
+    routing_info: &RoutingInfo,
+    ticket: FA2_1Ticket,
+) -> Result<OutboxMessage> {
+    let receiver_pkh = routing_info.receiver.to_base58();
+    let destination = Contract::Originated(routing_info.proxy_l1_contract.clone());
+    let message = OutboxMessage::new_withdrawal_message(
+        &Contract::try_from(receiver_pkh).unwrap(),
+        &destination,
+        ticket,
+        WITHDRAW_ENTRYPOINT,
+    )?;
+    Ok(message)
+}
+
+// Deducts `amount` from the ticket balance of `ticket_owner` for `ticket.hash`
+// and pushes a withdraw outbox message to the outbox queue, returning the outbox
+// message id.
+fn withdraw_from_ticket_owner(
+    rt: &mut impl HostRuntime,
+    tx: &mut Transaction,
+    ticket_owner: &Address,
+    routing_info: &RoutingInfo,
+    amount: Amount,
+    ticket: Ticket,
+) -> Result<OutboxMessageId> {
+    TicketTable::sub(rt, tx, ticket_owner, &ticket.hash, amount)?;
+    let message = create_fa_withdrawal_message(routing_info, ticket.value)?;
+    tx.queue_outbox_message(rt, message)?;
+    // TODO: https://linear.app/tezos/issue/JSTZ-113/implement-outbox-message-id
+    // Implement outbox message id
+    Ok("".to_string())
+}
+
+/// Execute the [FaWithdrawal] request by deducting ticket balance from `source`` and
+/// pushing a withdraw message to the outbox queue. `proxy_l1_contract` is expected to
+/// implement the %withdraw entrypoint. See /jstz/contracts/examples/fa_ticketer/fa_ticketer.mligo.
+///
+/// Fails if:
+/// * Source account has insufficient funds
+/// * Outbox queue is full
+/// * Amount is zero
+fn fa_withdraw(
+    rt: &mut impl HostRuntime,
+    tx: &mut Transaction,
+    source: &Address,
+    fa_withdrawal: FaWithdrawal,
+) -> Result<FaWithdrawalReceiptContent> {
+    if fa_withdrawal.amount == 0 {
+        Err(Error::ZeroAmountNotAllowed)?
+    }
+    let FaWithdrawal {
+        amount,
+        routing_info,
+        ticket_info,
+    } = fa_withdrawal;
+    let ticket = ticket_info.to_ticket(amount)?;
+    let outbox_message_id =
+        withdraw_from_ticket_owner(rt, tx, source, &routing_info, amount, ticket)?;
+    Ok(FaWithdrawalReceiptContent {
+        source: source.clone(),
+        outbox_message_id,
+    })
+}
+
+/// Execute the [FaWithdrawal] request atomically. See [fa_withdraw].
+/// for implmentation details.
+pub fn execute_fa_withdraw(
+    rt: &mut impl HostRuntime,
+    tx: &mut Transaction,
+    source: &Address,
+    // TODO: https://linear.app/tezos/issue/JSTZ-114/fa-withdraw-gas-calculation
+    // Properly consume gas
+    _gas_limit: u64,
+    fa_withdrawal: FaWithdrawal,
+) -> Result<FaWithdrawalReceiptContent> {
+    tx.begin();
+    let result = fa_withdraw(rt, tx, source, fa_withdrawal);
+    if result.is_ok() {
+        tx.commit(rt)?;
+    } else {
+        tx.rollback()?;
+    }
+    result
+}
+
+#[cfg(test)]
+mod test {
+    use tezos_data_encoding::nom::NomReader;
+    use tezos_smart_rollup::{
+        michelson::MichelsonContract,
+        outbox::{OutboxMessageFull, OutboxMessageTransaction},
+        types::Entrypoint,
+    };
+    use tezos_smart_rollup_mock::MockHost;
+
+    use crate::context::ticket_table::TicketTableError;
+
+    use super::*;
+
+    fn create_fa_withdrawal() -> FaWithdrawal {
+        let ticket_info = TicketInfo {
+            id: 1234,
+            content: Some(b"random ticket content".to_vec()),
+            ticketer: jstz_mock::kt1_account1(),
+        };
+        let routing_info = RoutingInfo {
+            receiver: jstz_mock::account2(),
+            proxy_l1_contract: jstz_mock::kt1_account1(),
+        };
+        FaWithdrawal {
+            amount: 10,
+            routing_info,
+            ticket_info,
+        }
+    }
+
+    #[test]
+    fn execute_fa_withdraw_succeeds() {
+        let mut rt = MockHost::default();
+        let mut tx = Transaction::default();
+        let source = jstz_mock::account1();
+        let fa_withdrawal = create_fa_withdrawal();
+        let FaWithdrawal {
+            amount,
+            routing_info,
+            ticket_info,
+        } = fa_withdrawal.clone();
+        tx.begin();
+        TicketTable::add(
+            &mut rt,
+            &mut tx,
+            &source,
+            &fa_withdrawal.ticket_info.clone().to_ticket(1).unwrap().hash,
+            100,
+        )
+        .expect("Adding ticket balance should succeed");
+        tx.commit(&mut rt).unwrap();
+
+        tx.begin();
+        let fa_withdrawal_receipt_content =
+            execute_fa_withdraw(&mut rt, &mut tx, &source, 100, fa_withdrawal)
+                .expect("Should succeed");
+        tx.commit(&mut rt).unwrap();
+        assert_eq!(
+            FaWithdrawalReceiptContent {
+                source,
+                outbox_message_id: "".to_string() // outbox message not implemented yet
+            },
+            fa_withdrawal_receipt_content,
+        );
+
+        let level = rt.run_level(|_| {});
+        let outbox = rt.outbox_at(level);
+
+        assert_eq!(1, outbox.len());
+
+        for message in outbox.iter() {
+            let (_, message) =
+                OutboxMessageFull::<OutboxMessage>::nom_read(message).unwrap();
+            let parameters = MichelsonPair(
+                MichelsonContract(
+                    Contract::try_from(routing_info.clone().receiver.to_base58())
+                        .unwrap(),
+                ),
+                ticket_info.clone().to_ticket(amount).unwrap().value,
+            );
+            assert_eq!(
+                message,
+                OutboxMessage::Withdrawal(
+                    vec![OutboxMessageTransaction {
+                        parameters,
+                        destination: Contract::Originated(
+                            routing_info.clone().proxy_l1_contract
+                        ),
+                        entrypoint: Entrypoint::try_from(WITHDRAW_ENTRYPOINT.to_string())
+                            .unwrap(),
+                    }]
+                    .into()
+                )
+                .into()
+            );
+        }
+    }
+
+    #[test]
+    fn execute_fa_withdraw_fails_on_insufficient_funds() {
+        let mut rt = MockHost::default();
+        let mut tx = Transaction::default();
+        let source = jstz_mock::account1();
+        let fa_withdrawal = create_fa_withdrawal();
+
+        tx.begin();
+        TicketTable::add(
+            &mut rt,
+            &mut tx,
+            &source,
+            &fa_withdrawal.ticket_info.clone().to_ticket(1).unwrap().hash,
+            5,
+        )
+        .expect("Adding ticket balance should succeed");
+        tx.commit(&mut rt).unwrap();
+
+        let result = execute_fa_withdraw(&mut rt, &mut tx, &source, 100, fa_withdrawal);
+        assert!(matches!(
+            result,
+            Err(Error::TicketTableError {
+                source: TicketTableError::InsufficientFunds
+            })
+        ));
+    }
+
+    #[test]
+    fn execute_fa_withdraw_fails_on_zero_amount() {
+        let mut rt = MockHost::default();
+        let mut tx = Transaction::default();
+        let source = jstz_mock::account1();
+        let ticket_info = TicketInfo {
+            id: 1234,
+            content: Some(b"random ticket content".to_vec()),
+            ticketer: jstz_mock::kt1_account1(),
+        };
+        let routing_info = RoutingInfo {
+            receiver: jstz_mock::account2(),
+            proxy_l1_contract: jstz_mock::kt1_account1(),
+        };
+        let fa_withdrawal = FaWithdrawal {
+            amount: 0,
+            routing_info,
+            ticket_info,
+        };
+
+        tx.begin();
+        TicketTable::add(
+            &mut rt,
+            &mut tx,
+            &source,
+            &fa_withdrawal.ticket_info.clone().to_ticket(1).unwrap().hash,
+            5,
+        )
+        .expect("Adding ticket balance should succeed");
+        tx.commit(&mut rt).unwrap();
+
+        let result = execute_fa_withdraw(&mut rt, &mut tx, &source, 100, fa_withdrawal);
+        assert!(matches!(result, Err(Error::ZeroAmountNotAllowed)));
+    }
+}

--- a/crates/jstz_proto/src/executor/mod.rs
+++ b/crates/jstz_proto/src/executor/mod.rs
@@ -9,9 +9,9 @@ use crate::{
 
 pub mod deposit;
 pub mod fa_deposit;
+pub mod fa_withdraw;
 pub mod smart_function;
 pub mod withdraw;
-
 pub const JSTZ_HOST: &str = "jstz";
 
 fn execute_operation_inner(

--- a/crates/jstz_proto/src/executor/smart_function.rs
+++ b/crates/jstz_proto/src/executor/smart_function.rs
@@ -521,23 +521,26 @@ pub mod run {
 
 pub mod jstz_run {
     use jstz_core::kv::Storage;
+    use serde::Deserialize;
     use tezos_crypto_rs::hash::ContractKt1Hash;
     use tezos_smart_rollup::storage::path::{OwnedPath, RefPath};
 
     use super::*;
     use crate::{
-        executor::{withdraw::Withdrawal, JSTZ_HOST},
-        operation::{self, RunFunction},
+        executor::{fa_withdraw::FaWithdrawal, withdraw::Withdrawal, JSTZ_HOST},
+        operation::RunFunction,
         receipt,
     };
 
     const WITHDRAW_PATH: &str = "/withdraw";
+    const FA_WITHDRAW_PATH: &str = "/fa-withdraw";
 
-    fn validate_withdraw_request(
-        method: http::Method,
-        body: HttpBody,
-    ) -> Result<Withdrawal> {
-        let method = method
+    fn validate_withdraw_request<'de, T>(run: &'de RunFunction) -> Result<T>
+    where
+        T: Deserialize<'de>,
+    {
+        let method = run
+            .method
             .as_str()
             .parse::<http::Method>()
             .map_err(|_| Error::InvalidHttpRequestMethod)?;
@@ -546,18 +549,11 @@ pub mod jstz_run {
             return Err(Error::InvalidHttpRequestMethod);
         }
 
-        let body = match body {
-            Some(body) => body,
-            None => Err(Error::InvalidHttpRequestBody)?,
-        };
-
-        let withdrawal: Withdrawal = serde_json::from_str(
-            String::from_utf8(body)
-                .map_err(|_| Error::InvalidHttpRequestBody)?
-                .as_str(),
-        )
-        .map_err(|_| Error::InvalidHttpRequestBody)?;
-
+        if run.body.is_none() {
+            return Err(Error::InvalidHttpRequestBody);
+        }
+        let withdrawal = serde_json::from_slice(run.body.as_ref().unwrap())
+            .map_err(|_| Error::InvalidHttpRequestBody)?;
         Ok(withdrawal)
     }
 
@@ -566,11 +562,9 @@ pub mod jstz_run {
         tx: &mut Transaction,
         ticketer: &ContractKt1Hash,
         source: &Address,
-        run: operation::RunFunction,
+        run: RunFunction,
     ) -> Result<receipt::RunFunction> {
-        let RunFunction {
-            uri, method, body, ..
-        } = run;
+        let uri = run.uri.clone();
         if uri.host() != Some(JSTZ_HOST) {
             return Err(Error::InvalidHost);
         }
@@ -578,7 +572,8 @@ pub mod jstz_run {
             WITHDRAW_PATH => {
                 // TODO: https://linear.app/tezos/issue/JSTZ-77/check-gas-limit-when-performing-native-withdraws
                 // Check gas limit
-                let withdrawal = validate_withdraw_request(method, body)?;
+
+                let withdrawal = validate_withdraw_request::<Withdrawal>(&run)?;
                 crate::executor::withdraw::execute_withdraw(
                     hrt, tx, source, withdrawal, ticketer,
                 )?;
@@ -589,7 +584,23 @@ pub mod jstz_run {
                 };
                 Ok(receipt)
             }
-
+            FA_WITHDRAW_PATH => {
+                let fa_withdrawal = validate_withdraw_request::<FaWithdrawal>(&run)?;
+                let fa_withdrawa_receipt_content =
+                    crate::executor::fa_withdraw::execute_fa_withdraw(
+                        hrt,
+                        tx,
+                        source,
+                        1000, // fake gas limit
+                        fa_withdrawal,
+                    )?;
+                let receipt = receipt::RunFunction {
+                    body: fa_withdrawa_receipt_content.to_http_body(),
+                    status_code: http::StatusCode::OK,
+                    headers: http::HeaderMap::new(),
+                };
+                Ok(receipt)
+            }
             _ => Err(Error::UnsupportedPath),
         }
     }
@@ -598,7 +609,7 @@ pub mod jstz_run {
         hrt: &mut impl HostRuntime,
         tx: &mut Transaction,
         source: &Address,
-        run: operation::RunFunction,
+        run: RunFunction,
     ) -> Result<receipt::RunFunction> {
         let ticketer_path = OwnedPath::from(&RefPath::assert_from(b"/ticketer"));
         let ticketer: ContractKt1Hash =
@@ -616,7 +627,11 @@ pub mod jstz_run {
         use tezos_smart_rollup_mock::MockHost;
 
         use crate::{
-            executor::smart_function::jstz_run::{execute_without_ticketer, Account},
+            context::ticket_table::TicketTable,
+            executor::{
+                fa_withdraw::{FaWithdrawal, RoutingInfo, TicketInfo},
+                smart_function::jstz_run::{execute_without_ticketer, Account},
+            },
             operation::RunFunction,
             Error,
         };
@@ -642,6 +657,34 @@ pub mod jstz_run {
                     .as_bytes()
                     .to_vec(),
                 ),
+                gas_limit: 10,
+            }
+        }
+
+        fn fa_withdraw_request() -> RunFunction {
+            let ticket_info = TicketInfo {
+                id: 1234,
+                content: Some(b"random ticket content".to_vec()),
+                ticketer: jstz_mock::kt1_account1(),
+            };
+            let routing_info = RoutingInfo {
+                receiver: jstz_mock::account2(),
+                proxy_l1_contract: jstz_mock::kt1_account1(),
+            };
+            let fa_withdrawal = FaWithdrawal {
+                amount: 10,
+                routing_info,
+                ticket_info,
+            };
+
+            RunFunction {
+                uri: Uri::try_from("tezos://jstz/fa-withdraw").unwrap(),
+                method: Method::POST,
+                headers: HeaderMap::from_iter([(
+                    header::CONTENT_TYPE,
+                    "application/json".try_into().unwrap(),
+                )]),
+                body: Some(json!(fa_withdrawal).to_string().as_bytes().to_vec()),
                 gas_limit: 10,
             }
         }
@@ -774,6 +817,89 @@ pub mod jstz_run {
 
             let level = rt.run_level(|_| {});
             assert_eq!(1, rt.outbox_at(level).len());
+        }
+
+        #[test]
+        fn execute_fa_withdraw_fails_on_invalid_request_method() {
+            let mut host = MockHost::default();
+            let mut tx = Transaction::default();
+            let source = jstz_mock::account1();
+            let req = RunFunction {
+                method: Method::GET,
+                ..fa_withdraw_request()
+            };
+            let ticketer =
+                ContractKt1Hash::from_base58_check(jstz_mock::host::NATIVE_TICKETER)
+                    .unwrap();
+            let result = execute(&mut host, &mut tx, &ticketer, &source, req);
+            assert!(matches!(
+                result,
+                Err(super::Error::InvalidHttpRequestMethod)
+            ));
+        }
+
+        #[test]
+        fn execute_fa_withdraw_fails_on_invalid_request_body() {
+            let mut host = MockHost::default();
+            let mut tx = Transaction::default();
+            let source = jstz_mock::account1();
+            let req = RunFunction {
+                body: Some(
+                    json!({
+                        "amount": 10,
+                        "not_receiver": jstz_mock::account2().to_base58()
+                    })
+                    .to_string()
+                    .as_bytes()
+                    .to_vec(),
+                ),
+                ..fa_withdraw_request()
+            };
+            let ticketer =
+                ContractKt1Hash::from_base58_check(jstz_mock::host::NATIVE_TICKETER)
+                    .unwrap();
+            let result = execute(&mut host, &mut tx, &ticketer, &source, req);
+            assert!(matches!(result, Err(Error::InvalidHttpRequestBody)));
+
+            let req = RunFunction {
+                body: None,
+                ..withdraw_request()
+            };
+            let result = execute(&mut host, &mut tx, &ticketer, &source, req);
+            assert!(matches!(result, Err(Error::InvalidHttpRequestBody)));
+        }
+
+        #[test]
+        fn execute_fa_withdraw_succeeds() {
+            let mut host = MockHost::default();
+            let mut tx = Transaction::default();
+            let source = jstz_mock::account1();
+
+            let ticket = TicketInfo {
+                id: 1234,
+                content: Some(b"random ticket content".to_vec()),
+                ticketer: jstz_mock::kt1_account1(),
+            }
+            .to_ticket(1)
+            .unwrap();
+
+            tx.begin();
+            TicketTable::add(&mut host, &mut tx, &source, &ticket.hash, 10).unwrap();
+            tx.commit(&mut host).unwrap();
+
+            let req = fa_withdraw_request();
+            let ticketer =
+                ContractKt1Hash::from_base58_check(jstz_mock::host::NATIVE_TICKETER)
+                    .unwrap();
+
+            execute(&mut host, &mut tx, &ticketer, &source, req)
+                .expect("Withdraw should not fail");
+
+            tx.begin();
+            assert_eq!(0, Account::balance(&host, &mut tx, &source).unwrap());
+
+            let level = host.run_level(|_| {});
+            assert_eq!(1, host.outbox_at(level).len());
         }
     }
 }

--- a/crates/jstz_proto/src/receipt.rs
+++ b/crates/jstz_proto/src/receipt.rs
@@ -3,8 +3,12 @@ use jstz_api::http::body::HttpBody;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    context::account::Address, executor::fa_deposit::FaDepositReceiptContent,
-    operation::OperationHash, Result,
+    context::account::Address,
+    executor::{
+        fa_deposit::FaDepositReceiptContent, fa_withdraw::FaWithdrawalReceiptContent,
+    },
+    operation::OperationHash,
+    Result,
 };
 
 pub type ReceiptResult<T> = std::result::Result<T, String>;
@@ -46,4 +50,5 @@ pub enum Content {
     RunFunction(RunFunction),
     Deposit,
     FaDeposit(FaDepositReceiptContent),
+    FaWithdrawal(FaWithdrawalReceiptContent),
 }


### PR DESCRIPTION
# Context
Adds support for direct fa withdraw from external operation `RunFunction`.

 However, in most cases, users will want to withdraw tokens from their
<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
 Users use this flow only in the case where they are the ticket owner. This would happen if the user deposited fa tickets directly to their account instead of going through a proxy or if the proxy doesn't exist/rejected their deposit. In most cases, the user will want to withdraw from the token smart function and so the token smart function will invoke the fa ticket withdraw on the users behalf by withdrawing from its ticket balance. 

This design is based on TZIP-029 except that the user initiates the withdrawal by calling the proxy smart function instead of the protocol.

This design has a few benefits over TZIP-029
1. Simpler  and symmetric UX -J ust like how users don't need to know the ticket details of a deposit, users should not need to know ticket details to withdraw. This information is correctly exposed in proxy smart function only.
2. Simplifies implementation in the protocol
3. Removes 1 level of indirection. It is obvious now that the proxy smart function needs to implement a withdraw bridge to withdraw their tokens

Withdraw and FA withdraw share similarities in how they are validated. The only difference between their request objects is the body, so the `validate_withdraw_request` was refactored with a generic `<T: Deserialize>`.

Doc string comments were added to `TicketTable::add/sub` as the return type is an ambiguous `Amount`


<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
```
cargo test -p jstz_proto fa_withdraw
```

<!-- Describe how reviewers and approvers can test this PR. -->
