### PR TITLE
Eng offsite preparation

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,33 +28,32 @@ on:
 
 env:
   DOCKER_REGISTRY: ghcr.io
-  DOCKER_IMAGE_BASE: trilitech
+  DOCKER_IMAGE_BASE: jstz-dev/jstz
 
 jobs:
   build-kernel:
     name: Build (Kernel)
-    runs-on: ubuntu-latest
+    runs-on: [x86_64, linux, nix]
     steps:
       - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2.7.1
-      - name: Rust setup
-        # FIXME: Once rustup adds a command to install a toolchain from rust-toolchain.toml, we can remove this.
-        run: rustup toolchain add 1.73.0 --profile minimal
-
-      - name: Build kernel
-        run: make build-kernel
+      - run: nix --version
+      - name: Format
+        run: nix --accept-flake-config fmt -- --fail-on-change
+      - name: Prevent blst
+        run: nix --accept-flake-config develop -j auto --command sh -c '[ -z "$(cargo tree | grep blst)" ]'
+      - name: Build
+        run: nix --accept-flake-config --log-format raw -L build -j auto .#jstz_kernel
       - name: Upload kernel
         id: upload-kernel
         uses: actions/upload-artifact@v4
         with:
           name: jstz-kernel
-          path: target/wasm32-unknown-unknown/release/jstz_kernel.wasm
+          path: result/lib/jstz_kernel.wasm
 
   build-docker:
     name: Build (Docker)
     needs: [build-kernel]
-    runs-on:
-      group: jstz
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ node_modules/
 
 # Required by the CLI
 crates/jstz_cli/jstz_kernel.wasm
