### PR TITLE
chore(nix): add octez distribution to nix shell and integration tests

### DIFF
--- a/crates/jstzd/tests/dummy.rs
+++ b/crates/jstzd/tests/dummy.rs
@@ -1,6 +1,17 @@
 use jstzd::main;
+use tokio::process::Command;
 
 #[tokio::test]
 async fn test_main() {
     main().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_octez_client() {
+    let output = Command::new("octez-client")
+        .arg("--version")
+        .output()
+        .await
+        .unwrap();
+    println!("octez-client --version: {:?}", output);
 }

--- a/flake.lock
+++ b/flake.lock
@@ -73,12 +73,101 @@
         "type": "github"
       }
     },
+    "octez-v21": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "opam-nix-integration": [
+          "opam-nix-integration"
+        ],
+        "opam-repository": "opam-repository",
+        "rust-overlay": [
+          "rust-overlay"
+        ]
+      },
+      "locked": {
+        "lastModified": 1726495500,
+        "narHash": "sha256-LxIn3uvqOrNdlcUnbSvHGnVTn47rREvVqdvA4+AL8D0=",
+        "owner": "tezos",
+        "repo": "tezos",
+        "rev": "44643df827aa2d745c3d8a09a6649fe175ff77d7",
+        "type": "gitlab"
+      },
+      "original": {
+        "owner": "tezos",
+        "ref": "octez-v21.0-rc2",
+        "repo": "tezos",
+        "type": "gitlab"
+      }
+    },
+    "opam-nix-integration": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "opam-repository": "opam-repository_2"
+      },
+      "locked": {
+        "lastModified": 1716561961,
+        "narHash": "sha256-SgeZItYuUZV7WSaoX4G7J1ZpmwgeI3ocQCLP95E+O1U=",
+        "owner": "vapourismo",
+        "repo": "opam-nix-integration",
+        "rev": "0f98236c75cdb436be7669ccaa249264456baa37",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vapourismo",
+        "repo": "opam-nix-integration",
+        "type": "github"
+      }
+    },
+    "opam-repository": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1723381368,
+        "narHash": "sha256-fN8jaeSfK8lbIQcvPXk96FeH8i7sjGjkwqnf0C9ZCog=",
+        "owner": "ocaml",
+        "repo": "opam-repository",
+        "rev": "0f4d0ee5b69b496a4e26f305891c31400f0b4b5f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ocaml",
+        "repo": "opam-repository",
+        "type": "github"
+      }
+    },
+    "opam-repository_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1688548241,
+        "narHash": "sha256-cmk1kCLtcL9GJplfl4J7t0r8g0N25O4G0ctycV4eyPo=",
+        "owner": "ocaml",
+        "repo": "opam-repository",
+        "rev": "860072345fa2f234ff10ffeee88db6906e138e92",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ocaml",
+        "repo": "opam-repository",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "crane": "crane",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "npm-buildpackage": "npm-buildpackage",
+        "octez-v21": "octez-v21",
+        "opam-nix-integration": "opam-nix-integration",
         "rust-overlay": "rust-overlay",
         "treefmt": "treefmt"
       }

--- a/nix/crates.nix
+++ b/nix/crates.nix
@@ -4,6 +4,7 @@
   lib,
   stdenv,
   rust-toolchain,
+  octez,
 }: let
   craneLib = (crane.mkLib pkgs).overrideToolchain (_: rust-toolchain);
 
@@ -114,33 +115,32 @@ in {
 
     cargo-test-unit = craneLib.cargoNextest (commonWorkspace
       // {
-        cargoArtifacts = cargoDeps;
         # Run the unit tests
         cargoNextestExtraArg = "--bins --lib";
       });
 
     cargo-test-int = craneLib.cargoNextest (commonWorkspace
       // {
-        cargoArtifacts = cargoDeps;
+        buildInputs = commonWorkspace.buildInputs ++ [octez];
+        doCheck = true;
         # Run the integration tests
         #
         # FIXME():
         # Don't run the `jstz_api` integration tests until they've been paralellized
         #
         # Note: --workspace is required for --exclude. Once --exclude is removed, remove --workspace
-        cargoNextestExtraArg = "--workspace --test \"*\" --exclude \"jstz_api\"";
+        cargoNextestExtraArgs = "--workspace --test \"*\" --exclude \"jstz_api\"";
       });
 
     cargo-llvm-cov = craneLib.cargoLlvmCov (commonWorkspace
       // {
-        cargoArtifacts = cargoDeps;
+        buildInputs = commonWorkspace.buildInputs ++ [octez];
         # Generate coverage reports for codecov
         cargoLlvmCovExtraArgs = "--workspace --exclude-from-test \"jstz_api\" --codecov --output-path $out";
       });
 
     cargo-clippy = craneLib.cargoClippy (commonWorkspace
       // {
-        cargoArtifacts = cargoDeps;
         cargoClippyExtraArgs = "--all-targets -- --deny warnings";
       });
   };

--- a/nix/patches/0001-fix-octez-rust-deps-for-nix.patch
+++ b/nix/patches/0001-fix-octez-rust-deps-for-nix.patch
@@ -1,0 +1,23 @@
+diff --git a/manifest/product_octez.ml b/manifest/product_octez.ml
+index f4336a077a..6ab49b65cf 100644
+--- a/manifest/product_octez.ml
++++ b/manifest/product_octez.ml
+@@ -522,7 +522,7 @@ let octez_rust_deps =
+               [S "source_tree"; S "../riscv"];
+               [S "source_tree"; S "../kernel_sdk"];
+             ];
+-            [S "action"; [S "no-infer"; [S "bash"; S "./build.sh"]]];
++            [S "action"; [S "no-infer"; [S "system"; S "bash ./build.sh"]]];
+           ];
+         ]
+ 
+diff --git a/src/rust_deps/dune b/src/rust_deps/dune
+index de48dbfde8..20934e2e21 100644
+--- a/src/rust_deps/dune
++++ b/src/rust_deps/dune
+@@ -22,4 +22,4 @@
+   (source_tree src)
+   (source_tree ../riscv)
+   (source_tree ../kernel_sdk))
+- (action (no-infer (bash ./build.sh))))
++ (action (no-infer (system "bash ./build.sh"))))


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

We will require octez for our integration tests for jstzd

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

This PR simply adds `octez-v21` using the Nix flake from https://gitlab.com/tezos/tezos/-/blob/master/flake.nix. 
Unfortunately, this will take along time to build, but the dependency will rarely change + once we have a Mac CI runner, we can use that as a cache. 

This PR includes two patches to the `tezos/tezos` flake:
- The first patches the `/bin/bash` issue and the `/usr/bin/env bash` shebang issue for `build.sh` in `src/rust_deps`
- The second patches the cargo dependencies for `src/rust_deps`, prefetching them using `importCargoLock`. Without this, the build fails as the `build.sh` script invokes `cargo` which tries to download the dependencies from `crates.io`. 

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

To execute the integration test that uses octez in a Nix environment, run:
```sh
nix build -L -v --print-build-logs .#checks.aarch64-darwin.cargo-test-int
```
