### PR TITLE
feat(jstzd): Use async octez node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3020,6 +3020,7 @@ dependencies = [
  "serde_json",
  "signal-hook",
  "tezos-smart-rollup-encoding",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/octez/Cargo.toml
+++ b/crates/octez/Cargo.toml
@@ -21,3 +21,4 @@ serde.workspace = true
 serde_json.workspace = true
 signal-hook.workspace = true
 tezos-smart-rollup-encoding.workspace = true
+tokio.workspace = true

--- a/crates/octez/src/async_node.rs
+++ b/crates/octez/src/async_node.rs
@@ -1,0 +1,73 @@
+use std::{fs::File, path::PathBuf, process::Stdio};
+
+use tokio::process::{Child, Command};
+
+use super::path_or_default;
+use anyhow::Result;
+
+pub struct AsyncOctezNode {
+    /// Path to the octez-node binary
+    /// If None, the binary will inside PATH will be used
+    pub octez_node_bin: Option<PathBuf>,
+    /// Path to the octez-node directory
+    pub octez_node_dir: PathBuf,
+}
+
+impl AsyncOctezNode {
+    fn command(&self) -> Command {
+        Command::new(path_or_default(self.octez_node_bin.as_ref(), "octez-node"))
+    }
+
+    pub async fn config_init(
+        &self,
+        network: &str,
+        rpc_endpoint: &str,
+        num_connections: u32,
+    ) -> Result<Child> {
+        Ok(self
+            .command()
+            .args([
+                "config",
+                "init",
+                "--network",
+                network,
+                "--data-dir",
+                self.octez_node_dir.to_str().expect("Invalid path"),
+                "--rpc-addr",
+                rpc_endpoint,
+                "--connections",
+                num_connections.to_string().as_str(),
+            ])
+            .spawn()?)
+    }
+
+    pub async fn generate_identity(&self) -> Result<Child> {
+        Ok(self
+            .command()
+            .args([
+                "identity",
+                "generate",
+                "0",
+                "--data-dir",
+                self.octez_node_dir.to_str().expect("Invalid path"),
+            ])
+            .spawn()?)
+    }
+
+    pub async fn run(&self, log_file: &File, options: &[&str]) -> Result<Child> {
+        let mut command = self.command();
+
+        command
+            .args([
+                "run",
+                "--data-dir",
+                self.octez_node_dir.to_str().expect("Invalid path"),
+                "--singleprocess",
+            ])
+            .args(options)
+            .stdout(Stdio::from(log_file.try_clone()?))
+            .stderr(Stdio::from(log_file.try_clone()?));
+
+        Ok(command.spawn()?)
+    }
+}

--- a/crates/octez/src/lib.rs
+++ b/crates/octez/src/lib.rs
@@ -2,11 +2,13 @@ use std::{path::PathBuf, process::Command};
 
 use anyhow::{anyhow, Result};
 
+mod async_node;
 mod client;
 mod node;
 mod rollup;
 mod thread;
 
+pub use async_node::*;
 pub use client::*;
 pub use node::*;
 pub use rollup::*;


### PR DESCRIPTION
# Context

Part of JSTZ-116.

[JSTZ-116](https://linear.app/tezos/issue/JSTZ-116/implement-octeznode)

# Description

Create an async version of `OctezNode` from crate `octez`.

This piece of code will replace the current `OctezNode` struct later on. For now it's kept in a separate module in order not to affect other pieces of code that are referencing `OctezNode`.

# Manually testing the PR

* Integration test: ran the code in the file `crate/jstzd/tests/octez_node_test.rs` and everything worked as expected.
