### PR TITLE
ci: cancel workflow runs for outdated commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   commitlint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Context

Cancel workflow runs for outdated commits to save resources and time.

# Description

Leverage [workflow concurrency](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency) to cancel redundant workflow runs.

# Manually testing the PR

Run [#11109580529](https://github.com/jstz-dev/jstz/actions/runs/11109580529) was cancelled when a new commit was pushed to this branch and replaced by [#11109992057](https://github.com/jstz-dev/jstz/actions/runs/11109992057).
