### PR TITLE
feat(jstzd): define Task trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,10 +403,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
-name = "async-trait"
-version = "0.1.74"
+name = "async-dropper"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
+checksum = "d901072ae4dcdca2201b98beb02d31fb4b6b2472fbd0e870b12ec15b8b35b2d2"
+dependencies = [
+ "async-dropper-derive",
+ "async-dropper-simple",
+ "async-trait",
+ "futures",
+ "tokio",
+]
+
+[[package]]
+name = "async-dropper-derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a35cf17a37761f1c88b8e770b5956820fe84c12854165b6f930c604ea186e47e"
+dependencies = [
+ "async-trait",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
+ "tokio",
+]
+
+[[package]]
+name = "async-dropper-simple"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c4748dfe8cd3d625ec68fc424fa80c134319881185866f9e173af9e5d8add8"
+dependencies = [
+ "async-scoped",
+ "async-trait",
+ "futures",
+ "rustc_version",
+ "tokio",
+]
+
+[[package]]
+name = "async-scoped"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4042078ea593edffc452eef14e99fdb2b120caa4ad9618bcdeabc4a023b98740"
+dependencies = [
+ "futures",
+ "pin-project",
+ "tokio",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2465,6 +2515,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "jstzd"
+version = "0.1.0-alpha.0"
+dependencies = [
+ "anyhow",
+ "async-dropper",
+ "async-trait",
+ "futures-util",
+ "tokio",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3069,6 +3130,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "crates/jstz_rollup",
   "crates/jstz_sdk",
   "crates/jstz_wpt",
+  "crates/jstzd",
   "crates/octez"
 ]
 
@@ -98,6 +99,8 @@ tokio-util = "0.7.10"
 url = "2.4.1"
 urlpattern = "0.2.0"
 wasm-bindgen = "0.2.92"
+async-dropper = { version = "0.3.1", features = ["tokio", "simple"] }
+async-trait = "0.1.82"
 
 [workspace.dependencies.tezos-smart-rollup]
 version = "0.2.2"

--- a/crates/jstzd/Cargo.toml
+++ b/crates/jstzd/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "jstzd"
+authors.workspace = true
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+tokio.workspace = true
+async-dropper.workspace = true
+async-trait.workspace = true
+futures-util.workspace = true

--- a/crates/jstzd/src/lib.rs
+++ b/crates/jstzd/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod task;

--- a/crates/jstzd/src/task/mod.rs
+++ b/crates/jstzd/src/task/mod.rs
@@ -1,0 +1,16 @@
+use anyhow::Result;
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait Task: Sized {
+    type Config;
+
+    /// Spins up the task with the given config.
+    async fn spawn(config: Self::Config) -> Result<Self>;
+
+    /// Aborts the running task.
+    async fn kill(&mut self) -> Result<()>;
+
+    /// Conducts a health check on the running task.
+    async fn health_check(&self) -> Result<bool>;
+}


### PR DESCRIPTION
# Context

Define the Task trait. Task represents any task to be run with backends, e.g. octez node, jstz node, etc.

[JSTZ-115](https://linear.app/tezos/issue/JSTZ-115/define-the-task-trait)

# Description

Define the basic `Task` trait.

The methods:
* `spawn`: The initialiser that takes in the necessary config for this task and runs the task.
* `kill`: Abort the running task.
* `health_check`: Check if the task is still alive.

# Manually testing the PR

`cargo build`

```sh
$ cd $(git rev-parse --show-toplevel)/crates/jstzd && cargo build
   Compiling jstzd v0.1.0-alpha.0 (/Users/huanchengchang/code/jstz/crates/jstzd)
    Finished dev [unoptimized + debuginfo] target(s) in 0.64s
```
