### PR TITLE
octez client: show address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2642,6 +2642,7 @@ dependencies = [
  "bollard",
  "futures-util",
  "http 1.1.0",
+ "jstz_crypto",
  "octez",
  "rand 0.8.5",
  "reqwest",

--- a/crates/jstzd/Cargo.toml
+++ b/crates/jstzd/Cargo.toml
@@ -18,6 +18,7 @@ serde.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
+jstz_crypto = { path = "../jstz_crypto" }
 
 [dev-dependencies]
 rand.workspace = true


### PR DESCRIPTION
# Context

[show url](https://linear.app/tezos/issue/JSTZ-146/implement-octezclientshow-address)

# Description

Show the address for the given alias. 
Implemented an `Address` struct that can be parsed from the stdout of the show address command

# Manually testing the PR

Added 3 integration tests
```
cargo test --package jstzd --test octez_client_test -- show_address

running 3 tests
test show_address_fails_for_non_existing_alias ... ok
test show_address_with_secret_key ... ok
test show_address ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 1.26s
```
4 unit tests:
```
cargo test --package jstzd --lib -- task::octez_client::test::address_try_from

running 4 tests
test task::octez_client::test::address_try_from_fails_on_invalid_input ... ok
test task::octez_client::test::address_try_from_fails_on_invalid_key ... ok
test task::octez_client::test::address_try_from_fails_on_missing_public_key ... ok
test task::octez_client::test::address_try_from ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 21 filtered out; finished in 0.00s
```

