### PR TITLE
feat(jstzd): add config init for client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2645,6 +2645,8 @@ dependencies = [
  "octez",
  "rand 0.8.5",
  "reqwest",
+ "serde",
+ "serde_json",
  "tempfile",
  "tokio",
 ]

--- a/crates/jstzd/Cargo.toml
+++ b/crates/jstzd/Cargo.toml
@@ -13,6 +13,8 @@ bollard.workspace = true
 futures-util.workspace = true
 http.workspace = true
 octez = { path = "../octez" }
+serde.workspace = true
+serde_json.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
 

--- a/crates/jstzd/src/task/octez_client.rs
+++ b/crates/jstzd/src/task/octez_client.rs
@@ -1,7 +1,11 @@
 use super::{directory::Directory, endpoint::Endpoint, octez_node::DEFAULT_RPC_ENDPOINT};
 use anyhow::{anyhow, bail, Result};
 use http::Uri;
-use std::{ffi::OsStr, path::PathBuf, str::FromStr};
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 use tempfile::tempdir;
 use tokio::process::{Child, Command};
 
@@ -75,7 +79,6 @@ impl OctezClientBuilder {
     }
 }
 
-#[allow(dead_code)]
 #[derive(Debug)]
 pub struct OctezClient {
     binary_path: PathBuf,
@@ -84,7 +87,6 @@ pub struct OctezClient {
     disable_unsafe_disclaimer: bool,
 }
 
-#[allow(dead_code)]
 impl OctezClient {
     fn command<S: AsRef<OsStr>, I: IntoIterator<Item = S>>(
         &self,
@@ -111,6 +113,16 @@ impl OctezClient {
     ) -> Result<Child> {
         let mut command = self.command(args)?;
         Ok(command.spawn()?)
+    }
+
+    pub async fn config_init(&self, output_path: &Path) -> Result<()> {
+        let output = output_path
+            .to_str()
+            .ok_or(anyhow!("config output path must be a valid utf-8 path"))?;
+        self.spawn_command(["config", "init", "--output", output])?
+            .wait()
+            .await?;
+        Ok(())
     }
 }
 

--- a/crates/jstzd/tests/octez_client_test.rs
+++ b/crates/jstzd/tests/octez_client_test.rs
@@ -1,0 +1,28 @@
+use jstzd::task::{endpoint::Endpoint, octez_client::OctezClientBuilder};
+use serde_json::Value;
+use std::fs::{read_to_string, remove_file};
+use tempfile::{NamedTempFile, TempDir};
+
+#[tokio::test]
+async fn config_init() {
+    let temp_dir = TempDir::new().unwrap();
+    let expected_base_dir = temp_dir.path().to_path_buf();
+    let expected_endpoint: Endpoint = Endpoint::localhost(3000);
+    let config_file = NamedTempFile::new().unwrap();
+    let _ = remove_file(config_file.path());
+    let octez_client = OctezClientBuilder::new()
+        .set_base_dir(expected_base_dir.clone())
+        .set_endpoint(expected_endpoint.clone())
+        .build()
+        .unwrap();
+    let res = octez_client.config_init(config_file.path()).await;
+    assert!(res.is_ok());
+    let actual: Value =
+        serde_json::from_str(&read_to_string(config_file).expect("Unable to read file"))
+            .expect("Unable to parse JSON");
+    assert_eq!(
+        actual["base_dir"],
+        expected_base_dir.to_str().unwrap().to_owned()
+    );
+    assert_eq!(actual["endpoint"], expected_endpoint.to_string());
+}


### PR DESCRIPTION
# Context
[141](https://linear.app/tezos/issue/JSTZ-141/implement-octezclientconfig-init)

blocked by #572 

# Description

This PR implements the `octez_client config init` 
In order to be consistent with the api for #582 i return the `Child` and let the user handle it.
Note: i omitted the following two argumetns as this is only used for `mockup mode` 
```
--bootstrap-accounts 
--protocol-constants
```

# Manually testing the PR
two integration test:
```
cargo test --package jstzd --test octez_client_test         
```
output:
```
running 2 tests
test command_fails_on_non_utf8_path ... ok
test config_init ... ok
```
