### PR TITLE
feat(jstzd): implement node run option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3023,6 +3023,7 @@ dependencies = [
  "serde",
  "serde_json",
  "signal-hook",
+ "tempfile",
  "tezos-smart-rollup-encoding",
  "tokio",
 ]

--- a/crates/jstzd/src/lib.rs
+++ b/crates/jstzd/src/lib.rs
@@ -7,11 +7,3 @@ pub async fn main() -> anyhow::Result<()> {
     println!("Hello, world!");
     Ok(())
 }
-
-pub fn unused_port() -> u16 {
-    std::net::TcpListener::bind("127.0.0.1:0")
-        .unwrap()
-        .local_addr()
-        .unwrap()
-        .port()
-}

--- a/crates/jstzd/src/task/octez_node.rs
+++ b/crates/jstzd/src/task/octez_node.rs
@@ -1,129 +1,13 @@
-use crate::unused_port;
-
 use super::Task;
 use anyhow::Result;
 use async_dropper_simple::{AsyncDrop, AsyncDropper};
 use async_trait::async_trait;
-use std::{fs::File, path::PathBuf, sync::Arc};
+use octez::OctezNodeConfig;
+use std::{fs::File, sync::Arc};
 use tokio::sync::RwLock;
 
 use octez::AsyncOctezNode;
 use tokio::process::Child;
