### PR TITLE
chore: enable integration testing in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,18 +66,11 @@ test-unit:
 test-int:
 # --test only runs a specified integration test (a test in /tests).
 #        the glob pattern is used to match all integration tests
-# 
-# FIXME(https://linear.app/tezos/issue/JSTZ-46): 
-# Currently this runs the test for `test_nested_transactions`. This test should 
-# be moved to an inline-test in the `jstz_core` crate to avoid this.  
 	@cargo nextest run --test "*"
 
 .PHONY: cov 
 cov:
-# TODO(https://linear.app/tezos/issue/JSTZ-47): 
-# This will only generate a coverage report for unit tests. We should add coverage 
-# for integration tests as well.
-	@cargo llvm-cov --lib --bins --html --open 
+	@cargo llvm-cov --workspace --exclude-from-test "jstz_api" --html --open 
 
 .PHONY: check
 check: lint fmt
@@ -123,9 +116,3 @@ lint:
 	@touch $(CLI_KERNEL_PATH)
 	@cargo clippy --all-targets -- --deny warnings
 	@rm -f $(CLI_KERNEL_PATH)
-
-.PHONY: ci-cov 
-ci-cov:
-# This will only generate a coverage report for unit tests. We should add coverage
-# for integration tests as well.
-	@cargo llvm-cov --lib --bins --codecov --output-path codecov.json

--- a/crates/jstzd/Cargo.toml
+++ b/crates/jstzd/Cargo.toml
@@ -12,3 +12,7 @@ async-trait.workspace = true
 bollard.workspace = true
 futures-util.workspace = true
 tokio.workspace = true
+
+[[bin]]
+name = "jstzd"
+path = "src/main.rs"

--- a/crates/jstzd/src/lib.rs
+++ b/crates/jstzd/src/lib.rs
@@ -1,2 +1,8 @@
 pub mod docker;
 pub mod task;
+
+/// The `main` function for running jstzd
+pub async fn main() -> anyhow::Result<()> {
+    println!("Hello, world!");
+    Ok(())
+}

--- a/crates/jstzd/src/main.rs
+++ b/crates/jstzd/src/main.rs
@@ -1,0 +1,7 @@
+#[tokio::main]
+async fn main() {
+    if let Err(e) = jstzd::main().await {
+        eprintln!("Error: {:?}", e);
+        std::process::exit(1);
+    }
+}

--- a/crates/jstzd/tests/dummy.rs
+++ b/crates/jstzd/tests/dummy.rs
@@ -1,0 +1,6 @@
+use jstzd::main;
+
+#[tokio::test]
+async fn test_main() {
+    main().await.unwrap();
+}

--- a/nix/crates.nix
+++ b/nix/crates.nix
@@ -119,11 +119,23 @@ in {
         cargoNextestExtraArg = "--bins --lib";
       });
 
+    cargo-test-int = craneLib.cargoNextest (commonWorkspace
+      // {
+        cargoArtifacts = cargoDeps;
+        # Run the integration tests
+        #
+        # FIXME():
+        # Don't run the `jstz_api` integration tests until they've been paralellized
+        #
+        # Note: --workspace is required for --exclude. Once --exclude is removed, remove --workspace
+        cargoNextestExtraArg = "--workspace --test \"*\" --exclude \"jstz_api\"";
+      });
+
     cargo-llvm-cov = craneLib.cargoLlvmCov (commonWorkspace
       // {
         cargoArtifacts = cargoDeps;
         # Generate coverage reports for codecov
-        cargoLlvmCovExtraArgs = "--bins --lib --codecov --output-path $out";
+        cargoLlvmCovExtraArgs = "--workspace --exclude-from-test \"jstz_api\" --codecov --output-path $out";
       });
 
     cargo-clippy = craneLib.cargoClippy (commonWorkspace
@@ -131,8 +143,5 @@ in {
         cargoArtifacts = cargoDeps;
         cargoClippyExtraArgs = "--all-targets -- --deny warnings";
       });
-
-    # TODO(https://linear.app/tezos/issue/JSTZ-44)
-    # Run the integration tests
   };
 }


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

[jstz-44](https://linear.app/tezos/issue/JSTZ-44/enable-integration-tests-in-ci)

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

This PR enables all integration tests except those in `jstz_api`. This is primarily due to 
the fact that `jstz_api`'s integration tests need parallelising before being executed in a CI
environment.

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

To test locally, run one of the following (or all of them :) ):
```
cargo test -p jstzd
nix build .#checks.aarch64-darwin.cargo-test-int
make cov
```

To check in CI, look at the codecov output (which will automatically be commented below)

