### PR TITLE
feat(jstzd): Implement Endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2641,6 +2641,7 @@ dependencies = [
  "async-trait",
  "bollard",
  "futures-util",
+ "http 1.1.0",
  "octez",
  "rand 0.8.5",
  "reqwest",

--- a/crates/jstzd/Cargo.toml
+++ b/crates/jstzd/Cargo.toml
@@ -11,6 +11,7 @@ async-dropper-simple.workspace = true
 async-trait.workspace = true
 bollard.workspace = true
 futures-util.workspace = true
+http.workspace = true
 octez = { path = "../octez" }
 tempfile.workspace = true
 tokio.workspace = true

--- a/crates/jstzd/src/task/endpoint.rs
+++ b/crates/jstzd/src/task/endpoint.rs
@@ -1,0 +1,86 @@
+#![allow(dead_code)]
+use http::{uri::Scheme, Uri};
+
+#[derive(Debug, Clone)]
+pub struct Endpoint {
+    scheme: String,
+    host: String,
+    port: u16,
+}
+
+impl Endpoint {
+    pub fn localhost(port: u16) -> Self {
+        Endpoint {
+            scheme: "http".to_owned(),
+            host: "localhost".to_owned(),
+            port,
+        }
+    }
+}
+
+impl TryFrom<Uri> for Endpoint {
+    type Error = anyhow::Error;
+    fn try_from(value: Uri) -> Result<Self, Self::Error> {
+        let host = value
+            .host()
+            .ok_or(anyhow::anyhow!(
+                "Cannot parse endpoint host from URI '{value:?}'"
+            ))?
+            .to_owned();
+        if host.is_empty() {
+            return Err(anyhow::anyhow!("No host part in URI '{value:?}'"));
+        }
+        Ok(Self {
+            scheme: value.scheme().unwrap_or(&Scheme::HTTP).to_string(),
+            host,
+            port: value.port_u16().unwrap_or(80),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use http::Uri;
+
+    use super::Endpoint;
+
+    #[test]
+    fn test_localhost() {
+        let endpoint = Endpoint::localhost(8765);
+        assert_eq!(endpoint.scheme, "http");
+        assert_eq!(endpoint.host, "localhost");
+        assert_eq!(endpoint.port, 8765);
+    }
+
+    #[test]
+    fn try_from_ok() {
+        let uri = Uri::from_static("https://foobar.local:9999");
+        let endpoint = Endpoint::try_from(uri).unwrap();
+        assert_eq!(endpoint.scheme, "https");
+        assert_eq!(endpoint.host, "foobar.local");
+        assert_eq!(endpoint.port, 9999);
+    }
+
+    #[test]
+    fn try_from_default() {
+        let uri = Uri::from_static("foobar.local");
+        let endpoint = Endpoint::try_from(uri).unwrap();
+        assert_eq!(endpoint.scheme, "http");
+        assert_eq!(endpoint.host, "foobar.local");
+        assert_eq!(endpoint.port, 80);
+    }
+
+    #[test]
+    fn try_from_err() {
+        let uri = Uri::from_static("/:9999/abc");
+        let err = Endpoint::try_from(uri).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Cannot parse endpoint host from URI '/:9999/abc'"
+        );
+
+        let uri = Uri::from_static("http://:9999/abc");
+        let err = Endpoint::try_from(uri).unwrap_err();
+        assert_eq!(err.to_string(), "No host part in URI 'http://:9999/abc'");
+    }
+}

--- a/crates/jstzd/src/task/mod.rs
+++ b/crates/jstzd/src/task/mod.rs
@@ -1,3 +1,4 @@
+pub mod endpoint;
 pub mod octez_node;
 
 use anyhow::Result;


### PR DESCRIPTION
# Context

[JSTZ-130](https://linear.app/tezos/issue/JSTZ-130/implement-endpoint)

# Description

Implemented struct `Endpoint` that represents an octez node RPC endpoint.

Note that the line `#[allow(dead_code)]` is added because the struct fields are not referenced anywhere else for now.

# Manually testing the PR

* Unit test: added test cases