+
+**/*/.DS_Store

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -2,36 +2,74 @@
 
 `jstz` maintains a persistent ledger of all accounts and their balances of L2 tez (stored as mutez).
 
-The `jstz` _bridge_ implements a bridge protocol that allows to transfer fungible tokens (namely [CTEZ](https://ctez.app/)) from Tezos to the `jstz` rollup (and back *soon*™️).
-
-::: danger
-⚠️ Withdrawals from `jstz` to Tezos is not supported ⚠️
-:::
+The `jstz` _bridge_ implements a bridge protocol that allows to transfer tezos tokens from Tezos to the `jstz` rollup and back.
 
 ## Quick Start
 
-The `jstz` CLI empowers you to effortlessly transfer assets between a Tezos address (`tz1`) and a `jstz` L2 address (`tz4`) using the provided `bridge` commands.
+### Deposit
+
+The `jstz` CLI empowers you to effortlessly transfer assets between a Tezos address (`tz1`) and a `jstz` L2 address (`tz1`) using the provided `bridge` commands.
 
 To deposit assets from a Tezos address to a `jstz` L2 address, run the following command:
 
 ```bash
-jstz bridge deposit --from <TZ1_ADDRESS/ALIAS> --to <TZ4_ADDRESS/ALIAS> --amount <AMOUNT>
+jstz bridge deposit --from <TZ1_ADDRESS/ALIAS> --to <TZ1_ADDRESS/ALIAS> --amount <AMOUNT>
 ```
 
-Replace `<TZ1_ADDRESS/ALIAS>` with the source Tezos address or alias (managed by `octez-client`), `<TZ4_ADDRESS/ALIAS>` with the destination `jstz` address, and `<AMOUNT>` with the quantity of CTEZ to deposit.
+Replace `<TZ1_ADDRESS/ALIAS>` with the source Tezos address or alias (managed by `octez-client`), `<TZ1_ADDRESS/ALIAS>` with the destination `jstz` address, and `<AMOUNT>` with the quantity of XTZ to deposit.
 
 For example, running:
 
 ```bash
 jstz bridge deposit --from tz1faswCTDciRzE4oJ9jn2Vm2dvjeyA9fUzU \
-    --to tz4N7y3T2e2dfCyHB1Ama68jnt3Fps7Ufu6d \
+    --to tz1ZvXcDBWMAys2ro6kJXrgiWUcUF8RvCHYy \
     --amount 42
 ```
 
-sucessfully deposits 42 CTEZ from `tz1faswCTDciRzE4oJ9jn2Vm2dvjeyA9fUzU` to the `tz4N7y3T2e2dfCyHB1Ama68jnt3Fps7Ufu6d` `jstz` address, outputting:
+sucessfully deposits 42 XTZ from `tz1faswCTDciRzE4oJ9jn2Vm2dvjeyA9fUzU` to the `tz1ZvXcDBWMAys2ro6kJXrgiWUcUF8RvCHYy` `jstz` address, outputting:
 
 ```
-Deposited 42 CTEZ to tz4N7y3T2e2dfCyHB1Ama68jnt3Fps7Ufu6d
+Deposited 42 XTZ to tz4N7y3T2e2dfCyHB1Ama68jnt3Fps7Ufu6d
+```
+
+### Withdraw
+
+::: danger
+⚠️ Withdrawals on `jstz` to Tezos is still a work in progress
+:::
+
+To withdraw assets from `jstz` L2 address to a Tezos address, run the following command:
+
+```bash
+ jstz bridge withdraw --to <TZ1_ADDRESS/ALIAS> --amount <AMOUNT>
+```
+
+This will withdraw `<AMOUNT>`ꜩ from the current logged in `jstz` account to `<TZ1_ADDRESS/ALIAS>` Tezos account
+
+For example, running:
+
+```bash
+jstz bridge withdraw --to tz1faswCTDciRzE4oJ9jn2Vm2dvjeyA9fUzU \
+    --amount 42
+```
+
+will output the following response on success:
+
+```bash
+Running function at tezos://jstz/withdraw
+Status code: 200 OK
+Headers: {}
+```
+
+Communication from L2 and L1 within the Tezos ecosystem is performed through [outbox messages](https://tezos.gitlab.io/shell/smart_rollup_node.html#triggering-the-execution-of-an-outbox-message). Use [execute_latest_outbox_message](https://github.com/jstz-dev/jstz/blob/main/scripts/execute_latest_outbox_message.sh) to execute the withdraw message.
+
+::: warning
+⚠️ The following example will not work with `octez-client` in the Nix shell.
+:::
+
+```bash
+# Requires octez client binary as an argument
+./scripts/execute_latest_outbox_message.sh octez-client
 ```
 
 ## How it Works?

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -74,6 +74,12 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 #### Octez 🐙
 
+::: tip
+
+The Nix shell ships with Octez binaries for convenience but it does take a little while to build for the very first time.
+Skip ahead to [Building](#building-👷‍♂️)
+
+:::
 The jstz sandbox uses a custom distribution of Octez found [here](https://gitlab.com/tezos/tezos/-/tree/jstz@octez-dev). See the [Octez docs](https://tezos.gitlab.io/introduction/howtoget.html?highlight=building#compiling-with-make) for instructions on building Octez from source.
 
 Once Octez has been built, copy the following binaries to `jstz`:
@@ -82,38 +88,16 @@ Once Octez has been built, copy the following binaries to `jstz`:
 - `octez-node`
 - `octez-smart-rollup-node`
 
-::: tip
-
-Using Nix, simply execute the following:
-
-```sh
-# Clone Octez
-git clone git@gitlab.com:tezos/tezos.git && cd tezos
-# Checkout custom distribution for jstz
-git checkout jstz@octez-dev
-# Build using Nix
-nix-build -j auto
-```
-
-After Nix successfully builds Octez (it takes a long time 🕣), the Octez binaries will be accessable from `result`.
-:::
-
 ### Building 👷‍♂️
 
 ::: tip
 Using Nix, simply run `nix develop` to enter a shell with all build dependencies or use `direnv` to automatically enter the shell when you `cd` into the `jstz` directory.
 :::
 
-Additional build dependencies can be installed with:
+The kernel can be built with:
 
 ```sh
-make build-deps
-```
-
-The `.wasm` file for `jstz`'s kernel is built with:
-
-```sh
-make build-kernel
+make build
 ```
 
 You can locate the resulting build artifact at `/target/wasm32-unknown-unknown/release/jstz_kernel.wasm`.
@@ -123,8 +107,9 @@ You can locate the resulting build artifact at `/target/wasm32-unknown-unknown/r
 You can start the sandbox with:
 
 ```sh
-make build-cli-kernel
+make build-cli
 PATH=.:$PATH cargo run --bin jstz -- sandbox start
 ```
 
-This will initially run `octez-node` and initialize `octez-client`. Once the client is initialized, the `jstz_kernel` and `jstz_bridge` is originated, a `octez-smart-rollup-node` and `jstz-node` is spun up.
+This will initially run `octez-node` and initialize `octez-client`. Once the client is initialized, the `jstz_kernel` and `jstz_bridge`
+is originated, a `octez-smart-rollup-node` and `jstz-node` is spun up.

--- a/scripts/install-jstz-cli.sh
+++ b/scripts/install-jstz-cli.sh
@@ -2,12 +2,12 @@
 
 { # this ensures the entire script is downloaded
 
-  version="20240703"
+  version="20241007"
   network="ghostnet"
   # FIXME: https://app.asana.com/0/1205770721173533/1207698416028745/f
   # Update the container URL to point to jstz-dev instead of trilitech
   # (once the runners have been transferred)
-  container="ghcr.io/trilitech/jstz-cli:$version"
+  container="ghcr.io/jstz-dev/jstz/jstz-cli:$version"
   jstz_home="$HOME/.jstz"
 
   # ps -p filters on the parent process, -o comm= prints the command name (supressing the header)


### PR DESCRIPTION
# Context
Getting docs ready for Engineering offsite

# Description
* Update docs for eng offsite with focus on installation and native bridge. 
* [Fix CI for docker image publication](https://github.com/jstz-dev/jstz/actions/runs/11225663601)
* Update install script to point to new published image
