### PR TITLE
Octez client gen keys

### DIFF
--- a/crates/jstzd/src/task/octez_client.rs
+++ b/crates/jstzd/src/task/octez_client.rs
@@ -1,11 +1,8 @@
 use super::{directory::Directory, endpoint::Endpoint, octez_node::DEFAULT_RPC_ENDPOINT};
 use anyhow::{anyhow, bail, Result};
 use http::Uri;
-use std::{
-    ffi::OsStr,
-    path::{Path, PathBuf},
-    str::FromStr,
-};
+use std::path::Path;
+use std::{ffi::OsStr, path::PathBuf, str::FromStr};
 use tempfile::tempdir;
 use tokio::process::{Child, Command};
 

--- a/crates/jstzd/tests/octez_client_test.rs
+++ b/crates/jstzd/tests/octez_client_test.rs
@@ -1,7 +1,19 @@
 use jstzd::task::{endpoint::Endpoint, octez_client::OctezClientBuilder};
 use serde_json::Value;
-use std::fs::{read_to_string, remove_file};
+use std::{
+    fs::{read_to_string, remove_file},
+    path::Path,
+};
 use tempfile::{NamedTempFile, TempDir};
+
+fn read_file(path: &Path) -> Value {
+    serde_json::from_str(&read_to_string(path).expect("Unable to read file"))
+        .expect("Unable to parse JSON")
+}
+
+fn first_item(json: Value) -> Value {
+    json.as_array().unwrap()[0].clone()
+}
 
 #[tokio::test]
 async fn config_init() {
@@ -25,4 +37,37 @@ async fn config_init() {
         expected_base_dir.to_str().unwrap().to_owned()
     );
     assert_eq!(actual["endpoint"], expected_endpoint.to_string());
+}
+
+#[tokio::test]
+async fn generates_keys() {
+    let temp_dir = TempDir::new().unwrap();
+    let base_dir = temp_dir.path().to_path_buf();
+    let octez_client = OctezClientBuilder::new()
+        .set_base_dir(base_dir.clone())
+        .build()
+        .unwrap();
+    let alias = "test_alias".to_string();
+    let res = octez_client.gen_keys(&alias, None).await;
+    assert!(res.is_ok());
+    let hashes = first_item(read_file(&base_dir.join("public_key_hashs")));
+    let pub_keys = first_item(read_file(&base_dir.join("public_keys")));
+    let secret_keys = first_item(read_file(&base_dir.join("secret_keys")));
+    assert_eq!(hashes["name"], alias);
+    assert_eq!(pub_keys["name"], alias);
+    assert_eq!(secret_keys["name"], alias);
+}
+
+#[tokio::test]
+async fn generates_keys_throws() {
+    let temp_dir = TempDir::new().unwrap();
+    let base_dir = temp_dir.path().to_path_buf();
+    let octez_client = OctezClientBuilder::new()
+        .set_base_dir(base_dir.clone())
+        .build()
+        .unwrap();
+    let alias = "test_alias".to_string();
+    let _ = octez_client.gen_keys(&alias, None).await;
+    let res = octez_client.gen_keys(&alias, None).await;
+    assert!(res.is_err_and(|e| e.to_string().contains("failed to generate key")));
 }


### PR DESCRIPTION
# Context

[implement gen keys](https://linear.app/tezos/issue/JSTZ-136/implement-octezclientgen-keys)

blocked by #577 
blocked by #572 

# Description

implement gen keys for octez client

# Manually testing the PR

added integration test:
`generates_keys`
