### PR TITLE
feat(jstzd): Implement OctezNode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,32 +403,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
-name = "async-dropper"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d901072ae4dcdca2201b98beb02d31fb4b6b2472fbd0e870b12ec15b8b35b2d2"
-dependencies = [
- "async-dropper-derive",
- "async-dropper-simple",
- "async-trait",
- "futures",
- "tokio",
-]
-
-[[package]]
-name = "async-dropper-derive"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35cf17a37761f1c88b8e770b5956820fe84c12854165b6f930c604ea186e47e"
-dependencies = [
- "async-trait",
- "proc-macro2",
- "quote",
- "syn 2.0.68",
- "tokio",
-]
-
-[[package]]
 name = "async-dropper-simple"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2663,10 +2637,14 @@ name = "jstzd"
 version = "0.1.0-alpha.0"
 dependencies = [
  "anyhow",
- "async-dropper",
+ "async-dropper-simple",
  "async-trait",
  "bollard",
  "futures-util",
+ "octez",
+ "rand 0.8.5",
+ "reqwest",
+ "tempfile",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ actix-web = "4.5.1"
 actix-web-lab = "0.20.0"
 ansi_term = "0.12.1"
 anyhow = "1.0.82"
+async-dropper-simple = { version = "0.2.6", features = ["tokio"] }
+async-trait = "0.1.82"
 base64 = "0.21.7"
 bincode = "1.3.3"
 boa_engine = { version = "0.17.0", features = ["fuzz"] }
@@ -100,8 +102,6 @@ tokio-util = "0.7.10"
 url = "2.4.1"
 urlpattern = "0.2.0"
 wasm-bindgen = "0.2.92"
-async-dropper = { version = "0.3.1", features = ["tokio", "simple"] }
-async-trait = "0.1.82"
 
 [workspace.dependencies.tezos-smart-rollup]
 version = "0.2.2"

--- a/crates/jstzd/Cargo.toml
+++ b/crates/jstzd/Cargo.toml
@@ -7,11 +7,17 @@ repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-async-dropper.workspace = true
+async-dropper-simple.workspace = true
 async-trait.workspace = true
 bollard.workspace = true
 futures-util.workspace = true
+octez = { path = "../octez" }
+tempfile.workspace = true
 tokio.workspace = true
+
+[dev-dependencies]
+rand.workspace = true
+reqwest.workspace = true
 
 [[bin]]
 name = "jstzd"

--- a/crates/jstzd/src/task/mod.rs
+++ b/crates/jstzd/src/task/mod.rs
@@ -1,3 +1,5 @@
+pub mod octez_node;
+
 use anyhow::Result;
 use async_trait::async_trait;
 

--- a/crates/jstzd/src/task/octez_node.rs
+++ b/crates/jstzd/src/task/octez_node.rs
@@ -1,0 +1,225 @@
+use super::Task;
+use anyhow::Result;
+use async_dropper_simple::{AsyncDrop, AsyncDropper};
+use async_trait::async_trait;
+use std::{fs::File, path::PathBuf, sync::Arc};
+use tokio::sync::RwLock;
+
+use octez::OctezNode as InnerOctezNode;
+use std::process::Child;
+
+const DEFAULT_RPC_ENDPOINT: &str = "localhost:8732";
+const DEFAULT_NETWORK: &str = "sandbox";
+const DEFAULT_BINARY_PATH: &str = "octez-node";
+
+#[derive(Clone)]
+pub struct OctezNodeConfig {
+    /// Path to the octez node binary.
+    binary_path: PathBuf,
+    /// Path to the directory where the node keeps data.
+    data_dir: PathBuf,
+    /// Name of the tezos network that the node instance runs on.
+    network: String,
+    /// HTTP endpoint of the node RPC interface, e.g. 'localhost:8732'
+    rpc_endpoint: String,
+    /// Path to the file that keeps octez node logs.
+    log_file: PathBuf,
+    /// Run options for octez node.
+    options: Vec<String>,
+}
+
+#[derive(Default)]
+pub struct OctezNodeConfigBuilder {
+    binary_path: Option<PathBuf>,
+    data_dir: Option<PathBuf>,
+    network: Option<String>,
+    rpc_endpoint: Option<String>,
+    log_file: Option<PathBuf>,
+    options: Option<Vec<String>>,
+}
+
+impl OctezNodeConfigBuilder {
+    pub fn new() -> Self {
+        OctezNodeConfigBuilder::default()
+    }
+
+    /// Sets the path to the octez node binary.
+    pub fn set_binary_path(&mut self, path: &str) -> &mut Self {
+        self.binary_path = Some(PathBuf::from(path));
+        self
+    }
+
+    /// Sets the path to the directory where the node keeps data.
+    pub fn set_data_dir(&mut self, path: &str) -> &mut Self {
+        self.data_dir = Some(PathBuf::from(path));
+        self
+    }
+
+    /// Sets the name of the tezos network that the node instance runs on.
+    pub fn set_network(&mut self, network: &str) -> &mut Self {
+        self.network = Some(network.to_owned());
+        self
+    }
+
+    /// Sets the HTTP(S) endpoint of the node RPC interface, e.g. 'http://localhost:8732'
+    pub fn set_rpc_endpoint(&mut self, endpoint: &str) -> &mut Self {
+        self.rpc_endpoint = Some(endpoint.to_owned());
+        self
+    }
+
+    /// Sets the path to the file that keeps octez node logs.
+    pub fn set_log_file(&mut self, path: &str) -> &mut Self {
+        self.log_file = Some(PathBuf::from(path));
+        self
+    }
+
+    /// Sets run options for octez node.
+    pub fn set_run_options(&mut self, options: &[&str]) -> &mut Self {
+        self.options = Some(
+            options
+                .iter()
+                .map(|v| (*v).to_owned())
+                .collect::<Vec<String>>(),
+        );
+        self
+    }
+
+    /// Builds a config set based on values collected.
+    pub fn build(&mut self) -> Result<OctezNodeConfig> {
+        Ok(OctezNodeConfig {
+            binary_path: self
+                .binary_path
+                .take()
+                .unwrap_or(PathBuf::from(DEFAULT_BINARY_PATH)),
+            data_dir: self
+                .data_dir
+                .take()
+                .unwrap_or(PathBuf::from(tempfile::TempDir::new().unwrap().path())),
+            network: self.network.take().unwrap_or(DEFAULT_NETWORK.to_owned()),
+            rpc_endpoint: self
+                .rpc_endpoint
+                .take()
+                .unwrap_or(DEFAULT_RPC_ENDPOINT.to_owned()),
+            log_file: self.log_file.take().unwrap_or(PathBuf::from(
+                tempfile::NamedTempFile::new().unwrap().path(),
+            )),
+            options: self.options.take().unwrap_or_default(),
+        })
+    }
+}
+
+#[derive(Default)]
+struct ChildWrapper {
+    inner: Option<Child>,
+}
+
+impl ChildWrapper {
+    pub async fn kill(&mut self) -> anyhow::Result<()> {
+        if let Some(mut v) = self.inner.take() {
+            return Ok(v.kill()?);
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl AsyncDrop for ChildWrapper {
+    async fn async_drop(&mut self) {
+        let _ = self.kill().await;
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct OctezNode {
+    inner: Arc<RwLock<AsyncDropper<ChildWrapper>>>,
+}
+
+#[async_trait]
+impl Task for OctezNode {
+    type Config = OctezNodeConfig;
+
+    /// Spins up the task with the given config.
+    async fn spawn(config: Self::Config) -> Result<Self> {
+        let node = InnerOctezNode {
+            octez_node_bin: Some(config.binary_path),
+            octez_node_dir: config.data_dir,
+        };
+
+        // localhost:8731 refers to the peer http endpoint. This will be removed
+        // when we switch to the async node implementation where this option is removed
+        node.config_init(&config.network, "localhost:8731", &config.rpc_endpoint, 0)?;
+        node.generate_identity()?;
+        Ok(OctezNode {
+            inner: Arc::new(RwLock::new(AsyncDropper::new(ChildWrapper {
+                inner: Some(
+                    node.run(
+                        &File::create(&config.log_file)?,
+                        config
+                            .options
+                            .iter()
+                            .map(|s| s as &str)
+                            .collect::<Vec<&str>>()
+                            .as_slice(),
+                    )?,
+                ),
+            }))),
+        })
+    }
+
+    /// Aborts the running task.
+    async fn kill(&mut self) -> Result<()> {
+        let mut inner = self.inner.write().await;
+        Ok(inner.inner_mut().kill().await?)
+    }
+
+    /// Conducts a health check on the running task.
+    async fn health_check(&self) -> Result<bool> {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use crate::task::octez_node::{
+        DEFAULT_BINARY_PATH, DEFAULT_NETWORK, DEFAULT_RPC_ENDPOINT,
+    };
+
+    use super::OctezNodeConfigBuilder;
+
+    #[test]
+    fn config_builder() {
+        let config = OctezNodeConfigBuilder::new()
+            .set_binary_path("/tmp/binary")
+            .set_data_dir("/tmp/something")
+            .set_network("network")
+            .set_rpc_endpoint("my_endpoint")
+            .set_log_file("/log_file")
+            .set_run_options(&["foo", "bar"])
+            .build()
+            .unwrap();
+        assert_eq!(config.binary_path, PathBuf::from("/tmp/binary"));
+        assert_eq!(config.data_dir, PathBuf::from("/tmp/something"));
+        assert_eq!(config.network, "network".to_owned());
+        assert_eq!(config.rpc_endpoint, "my_endpoint".to_owned());
+        assert_eq!(config.log_file, PathBuf::from("/log_file"));
+        assert_eq!(
+            config.options,
+            Vec::from(["foo".to_owned(), "bar".to_owned()])
+        );
+    }
+
+    #[test]
+    fn config_builder_default() {
+        let config = OctezNodeConfigBuilder::new().build().unwrap();
+        assert_eq!(config.binary_path, PathBuf::from(DEFAULT_BINARY_PATH));
+        // Checks if the default path is a valid one that actually can exist in the file system
+        std::fs::create_dir(config.data_dir).unwrap();
+        assert_eq!(config.network, DEFAULT_NETWORK.to_owned());
+        assert_eq!(config.rpc_endpoint, DEFAULT_RPC_ENDPOINT.to_owned());
+        // Checks if the default path is a valid one that actually can exist in the file system
+        std::fs::File::create(config.log_file).unwrap();
+        assert_eq!(config.options, Vec::<String>::default());
+    }
+}

--- a/crates/jstzd/tests/octez_node_test.rs
+++ b/crates/jstzd/tests/octez_node_test.rs
@@ -1,0 +1,70 @@
+use jstzd::task::{octez_node, Task};
+
+async fn retry<'a, F>(retries: u16, interval_ms: u64, f: impl Fn() -> F) -> bool
+where
+    F: std::future::Future<Output = anyhow::Result<bool>> + Send + 'a,
+{
+    let duration = tokio::time::Duration::from_millis(interval_ms);
+    for _ in 0..retries {
+        tokio::time::sleep(duration).await;
+        if let Ok(v) = f().await {
+            if v {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn octez_node_test() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let log_file = tempfile::NamedTempFile::new().unwrap();
+    let port = std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port();
+    let rpc_endpoint = format!("localhost:{}", port);
+
+    let mut config_builer = octez_node::OctezNodeConfigBuilder::new();
+    config_builer
+        .set_binary_path("octez-node")
+        .set_data_dir(data_dir.path().to_str().unwrap())
+        .set_network("sandbox")
+        .set_rpc_endpoint(&rpc_endpoint)
+        .set_log_file(log_file.path().to_str().unwrap())
+        .set_run_options(&[]);
+    let mut f = octez_node::OctezNode::spawn(config_builer.build().unwrap())
+        .await
+        .unwrap();
+
+    let health_check_endpoint = format!("http://{}/health/ready", rpc_endpoint);
+    // Should be able to hit the endpoint since the node should have been launched
+    let node_ready = retry(10, 1000, || async {
+        let res = reqwest::get(&health_check_endpoint).await;
+        if let Ok(raw_body) = res {
+            let body = raw_body
+                .json::<std::collections::HashMap<String, bool>>()
+                .await
+                .unwrap();
+            return body.get("ready").cloned().ok_or(anyhow::anyhow!(""));
+        }
+        Err(anyhow::anyhow!(""))
+    })
+    .await;
+    assert!(node_ready);
+
+    let _ = f.kill().await;
+    // Wait for the process to shutdown entirely
+    let node_destroyed = retry(10, 1000, || async {
+        let res = reqwest::get(&health_check_endpoint).await;
+        // Should get an error since the node should have been terminated
+        if let Err(e) = res {
+            return Ok(e.to_string().contains("Connection refused"));
+        }
+        Err(anyhow::anyhow!(""))
+    })
+    .await;
+    assert!(node_destroyed);
+}

--- a/crates/octez/src/node.rs
+++ b/crates/octez/src/node.rs
@@ -50,6 +50,7 @@ impl OctezNode {
         run_command(self.command().args([
             "identity",
             "generate",
+            "0",
             "--data-dir",
             self.octez_node_dir.to_str().expect("Invalid path"),
         ]))

--- a/nix/crates.nix
+++ b/nix/crates.nix
@@ -103,6 +103,7 @@ in {
     jstz_rollup = crate "jstz_rollup";
     inherit jstz_kernel;
     jstz_wpt = crate "jstz_wpt";
+    jstzd = crate "jstzd";
     octez = crate "octez";
 
     # Special target to build all crates in the workspace
@@ -121,7 +122,7 @@ in {
 
     cargo-test-int = craneLib.cargoNextest (commonWorkspace
       // {
-        buildInputs = commonWorkspace.buildInputs ++ [octez];
+        buildInputs = commonWorkspace.buildInputs ++ [octez pkgs.cacert];
         doCheck = true;
         # Run the integration tests
         #
@@ -134,7 +135,7 @@ in {
 
     cargo-llvm-cov = craneLib.cargoLlvmCov (commonWorkspace
       // {
-        buildInputs = commonWorkspace.buildInputs ++ [octez];
+        buildInputs = commonWorkspace.buildInputs ++ [octez pkgs.cacert];
         # Generate coverage reports for codecov
         cargoLlvmCovExtraArgs = "--workspace --exclude-from-test \"jstz_api\" --codecov --output-path $out";
       });


### PR DESCRIPTION
# Context

[JSTZ-116](https://linear.app/tezos/issue/JSTZ-116/implement-octeznode)

# Description

Created struct `OctezNode` that implements `Trait`. Each instance of this struct represents an octez node process.

Note:
* There is no config validation in `OctezNode`. It simply attempts to call the node binary with the given config values and returns errors if there is any. It does not check if there are existing files or directories, e.g. previously created data directory. It is therefore possible that the created process does not use the given config values because it reads the config file from the previously created data directory. Validation is left to the caller. I thought about implementing these checks or removing existing files, but then I thought it might actually lead to unexpected results, so I decided to leave it as is and leave the checks to the caller.
* This implementation leverages the node implementation in crate `octez`. Methods there are all synchronous. An async version is created and referenced in #565.
* Health check is excluded from this PR so that the PR does not get too big. #566 covers the health check.

I used mocks for the `OctezNode` struct and `Child` in unit tests to make test cases simple enough, though side effects are still inevitable, e.g. creating temporary files and directories.

Also re-ordered dependencies in `Cargo.toml`. This was missed out in #563.

# Manually testing the PR

* Unit test: new test cases
```sh
$ cargo test task::octez_node
running 2 tests
test task::octez_node::tests::config_builder ... ok
test task::octez_node::tests::config_builder_default ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s
```
* Manual integration test: added one case
```sh
$ cargo test --test octez_node_test
running 1 test
test octez_node_test ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 20.59s
```