-
-const DEFAULT_NETWORK: &str = "sandbox";
-const DEFAULT_BINARY_PATH: &str = "octez-node";
-const LOCALHOST: &str = "localhost";
-const LOCAL_ADDRESS: &str = "127.0.0.1";
-
-#[derive(Default, Clone)]
-pub struct OctezNodeConfig {
-    /// Path to the octez node binary.
-    binary_path: PathBuf,
-    /// Path to the directory where the node keeps data.
-    data_dir: PathBuf,
-    /// Name of the tezos network that the node instance runs on.
-    network: String,
-    /// HTTP endpoint of the node RPC interface, e.g. 'localhost:8732'
-    rpc_endpoint: String,
-    // TCP address and port at for p2p which this instance can be reached
-    p2p_address: String,
-    /// Path to the file that keeps octez node logs.
-    log_file: PathBuf,
-    /// Run options for octez node.
-    options: Vec<String>,
-}
-
-#[derive(Default)]
-pub struct OctezNodeConfigBuilder {
-    binary_path: Option<PathBuf>,
-    data_dir: Option<PathBuf>,
-    network: Option<String>,
-    rpc_endpoint: Option<String>,
-    p2p_endpoint: Option<String>,
-    log_file: Option<PathBuf>,
-    options: Option<Vec<String>>,
-}
-
-impl OctezNodeConfigBuilder {
-    pub fn new() -> Self {
-        OctezNodeConfigBuilder::default()
-    }
-
-    /// Sets the path to the octez node binary.
-    pub fn set_binary_path(&mut self, path: &str) -> &mut Self {
-        self.binary_path = Some(PathBuf::from(path));
-        self
-    }
-
-    /// Sets the path to the directory where the node keeps data.
-    pub fn set_data_dir(&mut self, path: &str) -> &mut Self {
-        self.data_dir = Some(PathBuf::from(path));
-        self
-    }
-
-    /// Sets the name of the tezos network that the node instance runs on.
-    pub fn set_network(&mut self, network: &str) -> &mut Self {
-        self.network = Some(network.to_owned());
-        self
-    }
-
-    /// Sets the HTTP(S) endpoint of the node RPC interface, e.g. 'localhost:8732'
-    pub fn set_rpc_endpoint(&mut self, endpoint: &str) -> &mut Self {
-        self.rpc_endpoint = Some(endpoint.to_owned());
-        self
-    }
-
-    pub fn set_p2p_endpoint(&mut self, endpoint: &str) -> &mut Self {
-        self.p2p_endpoint = Some(endpoint.to_owned());
-        self
-    }
-
-    /// Sets the path to the file that keeps octez node logs.
-    pub fn set_log_file(&mut self, path: &str) -> &mut Self {
-        self.log_file = Some(PathBuf::from(path));
-        self
-    }
-
-    /// Sets run options for octez node.
-    pub fn set_run_options(&mut self, options: &[&str]) -> &mut Self {
-        self.options = Some(
-            options
-                .iter()
-                .map(|v| (*v).to_owned())
-                .collect::<Vec<String>>(),
-        );
-        self
-    }
-
-    /// Builds a config set based on values collected.
-    pub fn build(&mut self) -> Result<OctezNodeConfig> {
-        Ok(OctezNodeConfig {
-            binary_path: self
-                .binary_path
-                .take()
-                .unwrap_or(PathBuf::from(DEFAULT_BINARY_PATH)),
-            data_dir: self
-                .data_dir
-                .take()
-                .unwrap_or(PathBuf::from(tempfile::TempDir::new().unwrap().path())),
-            network: self.network.take().unwrap_or(DEFAULT_NETWORK.to_owned()),
-            rpc_endpoint: self.rpc_endpoint.take().unwrap_or(format!(
-                "{}:{}",
-                LOCALHOST,
-                unused_port()
-            )),
-            p2p_address: self.p2p_endpoint.take().unwrap_or(format!(
-                "{}:{}",
-                LOCAL_ADDRESS,
-                unused_port()
-            )),
-            log_file: self.log_file.take().unwrap_or(PathBuf::from(
-                tempfile::NamedTempFile::new().unwrap().path(),
-            )),
-            options: self.options.take().unwrap_or_default(),
-        })
-    }
-}
 
 #[derive(Default)]
 struct ChildWrapper {
@@ -193,16 +77,8 @@ impl Task for OctezNode {
         Ok(OctezNode {
             inner: Arc::new(RwLock::new(AsyncDropper::new(ChildWrapper {
                 inner: Some(
-                    node.run(
-                        &File::create(&config.log_file)?,
-                        config
-                            .options
-                            .iter()
-                            .map(|s| s as &str)
-                            .collect::<Vec<&str>>()
-                            .as_slice(),
-                    )
-                    .await?,
+                    node.run(&File::create(&config.log_file)?, &config.run_options)
+                        .await?,
                 ),
             }))),
             config,
@@ -233,48 +109,5 @@ impl Task for OctezNode {
             return Ok(*v);
         }
         return Err(anyhow::anyhow!("unexpected error: `ready` cannot be retrieved from octez-node health check endpoint"));
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::path::PathBuf;
-
-    use crate::task::octez_node::{DEFAULT_BINARY_PATH, DEFAULT_NETWORK};
-
-    use super::OctezNodeConfigBuilder;
-
-    #[test]
-    fn config_builder() {
-        let config = OctezNodeConfigBuilder::new()
-            .set_binary_path("/tmp/binary")
-            .set_data_dir("/tmp/something")
-            .set_network("network")
-            .set_rpc_endpoint("my_endpoint")
-            .set_log_file("/log_file")
-            .set_run_options(&["foo", "bar"])
-            .build()
-            .unwrap();
-        assert_eq!(config.binary_path, PathBuf::from("/tmp/binary"));
-        assert_eq!(config.data_dir, PathBuf::from("/tmp/something"));
-        assert_eq!(config.network, "network".to_owned());
-        assert_eq!(config.rpc_endpoint, "my_endpoint".to_owned());
-        assert_eq!(config.log_file, PathBuf::from("/log_file"));
-        assert_eq!(
-            config.options,
-            Vec::from(["foo".to_owned(), "bar".to_owned()])
-        );
-    }
-
-    #[test]
-    fn config_builder_default() {
-        let config = OctezNodeConfigBuilder::new().build().unwrap();
-        assert_eq!(config.binary_path, PathBuf::from(DEFAULT_BINARY_PATH));
-        // Checks if the default path is a valid one that actually can exist in the file system
-        std::fs::create_dir(config.data_dir).unwrap();
-        assert_eq!(config.network, DEFAULT_NETWORK.to_owned());
-        // Checks if the default path is a valid one that actually can exist in the file system
-        std::fs::File::create(config.log_file).unwrap();
-        assert_eq!(config.options, Vec::<String>::default());
     }
 }

--- a/crates/jstzd/tests/octez_client_test.rs
+++ b/crates/jstzd/tests/octez_client_test.rs
@@ -245,12 +245,13 @@ async fn activate_protocol() {
 async fn spawn_octez_node() -> (octez_node::OctezNode, TempDir) {
     let temp_dir = TempDir::new().unwrap();
     let data_dir = temp_dir.path();
-    let mut config_builder = octez_node::OctezNodeConfigBuilder::new();
+    let mut config_builder = octez::OctezNodeConfigBuilder::new();
+    let mut run_option_builder = octez::OctezNodeRunOptionsBuilder::new();
     config_builder
         .set_binary_path("octez-node")
         .set_network("sandbox")
         .set_data_dir(data_dir.to_str().unwrap())
-        .set_run_options(&["--synchronisation-threshold", "0"]);
+        .set_run_options(&run_option_builder.set_synchronisation_threshold(0).build());
     let octez_node = octez_node::OctezNode::spawn(config_builder.build().unwrap())
         .await
         .unwrap();

--- a/crates/jstzd/tests/octez_node_test.rs
+++ b/crates/jstzd/tests/octez_node_test.rs
@@ -13,14 +13,19 @@ async fn octez_node_test() {
         .port();
     let rpc_endpoint = format!("localhost:{}", port);
 
-    let mut config_builer = octez_node::OctezNodeConfigBuilder::new();
+    let mut run_option_builder = octez::OctezNodeRunOptionsBuilder::new();
+    let run_options = run_option_builder
+        .set_synchronisation_threshold(0)
+        .set_network("sandbox")
+        .build();
+    let mut config_builer = octez::OctezNodeConfigBuilder::new();
     config_builer
         .set_binary_path("octez-node")
         .set_data_dir(data_dir.path().to_str().unwrap())
         .set_network("sandbox")
         .set_rpc_endpoint(&rpc_endpoint)
         .set_log_file(log_file.path().to_str().unwrap())
-        .set_run_options(&[]);
+        .set_run_options(&run_options);
     let mut f = octez_node::OctezNode::spawn(config_builer.build().unwrap())
         .await
         .unwrap();

--- a/crates/octez/Cargo.toml
+++ b/crates/octez/Cargo.toml
@@ -20,5 +20,6 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 signal-hook.workspace = true
+tempfile.workspace = true
 tezos-smart-rollup-encoding.workspace = true
 tokio.workspace = true

--- a/crates/octez/src/async_node.rs
+++ b/crates/octez/src/async_node.rs
@@ -2,6 +2,8 @@ use std::{fs::File, path::PathBuf, process::Stdio};
 
 use tokio::process::{Child, Command};
 
+use crate::OctezNodeRunOptions;
+
 use super::path_or_default;
 use anyhow::Result;
 
@@ -57,7 +59,11 @@ impl AsyncOctezNode {
             .spawn()?)
     }
 
-    pub async fn run(&self, log_file: &File, options: &[&str]) -> Result<Child> {
+    pub async fn run(
+        &self,
+        log_file: &File,
+        options: &OctezNodeRunOptions,
+    ) -> Result<Child> {
         let mut command = self.command();
 
         command
@@ -67,7 +73,7 @@ impl AsyncOctezNode {
                 self.octez_node_dir.to_str().expect("Invalid path"),
                 "--singleprocess",
             ])
-            .args(options)
+            .args(options.to_string().split(' '))
             .stdout(Stdio::from(log_file.try_clone()?))
             .stderr(Stdio::from(log_file.try_clone()?));
 

--- a/crates/octez/src/lib.rs
+++ b/crates/octez/src/lib.rs
@@ -5,12 +5,14 @@ use anyhow::{anyhow, Result};
 mod async_node;
 mod client;
 mod node;
+mod node_config;
 mod rollup;
 mod thread;
 
 pub use async_node::*;
 pub use client::*;
 pub use node::*;
+pub use node_config::*;
 pub use rollup::*;
 pub use thread::*;
 
@@ -47,4 +49,12 @@ pub(crate) fn run_command(command: &mut Command) -> Result<()> {
     }
 
     Ok(())
+}
+
+pub fn unused_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
 }

--- a/crates/octez/src/node_config.rs
+++ b/crates/octez/src/node_config.rs
@@ -1,0 +1,292 @@
+use crate::unused_port;
+use anyhow::Result;
+use std::path::PathBuf;
+
+const DEFAULT_NETWORK: &str = "sandbox";
+const DEFAULT_BINARY_PATH: &str = "octez-node";
+const LOCALHOST: &str = "localhost";
+const LOCAL_ADDRESS: &str = "127.0.0.1";
+
+#[derive(Clone, PartialEq, Debug)]
+pub enum OctezNodeHistoryMode {
+    Archive,
+    // The numerical value represents additional cycles preserved. 0 is acceptable.
+    Full(u8),
+    Rolling(u8),
+}
+
+impl ToString for OctezNodeHistoryMode {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Archive => "archive".to_owned(),
+            Self::Full(v) => format!("full:{v}"),
+            Self::Rolling(v) => format!("rolling:{v}"),
+        }
+    }
+}
+
+#[derive(Default, Clone, PartialEq, Debug)]
+pub struct OctezNodeRunOptions {
+    synchonisation_threshold: u8,
+    network: String,
+    history_mode: Option<OctezNodeHistoryMode>,
+}
+
+impl ToString for OctezNodeRunOptions {
+    fn to_string(&self) -> String {
+        let mut s = vec![];
+        s.push(format!(
+            "--synchronisation-threshold {}",
+            &self.synchonisation_threshold
+        ));
+        s.push(format!("--network {}", &self.network));
+        if let Some(v) = &self.history_mode {
+            s.push(format!("--history-mode {}", v.to_string()));
+        }
+        s.join(" ")
+    }
+}
+
+#[derive(Default)]
+pub struct OctezNodeRunOptionsBuilder {
+    synchonisation_threshold: Option<u8>,
+    network: Option<String>,
+    history_mode: Option<OctezNodeHistoryMode>,
+}
+
+impl OctezNodeRunOptionsBuilder {
+    pub fn new() -> Self {
+        OctezNodeRunOptionsBuilder {
+            ..Default::default()
+        }
+    }
+
+    pub fn set_synchronisation_threshold(&mut self, threshold: u8) -> &mut Self {
+        self.synchonisation_threshold.replace(threshold);
+        self
+    }
+
+    pub fn set_network(&mut self, network: &str) -> &mut Self {
+        self.network.replace(network.to_owned());
+        self
+    }
+
+    pub fn set_history_mode(&mut self, mode: OctezNodeHistoryMode) -> &mut Self {
+        self.history_mode.replace(mode);
+        self
+    }
+
+    pub fn build(&mut self) -> OctezNodeRunOptions {
+        OctezNodeRunOptions {
+            synchonisation_threshold: self
+                .synchonisation_threshold
+                .take()
+                .unwrap_or_default(),
+            network: self.network.take().unwrap_or(DEFAULT_NETWORK.to_owned()),
+            history_mode: self.history_mode.take(),
+        }
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct OctezNodeConfig {
+    /// Path to the octez node binary.
+    pub binary_path: PathBuf,
+    /// Path to the directory where the node keeps data.
+    pub data_dir: PathBuf,
+    /// Name of the tezos network that the node instance runs on.
+    pub network: String,
+    /// HTTP endpoint of the node RPC interface, e.g. 'localhost:8732'
+    pub rpc_endpoint: String,
+    // TCP address and port at for p2p which this instance can be reached
+    pub p2p_address: String,
+    /// Path to the file that keeps octez node logs.
+    pub log_file: PathBuf,
+    /// Run options for octez node.
+    pub run_options: OctezNodeRunOptions,
+}
+
+#[derive(Default)]
+pub struct OctezNodeConfigBuilder {
+    binary_path: Option<PathBuf>,
+    data_dir: Option<PathBuf>,
+    network: Option<String>,
+    rpc_endpoint: Option<String>,
+    p2p_endpoint: Option<String>,
+    log_file: Option<PathBuf>,
+    run_options: Option<OctezNodeRunOptions>,
+}
+
+impl OctezNodeConfigBuilder {
+    pub fn new() -> Self {
+        OctezNodeConfigBuilder::default()
+    }
+
+    /// Sets the path to the octez node binary.
+    pub fn set_binary_path(&mut self, path: &str) -> &mut Self {
+        self.binary_path = Some(PathBuf::from(path));
+        self
+    }
+
+    /// Sets the path to the directory where the node keeps data.
+    pub fn set_data_dir(&mut self, path: &str) -> &mut Self {
+        self.data_dir = Some(PathBuf::from(path));
+        self
+    }
+
+    /// Sets the name of the tezos network that the node instance runs on.
+    pub fn set_network(&mut self, network: &str) -> &mut Self {
+        self.network = Some(network.to_owned());
+        self
+    }
+
+    /// Sets the HTTP(S) endpoint of the node RPC interface, e.g. 'localhost:8732'
+    pub fn set_rpc_endpoint(&mut self, endpoint: &str) -> &mut Self {
+        self.rpc_endpoint = Some(endpoint.to_owned());
+        self
+    }
+
+    pub fn set_p2p_endpoint(&mut self, endpoint: &str) -> &mut Self {
+        self.p2p_endpoint = Some(endpoint.to_owned());
+        self
+    }
+
+    /// Sets the path to the file that keeps octez node logs.
+    pub fn set_log_file(&mut self, path: &str) -> &mut Self {
+        self.log_file = Some(PathBuf::from(path));
+        self
+    }
+
+    /// Sets run options for octez node.
+    pub fn set_run_options(&mut self, options: &OctezNodeRunOptions) -> &mut Self {
+        self.run_options.replace(options.clone());
+        self
+    }
+
+    /// Builds a config set based on values collected.
+    pub fn build(&mut self) -> Result<OctezNodeConfig> {
+        Ok(OctezNodeConfig {
+            binary_path: self
+                .binary_path
+                .take()
+                .unwrap_or(PathBuf::from(DEFAULT_BINARY_PATH)),
+            data_dir: self
+                .data_dir
+                .take()
+                .unwrap_or(PathBuf::from(tempfile::TempDir::new().unwrap().path())),
+            network: self.network.take().unwrap_or(DEFAULT_NETWORK.to_owned()),
+            rpc_endpoint: self.rpc_endpoint.take().unwrap_or(format!(
+                "{}:{}",
+                LOCALHOST,
+                unused_port()
+            )),
+            p2p_address: self.p2p_endpoint.take().unwrap_or(format!(
+                "{}:{}",
+                LOCAL_ADDRESS,
+                unused_port()
+            )),
+            log_file: self.log_file.take().unwrap_or(PathBuf::from(
+                tempfile::NamedTempFile::new().unwrap().path(),
+            )),
+            run_options: self.run_options.take().unwrap_or_default(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::{
+        OctezNodeConfigBuilder, OctezNodeHistoryMode, OctezNodeRunOptions,
+        OctezNodeRunOptionsBuilder, DEFAULT_BINARY_PATH, DEFAULT_NETWORK,
+    };
+
+    #[test]
+    fn config_builder() {
+        let mut run_options_builder = OctezNodeRunOptionsBuilder::new();
+        let run_options = run_options_builder.set_network("sandbox").build();
+        let config = OctezNodeConfigBuilder::new()
+            .set_binary_path("/tmp/binary")
+            .set_data_dir("/tmp/something")
+            .set_network("network")
+            .set_rpc_endpoint("my_endpoint")
+            .set_log_file("/log_file")
+            .set_run_options(&run_options)
+            .build()
+            .unwrap();
+        assert_eq!(config.binary_path, PathBuf::from("/tmp/binary"));
+        assert_eq!(config.data_dir, PathBuf::from("/tmp/something"));
+        assert_eq!(config.network, "network".to_owned());
+        assert_eq!(config.rpc_endpoint, "my_endpoint".to_owned());
+        assert_eq!(config.log_file, PathBuf::from("/log_file"));
+        assert_eq!(config.run_options, run_options);
+    }
+
+    #[test]
+    fn config_builder_default() {
+        let config = OctezNodeConfigBuilder::new().build().unwrap();
+        assert_eq!(config.binary_path, PathBuf::from(DEFAULT_BINARY_PATH));
+        // Checks if the default path is a valid one that actually can exist in the file system
+        std::fs::create_dir(config.data_dir).unwrap();
+        assert_eq!(config.network, DEFAULT_NETWORK.to_owned());
+        // Checks if the default path is a valid one that actually can exist in the file system
+        std::fs::File::create(config.log_file).unwrap();
+        assert_eq!(config.run_options, OctezNodeRunOptions::default());
+    }
+
+    #[test]
+    fn run_option_builder() {
+        let mut run_options_builder = OctezNodeRunOptionsBuilder::new();
+        let run_options = run_options_builder
+            .set_network("foo")
+            .set_history_mode(OctezNodeHistoryMode::Full(5))
+            .set_synchronisation_threshold(3)
+            .build();
+        assert_eq!(
+            run_options.history_mode.unwrap(),
+            OctezNodeHistoryMode::Full(5)
+        );
+        assert_eq!(run_options.network, "foo");
+        assert_eq!(run_options.synchonisation_threshold, 3);
+    }
+
+    #[test]
+    fn run_option_builder_default() {
+        let mut run_options_builder = OctezNodeRunOptionsBuilder::new();
+        let run_options = run_options_builder.build();
+        assert!(run_options.history_mode.is_none());
+        assert_eq!(run_options.network, "sandbox");
+        assert_eq!(run_options.synchonisation_threshold, 0);
+    }
+
+    #[test]
+    fn run_option_to_string() {
+        let mut run_options_builder = OctezNodeRunOptionsBuilder::new();
+        let run_options = run_options_builder
+            .set_network("foo")
+            .set_history_mode(OctezNodeHistoryMode::Full(5))
+            .set_synchronisation_threshold(3)
+            .build()
+            .to_string();
+        assert_eq!(
+            run_options,
+            "--synchronisation-threshold 3 --network foo --history-mode full:5"
+        );
+
+        // No history mode
+        let run_options = run_options_builder
+            .set_network("foo")
+            .set_synchronisation_threshold(3)
+            .build()
+            .to_string();
+        assert_eq!(run_options, "--synchronisation-threshold 3 --network foo");
+    }
+
+    #[test]
+    fn history_mode_to_string() {
+        assert_eq!(OctezNodeHistoryMode::Archive.to_string(), "archive");
+        assert_eq!(OctezNodeHistoryMode::Full(2).to_string(), "full:2");
+        assert_eq!(OctezNodeHistoryMode::Rolling(1).to_string(), "rolling:1");
+    }
+}


### PR DESCRIPTION
# Context

Completes JSTZ-116.

[JSTZ-116](https://linear.app/tezos/issue/JSTZ-116/implement-octeznode)

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description

Replaces run options in string with a proper struct in order to be more selective compared with accepting random strings.

Also moved `OctezNodeConfig` to crate octez since it's actually not just for jstzd.

# Manually testing the PR

Added test cases for unit testing in crate octez.
