### PR TITLE
chore: update Boa to 0.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "async-dropper-simple"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,23 +581,25 @@ dependencies = [
 
 [[package]]
 name = "boa_ast"
-version = "0.17.0"
-source = "git+https://github.com/trilitech/boa.git?rev=78c8540e#78c8540eb0167abd62975f47d40aa55a7bbcf5d0"
+version = "0.19.0"
+source = "git+https://github.com/trilitech/boa.git?branch=ryutamago/fix-undefined-to-json#c7b9ff04991a4a9dfbc9356e7f92efba93fe9dac"
 dependencies = [
  "arbitrary",
  "bitflags 2.6.0",
  "boa_interner",
  "boa_macros",
+ "boa_string",
  "indexmap 2.6.0",
  "num-bigint 0.4.6",
- "rustc-hash",
+ "rustc-hash 2.0.0",
 ]
 
 [[package]]
 name = "boa_engine"
-version = "0.17.0"
-source = "git+https://github.com/trilitech/boa.git?rev=78c8540e#78c8540eb0167abd62975f47d40aa55a7bbcf5d0"
+version = "0.19.0"
+source = "git+https://github.com/trilitech/boa.git?branch=ryutamago/fix-undefined-to-json#c7b9ff04991a4a9dfbc9356e7f92efba93fe9dac"
 dependencies = [
+ "arrayvec",
  "bitflags 2.6.0",
  "boa_ast",
  "boa_gc",
@@ -599,22 +607,26 @@ dependencies = [
  "boa_macros",
  "boa_parser",
  "boa_profiler",
- "chrono",
+ "boa_string",
+ "bytemuck",
+ "cfg-if",
  "dashmap",
  "fast-float",
+ "hashbrown 0.14.5",
  "icu_normalizer",
  "indexmap 2.6.0",
- "itertools 0.11.0",
+ "intrusive-collections",
+ "itertools 0.13.0",
  "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
  "num_enum",
  "once_cell",
- "paste",
  "pollster",
+ "portable-atomic",
  "rand 0.8.5",
  "regress",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "ryu-js",
  "serde",
  "serde_json",
@@ -623,23 +635,25 @@ dependencies = [
  "tap",
  "thin-vec",
  "thiserror",
+ "time",
 ]
 
 [[package]]
 name = "boa_gc"
-version = "0.17.0"
-source = "git+https://github.com/trilitech/boa.git?rev=78c8540e#78c8540eb0167abd62975f47d40aa55a7bbcf5d0"
+version = "0.19.0"
+source = "git+https://github.com/trilitech/boa.git?branch=ryutamago/fix-undefined-to-json#c7b9ff04991a4a9dfbc9356e7f92efba93fe9dac"
 dependencies = [
  "boa_macros",
  "boa_profiler",
+ "boa_string",
  "hashbrown 0.14.5",
  "thin-vec",
 ]
 
 [[package]]
 name = "boa_interner"
-version = "0.17.0"
-source = "git+https://github.com/trilitech/boa.git?rev=78c8540e#78c8540eb0167abd62975f47d40aa55a7bbcf5d0"
+version = "0.19.0"
+source = "git+https://github.com/trilitech/boa.git?branch=ryutamago/fix-undefined-to-json#c7b9ff04991a4a9dfbc9356e7f92efba93fe9dac"
 dependencies = [
  "arbitrary",
  "boa_gc",
@@ -648,14 +662,14 @@ dependencies = [
  "indexmap 2.6.0",
  "once_cell",
  "phf",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "static_assertions",
 ]
 
 [[package]]
 name = "boa_macros"
-version = "0.17.0"
-source = "git+https://github.com/trilitech/boa.git?rev=78c8540e#78c8540eb0167abd62975f47d40aa55a7bbcf5d0"
+version = "0.19.0"
+source = "git+https://github.com/trilitech/boa.git?branch=ryutamago/fix-undefined-to-json#c7b9ff04991a4a9dfbc9356e7f92efba93fe9dac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -665,8 +679,8 @@ dependencies = [
 
 [[package]]
 name = "boa_parser"
-version = "0.17.0"
-source = "git+https://github.com/trilitech/boa.git?rev=78c8540e#78c8540eb0167abd62975f47d40aa55a7bbcf5d0"
+version = "0.19.0"
+source = "git+https://github.com/trilitech/boa.git?branch=ryutamago/fix-undefined-to-json#c7b9ff04991a4a9dfbc9356e7f92efba93fe9dac"
 dependencies = [
  "bitflags 2.6.0",
  "boa_ast",
@@ -678,13 +692,25 @@ dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
  "regress",
- "rustc-hash",
+ "rustc-hash 2.0.0",
 ]
 
 [[package]]
 name = "boa_profiler"
-version = "0.17.0"
-source = "git+https://github.com/trilitech/boa.git?rev=78c8540e#78c8540eb0167abd62975f47d40aa55a7bbcf5d0"
+version = "0.19.0"
+source = "git+https://github.com/trilitech/boa.git?branch=ryutamago/fix-undefined-to-json#c7b9ff04991a4a9dfbc9356e7f92efba93fe9dac"
+
+[[package]]
+name = "boa_string"
+version = "0.19.0"
+source = "git+https://github.com/trilitech/boa.git?branch=ryutamago/fix-undefined-to-json#c7b9ff04991a4a9dfbc9356e7f92efba93fe9dac"
+dependencies = [
+ "fast-float",
+ "paste",
+ "rustc-hash 2.0.0",
+ "sptr",
+ "static_assertions",
+]
 
 [[package]]
 name = "bollard"
@@ -771,6 +797,20 @@ name = "bytemuck"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
 
 [[package]]
 name = "byteorder"
@@ -1816,15 +1856,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -2148,9 +2179,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.3.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3907b2246e8dd5a29ead8a965e7c0c8a90e9b928e614a4279257d45c5e553e91"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -2160,9 +2191,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locid"
-version = "1.3.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f284eb342dc49d3e9d9f3b188489d76b5d22dfb1d1a5e0d1941811253bac625c"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2173,9 +2204,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locid_transform"
-version = "1.3.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6551daf80882d8e68eee186cc19e132d8bde1b1f059a79b93384a5ca0e8fc5e7"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
 dependencies = [
  "displaydoc",
  "icu_locid",
@@ -2187,15 +2218,15 @@ dependencies = [
 
 [[package]]
 name = "icu_locid_transform_data"
-version = "1.3.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a741eba5431f75eb2f1f9022d3cffabcadda6771e54fb4e77c8ba8653e4da44"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
 
 [[package]]
 name = "icu_normalizer"
-version = "1.3.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080fc33a720d50a7342b0c58df010fbcfb842d6f78ef81555f8b1ac6bba57d3c"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -2211,15 +2242,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.3.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d22f74066c2e6442db2a9aa14950278e86719e811e304e48bae03094b369d"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
 
 [[package]]
 name = "icu_properties"
-version = "1.3.2"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3477ae70f8ca8dc08ff7574b5398ed0a2f2e4e6b66bdff2558a92ed67e262be1"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -2232,15 +2263,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "1.3.4"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98507b488098f45eb95ef495612a2012e4d8ad6095dda86cb2f1728aa2204a60"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
 
 [[package]]
 name = "icu_provider"
-version = "1.3.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68acdef80034b5e35d8524e9817479d389a4f9774f3f0cbe1bf3884d80fd5934"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
 dependencies = [
  "displaydoc",
  "icu_locid",
@@ -2255,9 +2286,9 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_macros"
-version = "1.3.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2060258edfcfe32ca7058849bf0f146cb5c59aadbedf480333c0d0002f97bc99"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2349,6 +2380,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "intrusive-collections"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
+dependencies = [
+ "memoffset",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2373,18 +2413,18 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2866,6 +2906,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3050,6 +3099,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.79",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3708,11 +3766,11 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "regress"
-version = "0.7.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ed9969cad8051328011596bf549629f1b800cf1731e7964b1eef8dfc480d2c2"
+checksum = "1541daf4e4ed43a0922b7969bdc2170178bcacc5dabf7e39bc508a9fa3953a7a"
 dependencies = [
- "hashbrown 0.13.2",
+ "hashbrown 0.14.5",
  "memchr",
 ]
 
@@ -3849,6 +3907,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustc_version"
@@ -4861,7 +4925,10 @@ checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
+ "js-sys",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -4895,7 +4962,7 @@ dependencies = [
  "once_cell",
  "pbkdf2",
  "rand 0.8.5",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "sha2 0.10.8",
  "thiserror",
  "unicode-normalization",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ async-dropper-simple = { version = "0.2.6", features = ["tokio"] }
 async-trait = "0.1.82"
 base64 = "0.21.7"
 bincode = "1.3.3"
-boa_engine = { version = "0.17.0", features = ["fuzz"] }
-boa_gc = "0.17.0"
+boa_engine = { version = "0.19.0", features = ["fuzz"] }
+boa_gc = "0.19.0"
 bollard = "0.16.1"
 bs58 = "0.5"
 bytes = "1.4.0"
@@ -156,10 +156,10 @@ tezos-smart-rollup-entrypoint = { git = "https://gitlab.com/tezos/tezos.git" }
 tezos-smart-rollup-debug = { git = "https://gitlab.com/tezos/tezos.git" }
 tezos-smart-rollup-panic-hook = { git = "https://gitlab.com/tezos/tezos.git" }
 tezos-smart-rollup-storage = { git = "https://gitlab.com/tezos/tezos.git" }
-boa_ast = { git = "https://github.com/trilitech/boa.git", rev = "78c8540e" }
-boa_engine = { git = "https://github.com/trilitech/boa.git", rev = "78c8540e" }
-boa_gc = { git = "https://github.com/trilitech/boa.git", rev = "78c8540e" }
-boa_interner = { git = "https://github.com/trilitech/boa.git", rev = "78c8540e" }
-boa_macros = { git = "https://github.com/trilitech/boa.git", rev = "78c8540e" }
-boa_parser = { git = "https://github.com/trilitech/boa.git", rev = "78c8540e" }
-boa_profiler = { git = "https://github.com/trilitech/boa.git", rev = "78c8540e" }
+boa_ast = { git = "https://github.com/trilitech/boa.git", branch = "ryutamago/fix-undefined-to-json" }
+boa_engine = { git = "https://github.com/trilitech/boa.git", branch = "ryutamago/fix-undefined-to-json" }
+boa_gc = { git = "https://github.com/trilitech/boa.git", branch = "ryutamago/fix-undefined-to-json" }
+boa_interner = { git = "https://github.com/trilitech/boa.git", branch = "ryutamago/fix-undefined-to-json" }
+boa_macros = { git = "https://github.com/trilitech/boa.git", branch = "ryutamago/fix-undefined-to-json" }
+boa_parser = { git = "https://github.com/trilitech/boa.git", branch = "ryutamago/fix-undefined-to-json" }
+boa_profiler = { git = "https://github.com/trilitech/boa.git", branch = "ryutamago/fix-undefined-to-json" }

--- a/crates/jstz_api/src/encoding/global.rs
+++ b/crates/jstz_api/src/encoding/global.rs
@@ -52,7 +52,7 @@ impl GlobalApi {
 }
 
 impl jstz_core::Api for GlobalApi {
-    fn init(self, context: &mut boa_engine::Context<'_>) {
+    fn init(self, context: &mut Context) {
         context
             .register_global_builtin_callable(
                 js_string!("atob"),

--- a/crates/jstz_api/src/encoding/mod.rs
+++ b/crates/jstz_api/src/encoding/mod.rs
@@ -11,7 +11,7 @@ pub mod text_encoder;
 pub struct EncodingApi;
 
 impl jstz_core::Api for EncodingApi {
-    fn init(self, context: &mut Context<'_>) {
+    fn init(self, context: &mut Context) {
         TextEncoderApi.init(context);
         TextDecoderApi.init(context);
         GlobalApi.init(context);

--- a/crates/jstz_api/src/encoding/text_decoder.rs
+++ b/crates/jstz_api/src/encoding/text_decoder.rs
@@ -1,8 +1,8 @@
 use std::io::Write;
 
 use boa_engine::{
-    js_string, object::Object, property::Attribute, Context, JsArgs, JsError,
-    JsNativeError, JsResult, JsValue, NativeFunction,
+    js_string, object::ErasedObject, property::Attribute, Context, JsArgs, JsData,
+    JsError, JsNativeError, JsResult, JsValue, NativeFunction,
 };
 use boa_gc::{Finalize, GcRefMut, Trace};
 use encoding_rs::{Decoder, DecoderResult, Encoding};
@@ -12,8 +12,7 @@ use jstz_core::{
     value::{IntoJs, TryFromJs},
 };
 
-use crate::idl::{ArrayBufferLike, JsBufferSource};
-
+use crate::idl::{BufferSource, JsBufferSource};
 // https://encoding.spec.whatwg.org/#interface-textdecoder
 //
 // dictionary TextDecoderOptions {
@@ -40,7 +39,7 @@ use crate::idl::{ArrayBufferLike, JsBufferSource};
 //   readonly attribute boolean ignoreBOM;
 // };
 
-#[derive(Trace, Finalize)]
+#[derive(Trace, Finalize, JsData)]
 pub struct TextDecoder {
     encoding: &'static Encoding,
     #[unsafe_ignore_trace]
@@ -58,7 +57,7 @@ pub struct TextDecoderOptions {
 }
 
 impl TryFromJs for TextDecoderOptions {
-    fn try_from_js(value: &JsValue, context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, context: &mut Context) -> JsResult<Self> {
         let obj = value.as_object().ok_or_else(|| {
             JsError::from_native(JsNativeError::typ().with_message("Expected `JsObject`"))
         })?;
@@ -79,13 +78,13 @@ impl TryFromJs for TextDecoderOptions {
     }
 }
 
-#[derive(Trace, Finalize, Default)]
+#[derive(Trace, Finalize, JsData, Default)]
 pub struct TextDecodeOptions {
     stream: bool,
 }
 
 impl TryFromJs for TextDecodeOptions {
-    fn try_from_js(value: &JsValue, context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, context: &mut Context) -> JsResult<Self> {
         let obj = value.as_object().ok_or_else(|| {
             JsError::from_native(JsNativeError::typ().with_message("Expected `JsObject`"))
         })?;
@@ -101,7 +100,7 @@ impl TryFromJs for TextDecodeOptions {
 }
 
 impl TextDecoder {
-    fn try_from_js(value: &JsValue) -> JsResult<GcRefMut<'_, Object, Self>> {
+    fn try_from_js(value: &JsValue) -> JsResult<GcRefMut<'_, ErasedObject, Self>> {
         value
             .as_object()
             .and_then(|obj| obj.downcast_mut::<Self>())
@@ -272,7 +271,7 @@ impl TextDecoder {
 #[derive(Default, Clone, Trace, Finalize)]
 pub struct TextDecoderClass;
 impl TextDecoderClass {
-    fn encoding(context: &mut Context<'_>) -> Accessor {
+    fn encoding(context: &mut Context) -> Accessor {
         accessor!(
             context,
             TextDecoder,
@@ -280,7 +279,7 @@ impl TextDecoderClass {
             get:((this, context) => Ok(this.encoding().into_js(context)))
         )
     }
-    fn fatal(context: &mut Context<'_>) -> Accessor {
+    fn fatal(context: &mut Context) -> Accessor {
         accessor!(
             context,
             TextDecoder,
@@ -288,7 +287,7 @@ impl TextDecoderClass {
             get:((this, _context) => Ok(this.fatal().into()))
         )
     }
-    fn ignore_bom(context: &mut Context<'_>) -> Accessor {
+    fn ignore_bom(context: &mut Context) -> Accessor {
         accessor!(
             context,
             TextDecoder,
@@ -307,19 +306,15 @@ impl TextDecoderClass {
             args.get_or_undefined(0).try_js_into(context)?;
         let options = args.get_or_undefined(1).try_js_into(context)?;
 
-        // TODO: BORROW CHECKER ISSUE
-        // We cannot borrow the slice directly from `input` because we need to create
-        // 2 temporaries: a `JsArrayBufferData` and a `GcRefMut`.
         let result = match input {
             Some(input) => {
-                let array_buffer_data = input.to_array_buffer_data(context)?;
-                let array_buffer_slice = array_buffer_data.as_slice_mut();
-                text_decoder.decode(array_buffer_slice.as_deref(), options)
+                let bytes = input.clone_data(context)?;
+                text_decoder.decode(Some(&bytes), options)
             }
             None => text_decoder.decode(None, options),
         }?;
 
-        Ok(js_string!(result).into())
+        Ok(js_string!(result.as_slice()).into())
     }
 }
 
@@ -331,7 +326,7 @@ impl NativeClass for TextDecoderClass {
     fn data_constructor(
         _target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut Context,
     ) -> JsResult<TextDecoder> {
         let label: Option<String> = args.get_or_undefined(0).try_js_into(context)?;
         let options: Option<TextDecoderOptions> =
@@ -343,7 +338,7 @@ impl NativeClass for TextDecoderClass {
         })
     }
 
-    fn init(class: &mut ClassBuilder<'_, '_>) -> JsResult<()> {
+    fn init(class: &mut ClassBuilder<'_>) -> JsResult<()> {
         let encoding = Self::encoding(class.context());
         let fatal = Self::fatal(class.context());
         let ignore_bom = Self::ignore_bom(class.context());
@@ -363,7 +358,7 @@ impl NativeClass for TextDecoderClass {
 
 pub struct TextDecoderApi;
 impl jstz_core::Api for TextDecoderApi {
-    fn init(self, context: &mut Context<'_>) {
+    fn init(self, context: &mut Context) {
         register_global_class::<TextDecoderClass>(context)
             .expect("The `TextDecoder` class shouldn't exist yet");
     }

--- a/crates/jstz_api/src/encoding/text_encoder.rs
+++ b/crates/jstz_api/src/encoding/text_encoder.rs
@@ -2,11 +2,11 @@ use boa_engine::{
     js_string,
     object::{
         builtins::{JsArrayBuffer, JsUint8Array},
-        Object,
+        ErasedObject,
     },
     property::Attribute,
-    Context, JsArgs, JsBigInt, JsNativeError, JsResult, JsString, JsValue,
-    NativeFunction,
+    Context, JsArgs, JsBigInt, JsData, JsError, JsNativeError, JsResult, JsString,
+    JsValue, NativeFunction,
 };
 use boa_gc::{Finalize, GcRefMut, Trace};
 use encoding_rs::UTF_8;
@@ -17,8 +17,6 @@ use jstz_core::{
     },
     value::TryFromJs,
 };
-
-use crate::idl::ArrayBufferLike;
 
 // https://encoding.spec.whatwg.org/#textencodercommon
 //
@@ -39,17 +37,17 @@ use crate::idl::ArrayBufferLike;
 // };
 // TextEncoder includes TextEncoderCommon;
 
-#[derive(Trace, Finalize)]
+#[derive(Trace, Finalize, JsData)]
 pub struct TextEncoder;
 
-#[derive(Trace, Finalize, Default, TryFromJs)]
+#[derive(Trace, Finalize, JsData, Default, TryFromJs)]
 pub struct TextEncoderEncodeIntoResult {
     read: u128,
     written: u128,
 }
 
 impl TextEncoderEncodeIntoResult {
-    fn try_from_js(value: &JsValue) -> JsResult<GcRefMut<'_, Object, Self>> {
+    fn try_from_js(value: &JsValue) -> JsResult<GcRefMut<'_, ErasedObject, Self>> {
         value
           .as_object()
           .and_then(|obj| obj.downcast_mut::<Self>())
@@ -59,7 +57,7 @@ impl TextEncoderEncodeIntoResult {
                   .into()
           })
     }
-    fn read(context: &mut Context<'_>) -> Accessor {
+    fn read(context: &mut Context) -> Accessor {
         accessor!(
             context,
             TextEncoderEncodeIntoResult,
@@ -67,7 +65,7 @@ impl TextEncoderEncodeIntoResult {
             get:((x, _context) => Ok(JsBigInt::new(x.read).into()))
         )
     }
-    fn written(context: &mut Context<'_>) -> Accessor {
+    fn written(context: &mut Context) -> Accessor {
         accessor!(
             context,
             TextEncoderEncodeIntoResult,
@@ -88,12 +86,12 @@ impl NativeClass for TextEncoderEncodeIntoResult {
     fn data_constructor(
         _target: &JsValue,
         _args: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut Context,
     ) -> JsResult<TextEncoderEncodeIntoResult> {
         Ok(TextEncoderEncodeIntoResult::default())
     }
 
-    fn init(class: &mut ClassBuilder<'_, '_>) -> JsResult<()> {
+    fn init(class: &mut ClassBuilder<'_>) -> JsResult<()> {
         let read = Self::read(class.context());
         let written = Self::written(class.context());
         class
@@ -105,7 +103,7 @@ impl NativeClass for TextEncoderEncodeIntoResult {
 }
 
 impl TextEncoder {
-    fn try_from_js(value: &JsValue) -> JsResult<GcRefMut<'_, Object, Self>> {
+    fn try_from_js(value: &JsValue) -> JsResult<GcRefMut<'_, ErasedObject, Self>> {
         value
             .as_object()
             .and_then(|obj| obj.downcast_mut::<Self>())
@@ -193,10 +191,10 @@ impl TextEncoder {
     }
 }
 
-#[derive(Default, Clone, Trace, Finalize)]
+#[derive(Default, Clone, Trace, Finalize, JsData)]
 pub struct TextEncoderClass;
 impl TextEncoderClass {
-    fn encoding(context: &mut Context<'_>) -> Accessor {
+    fn encoding(context: &mut Context) -> Accessor {
         accessor!(
             context,
             TextEncoder,
@@ -206,9 +204,9 @@ impl TextEncoderClass {
     }
 
     fn encode(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let input = args.get_or_undefined(0).as_string().map(|x| x.as_slice());
+        let input = args.get_or_undefined(0).as_string().map(JsString::to_vec);
 
-        let result = TextEncoder::encode(input)?;
+        let result = TextEncoder::encode(input.as_deref())?;
 
         let uint8_array = JsUint8Array::from_array_buffer(
             JsArrayBuffer::from_byte_block(result, context)?,
@@ -226,20 +224,19 @@ impl TextEncoderClass {
         let src = args
             .get_or_undefined(0)
             .as_string()
-            .map(|x| x.as_slice())
-            .ok_or::<boa_engine::JsError>(
-            JsNativeError::typ()
-                .with_message("Failed to interpret argument as a string")
-                .into(),
-        )?;
+            .map(JsString::to_vec)
+            .ok_or::<JsError>(
+                JsNativeError::typ()
+                    .with_message("Failed to interpret argument as a string")
+                    .into(),
+            )?;
 
         let dst: JsUint8Array = args.get_or_undefined(1).try_js_into(context)?;
-
-        let array_buffer_data = dst.to_array_buffer_data(context)?;
-        let mut dst_slice = array_buffer_data.as_slice_mut();
+        let dst_buffer: JsArrayBuffer = dst.buffer(context)?.try_js_into(context)?;
+        let mut dst_slice = dst_buffer.data_mut();
 
         let result: TextEncoderEncodeIntoResult =
-            TextEncoder::encode_into(src, dst_slice.as_deref_mut().unwrap_or_default())?;
+            TextEncoder::encode_into(&src, dst_slice.as_deref_mut().unwrap_or_default())?;
 
         // create and return a TextEncoderEncodeIntoResult object
         let js_return: JsValue =
@@ -258,12 +255,12 @@ impl NativeClass for TextEncoderClass {
     fn data_constructor(
         _target: &JsValue,
         _args: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut Context,
     ) -> JsResult<TextEncoder> {
         Ok(TextEncoder)
     }
 
-    fn init(class: &mut ClassBuilder<'_, '_>) -> JsResult<()> {
+    fn init(class: &mut ClassBuilder<'_>) -> JsResult<()> {
         let encoding = Self::encoding(class.context());
         class
             .accessor(js_string!("encoding"), encoding, Attribute::all())
@@ -284,7 +281,7 @@ impl NativeClass for TextEncoderClass {
 
 pub struct TextEncoderApi;
 impl jstz_core::Api for TextEncoderApi {
-    fn init(self, context: &mut Context<'_>) {
+    fn init(self, context: &mut Context) {
         register_global_class::<TextEncoderClass>(context)
             .expect("The `TextEncoder` class shouldn't exist yet");
         register_global_class::<TextEncoderEncodeIntoResult>(context)

--- a/crates/jstz_api/src/file/blob.rs
+++ b/crates/jstz_api/src/file/blob.rs
@@ -12,14 +12,16 @@
 use std::cmp::{max, min};
 
 use boa_engine::{
+    builtins::{array_buffer::ArrayBuffer, dataview::DataView, typed_array::TypedArray},
     js_string,
     object::{
         builtins::{JsArray, JsArrayBuffer, JsPromise},
-        Object,
+        ErasedObject,
     },
     property::Attribute,
     value::TryFromJs,
-    Context, JsArgs, JsError, JsNativeError, JsResult, JsString, JsValue, NativeFunction,
+    Context, JsArgs, JsData, JsError, JsNativeError, JsResult, JsString, JsValue,
+    NativeFunction,
 };
 use boa_gc::{Finalize, GcRefMut, Trace};
 use jstz_core::{
@@ -30,9 +32,9 @@ use jstz_core::{
     value::IntoJs,
 };
 
-use crate::idl::{ArrayBufferLike, JsBufferSource};
+use crate::idl::{BufferSource, JsBufferSource};
 
-#[derive(Trace, Finalize, Clone)]
+#[derive(Trace, Finalize, JsData, Clone)]
 pub struct Blob {
     // TODO: Use https://docs.rs/bytes/1.5.0/bytes/
     bytes: Vec<u8>,
@@ -57,7 +59,7 @@ fn collect_code_points(mut position: &[u16]) -> (Vec<u16>, &[u16]) {
 }
 
 // https://w3c.github.io/FileAPI/#convert-line-endings-to-native
-fn convert_line_endings_to_native(s: &[u16]) -> Vec<u16> {
+fn convert_line_endings_to_native(s: Vec<u16>) -> Vec<u16> {
     // 1. Let native line ending be be the code point U+000A LF.
     let native_line_ending: u16 = 0x000A;
     // 3. Set result to the empty string.
@@ -66,7 +68,7 @@ fn convert_line_endings_to_native(s: &[u16]) -> Vec<u16> {
     let position = s;
     // 5. Let token be the result of collecting a sequence of code points that are not equal
     //    to U+000A LF or U+000D CR from s given position.
-    let (mut token, mut position) = collect_code_points(position);
+    let (mut token, mut position) = collect_code_points(&position);
     // 6. Append token to result.
     result.append(&mut token);
     // 7. While position is not past the end of s:
@@ -133,8 +135,8 @@ fn utf8_encoding(s: &[u16]) -> String {
 fn process_blob_parts(
     blob_parts: BlobParts,
     options: &BlobPropertyBag,
-    context: &mut Context<'_>,
-) -> Vec<u8> {
+    context: &mut Context,
+) -> JsResult<Vec<u8>> {
     let BlobParts(blob_parts) = blob_parts;
     // 1. Let bytes be an empty sequence of bytes.
     let mut bytes: Vec<u8> = vec![];
@@ -144,7 +146,7 @@ fn process_blob_parts(
             // 1. If element is a USVString, run the following substeps:
             BlobPart::String(string) => {
                 // 1. Let s be element.
-                let s = string.as_slice();
+                let s = string.to_vec();
                 // 2. If the endings member of options is "native", set s to the result
                 //    of converting line endings to native of element.
                 let s = match options {
@@ -160,9 +162,7 @@ fn process_blob_parts(
             // 2. If element is a BufferSource, get a copy of the bytes held by the
             //    buffer source, and append those bytes to bytes.
             BlobPart::BufferSource(buffer_source) => {
-                let buffer_data = buffer_source.to_array_buffer_data(context).unwrap();
-                let mut b: Vec<u8> =
-                    buffer_data.as_slice().unwrap().iter().copied().collect();
+                let mut b = buffer_source.clone_data(context)?;
                 bytes.append(&mut b)
             }
             // 3. If element is a Blob, append the bytes it represents to bytes.
@@ -170,7 +170,7 @@ fn process_blob_parts(
         }
     }
     // 3. Return bytes.
-    bytes
+    Ok(bytes)
 }
 
 impl Blob {
@@ -178,7 +178,7 @@ impl Blob {
     pub fn new(
         blob_parts: Option<BlobParts>,
         options: Option<BlobPropertyBag>,
-        context: &mut Context<'_>,
+        context: &mut Context,
     ) -> JsResult<Self> {
         // 1. If invoked with zero parameters, return a new Blob object consisting of
         //    0 bytes, with size set to 0, and with type set to the empty string.
@@ -200,7 +200,7 @@ impl Blob {
             (Some(blob_parts), Some(options)) => (blob_parts, options),
         };
         // 2. Let bytes be the result of processing blob parts given blobParts and options.
-        let bytes = process_blob_parts(blob_parts, &options, context);
+        let bytes = process_blob_parts(blob_parts, &options, context)?;
         let mut t = String::new();
         // 3. If the type member of the options argument is not the empty string, run the
         //    following sub-steps (see normalize_type)
@@ -225,17 +225,17 @@ impl Blob {
         self.type_.clone()
     }
 
-    pub fn text(&mut self, context: &mut Context<'_>) -> JsResult<JsPromise> {
+    pub fn text(&mut self, context: &mut Context) -> JsResult<JsPromise> {
         let s = js_string!(bytes_to_string(&self.bytes)?);
-        JsPromise::resolve(s, context)
+        Ok(JsPromise::resolve(s, context))
     }
 
-    pub fn array_buffer(&mut self, context: &mut Context<'_>) -> JsResult<JsPromise> {
+    pub fn array_buffer(&mut self, context: &mut Context) -> JsResult<JsPromise> {
         let b = &self.bytes;
-        JsPromise::resolve(
+        Ok(JsPromise::resolve(
             JsArrayBuffer::from_byte_block(b.to_vec(), context)?,
             context,
-        )
+        ))
     }
 
     // https://w3c.github.io/FileAPI/#slice-blob
@@ -300,7 +300,7 @@ impl Blob {
 }
 
 impl Blob {
-    pub fn try_from_js(value: &JsValue) -> JsResult<GcRefMut<'_, Object, Self>> {
+    pub fn try_from_js(value: &JsValue) -> JsResult<GcRefMut<'_, ErasedObject, Self>> {
         value
             .as_object()
             .and_then(|obj| obj.downcast_mut::<Self>())
@@ -319,7 +319,7 @@ pub enum BlobPart {
 }
 
 impl TryFromJs for BlobPart {
-    fn try_from_js(value: &JsValue, context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, context: &mut Context) -> JsResult<Self> {
         if value.is_string() {
             let string: String = value.try_js_into(context)?;
             return Ok(Self::String(js_string!(string)));
@@ -327,7 +327,7 @@ impl TryFromJs for BlobPart {
         let obj = value.as_object().ok_or_else(|| {
             JsError::from_native(JsNativeError::typ().with_message("Expected object"))
         })?;
-        if obj.is_array_buffer() || obj.is_typed_array() || obj.is_data_view() {
+        if obj.is::<ArrayBuffer>() || obj.is::<TypedArray>() || obj.is::<DataView>() {
             return Ok(Self::BufferSource(JsBufferSource::try_from_js(
                 value, context,
             )?));
@@ -341,7 +341,7 @@ impl TryFromJs for BlobPart {
 pub struct BlobParts(Vec<BlobPart>);
 
 impl TryFromJs for BlobParts {
-    fn try_from_js(value: &JsValue, context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, context: &mut Context) -> JsResult<Self> {
         let mut vec: Vec<BlobPart> = vec![];
 
         if value.is_object() {
@@ -365,7 +365,7 @@ pub enum Endings {
 }
 
 impl TryFromJs for Endings {
-    fn try_from_js(value: &JsValue, context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, context: &mut Context) -> JsResult<Self> {
         let endings = String::try_from_js(value, context)?;
         match endings.as_str() {
             "transparent" => Ok(Endings::Transparent),
@@ -385,7 +385,7 @@ pub struct BlobPropertyBag {
 }
 
 impl TryFromJs for BlobPropertyBag {
-    fn try_from_js(value: &JsValue, context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, context: &mut Context) -> JsResult<Self> {
         let obj = value.as_object().ok_or_else(|| {
             JsError::from_native(JsNativeError::typ().with_message("Expected object"))
         })?;
@@ -416,7 +416,7 @@ impl TryFromJs for BlobPropertyBag {
 pub struct BlobClass;
 
 impl BlobClass {
-    fn size(context: &mut Context<'_>) -> Accessor {
+    fn size(context: &mut Context) -> Accessor {
         accessor!(
             context,
             Blob,
@@ -425,7 +425,7 @@ impl BlobClass {
         )
     }
 
-    fn type_(context: &mut Context<'_>) -> Accessor {
+    fn type_(context: &mut Context) -> Accessor {
         accessor!(
             context,
             Blob,
@@ -437,7 +437,7 @@ impl BlobClass {
     fn text(
         this: &JsValue,
         _args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut Context,
     ) -> JsResult<JsValue> {
         let mut blob = Blob::try_from_js(this)?;
 
@@ -447,7 +447,7 @@ impl BlobClass {
     fn array_buffer(
         this: &JsValue,
         _args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut Context,
     ) -> JsResult<JsValue> {
         let mut blob = Blob::try_from_js(this)?;
 
@@ -457,7 +457,7 @@ impl BlobClass {
     fn slice(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut Context,
     ) -> JsResult<JsValue> {
         let blob = Blob::try_from_js(this)?;
         let start: Option<i64> = args.get_or_undefined(0).try_js_into(context)?;
@@ -479,7 +479,7 @@ impl NativeClass for BlobClass {
     fn data_constructor(
         _target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut Context,
     ) -> JsResult<Self::Instance> {
         let blob_parts: Option<BlobParts> =
             args.get_or_undefined(0).try_js_into(context)?;
@@ -489,7 +489,7 @@ impl NativeClass for BlobClass {
         Blob::new(blob_parts, options, context)
     }
 
-    fn init(class: &mut ClassBuilder<'_, '_>) -> JsResult<()> {
+    fn init(class: &mut ClassBuilder<'_>) -> JsResult<()> {
         let size = Self::size(class.context());
         let type_ = Self::type_(class.context());
 
@@ -519,7 +519,7 @@ impl NativeClass for BlobClass {
 pub struct BlobApi;
 
 impl jstz_core::Api for BlobApi {
-    fn init(self, context: &mut Context<'_>) {
+    fn init(self, context: &mut Context) {
         register_global_class::<BlobClass>(context)
             .expect("The `Blob` class shouldn't exist yet")
     }

--- a/crates/jstz_api/src/file/mod.rs
+++ b/crates/jstz_api/src/file/mod.rs
@@ -9,7 +9,7 @@ mod imp;
 pub struct FileApi;
 
 impl jstz_core::Api for FileApi {
-    fn init(self, context: &mut Context<'_>) {
+    fn init(self, context: &mut Context) {
         BlobApi.init(context);
         ImpFileApi.init(context);
     }

--- a/crates/jstz_api/src/http/header.rs
+++ b/crates/jstz_api/src/http/header.rs
@@ -16,10 +16,10 @@ use std::{cell::RefCell, collections::BTreeMap, ops::DerefMut};
 
 use boa_engine::{
     builtins, js_string,
-    object::{builtins::JsArray, Object},
+    object::{builtins::JsArray, ErasedObject},
     value::TryFromJs,
-    Context, JsArgs, JsError, JsNativeError, JsObject, JsResult, JsString, JsSymbol,
-    JsValue, NativeFunction,
+    Context, JsArgs, JsData, JsError, JsNativeError, JsObject, JsResult, JsString,
+    JsSymbol, JsValue, NativeFunction,
 };
 use boa_gc::{empty_trace, Finalize, GcRefMut, Trace};
 use derive_more::Deref;
@@ -29,7 +29,7 @@ use jstz_core::{
     native::{register_global_class, ClassBuilder, NativeClass},
     value::IntoJs,
 };
-#[derive(Default, Clone, Deref)]
+#[derive(Default, Clone, Deref, JsData)]
 pub struct Headers {
     // TODO probably don't need Deref? It exposes HeaderMap impl and
     // probably shouldn't
@@ -70,7 +70,7 @@ fn sort_and_combine_headers(headers: &HeaderMap) -> JsResult<Vec<(String, String
 impl Headers {
     pub fn from_http_headers(
         headers: http::HeaderMap,
-        _context: &mut Context<'_>,
+        _context: &mut Context,
     ) -> JsResult<Self> {
         Ok(Self {
             headers,
@@ -142,7 +142,7 @@ impl Header {
 }
 
 impl IntoJs for Header {
-    fn into_js(self, context: &mut Context<'_>) -> JsValue {
+    fn into_js(self, context: &mut Context) -> JsValue {
         if self.headers.is_empty() {
             return JsValue::null();
         }
@@ -234,7 +234,7 @@ impl Headers {
 pub struct HeadersClass;
 
 impl Headers {
-    fn try_from_js(value: &JsValue) -> JsResult<GcRefMut<'_, Object, Self>> {
+    fn try_from_js(value: &JsValue) -> JsResult<GcRefMut<'_, ErasedObject, Self>> {
         value
             .as_object()
             .and_then(|obj| obj.downcast_mut::<Self>())
@@ -271,10 +271,10 @@ fn require_args(
 struct ByteString(String);
 
 impl TryFromJs for ByteString {
-    fn try_from_js(value: &JsValue, context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, context: &mut Context) -> JsResult<Self> {
         let s: JsString = value.to_string(context)?;
         for c in s.iter() {
-            if c >= &256 {
+            if c >= 256 {
                 return Err(JsNativeError::typ().with_message("invalid ByteString"))?;
             }
         }
@@ -304,7 +304,7 @@ fn normalize_header_value(string: &str) -> &str {
 }
 
 impl TryFromJs for HeaderVal {
-    fn try_from_js(value: &JsValue, context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, context: &mut Context) -> JsResult<Self> {
         let ByteString(string) = value.try_js_into(context)?;
         let string = normalize_header_value(string.as_str()).to_string();
         Ok(HeaderVal(string))
@@ -315,7 +315,7 @@ impl HeadersClass {
     fn append(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut Context,
     ) -> JsResult<JsValue> {
         require_args(args, 2, "append", "Headers")?;
         let mut headers = Headers::try_from_js(this)?;
@@ -330,7 +330,7 @@ impl HeadersClass {
     fn delete(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut Context,
     ) -> JsResult<JsValue> {
         require_args(args, 1, "delete", "Headers")?;
         let mut headers = Headers::try_from_js(this)?;
@@ -341,11 +341,7 @@ impl HeadersClass {
         Ok(JsValue::undefined())
     }
 
-    fn get(
-        this: &JsValue,
-        args: &[JsValue],
-        context: &mut Context<'_>,
-    ) -> JsResult<JsValue> {
+    fn get(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         require_args(args, 1, "get", "Headers")?;
         let headers = Headers::try_from_js(this)?;
         let name: ByteString = args.get_or_undefined(0).try_js_into(context)?;
@@ -356,17 +352,13 @@ impl HeadersClass {
     fn get_set_cookie(
         this: &JsValue,
         _args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut Context,
     ) -> JsResult<JsValue> {
         let headers = Headers::try_from_js(this)?;
         Ok(headers.get_set_cookie()?.into_js(context))
     }
 
-    fn has(
-        this: &JsValue,
-        args: &[JsValue],
-        context: &mut Context<'_>,
-    ) -> JsResult<JsValue> {
+    fn has(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         require_args(args, 1, "has", "Headers")?;
         let headers = Headers::try_from_js(this)?;
         let name: ByteString = args.get_or_undefined(0).try_js_into(context)?;
@@ -374,11 +366,7 @@ impl HeadersClass {
         Ok(headers.contains(&name)?.into())
     }
 
-    fn set(
-        this: &JsValue,
-        args: &[JsValue],
-        context: &mut Context<'_>,
-    ) -> JsResult<JsValue> {
+    fn set(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         require_args(args, 2, "set", "Headers")?;
         let mut headers = Headers::try_from_js(this)?;
         let name: ByteString = args.get_or_undefined(0).try_js_into(context)?;
@@ -397,7 +385,7 @@ pub struct HeaderEntry {
 }
 
 impl TryFromJs for HeaderEntry {
-    fn try_from_js(value: &JsValue, context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, context: &mut Context) -> JsResult<Self> {
         let obj = value.as_object()
 	    .ok_or(JsNativeError::typ()
 		   .with_message("Failed to construct 'Headers': The provided value cannot be converted to a sequence."))?;
@@ -418,7 +406,7 @@ impl TryFromJs for HeaderEntry {
     }
 }
 
-fn get_iterator(obj: &JsObject, context: &mut Context<'_>) -> JsResult<JsValue> {
+fn get_iterator(obj: &JsObject, context: &mut Context) -> JsResult<JsValue> {
     // TODO workaround until JsSymbol::iterator() is pub
     let symbol_iterator: JsSymbol = context
         .intrinsics()
@@ -438,7 +426,7 @@ fn get_iterator(obj: &JsObject, context: &mut Context<'_>) -> JsResult<JsValue> 
 // for HeadersInit in particular we have sequence<sequence<ByteString>>
 //
 // TODO: using Array.from as a hack, expose something in boa
-fn iterable_to_sequence(obj: &JsObject, context: &mut Context<'_>) -> JsResult<JsValue> {
+fn iterable_to_sequence(obj: &JsObject, context: &mut Context) -> JsResult<JsValue> {
     let array_from_obj = context
         .intrinsics()
         .constructors()
@@ -462,7 +450,7 @@ fn iterable_to_sequence(obj: &JsObject, context: &mut Context<'_>) -> JsResult<J
 
 fn js_array_to_header_entries(
     obj: &JsObject,
-    context: &mut Context<'_>,
+    context: &mut Context,
 ) -> JsResult<Vec<HeaderEntry>> {
     let arr = JsArray::from_object(obj.clone())?;
 
@@ -510,7 +498,7 @@ impl Headers {
 }
 
 impl TryFromJs for HeadersInit {
-    fn try_from_js(value: &JsValue, context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, context: &mut Context) -> JsResult<Self> {
         if value.is_undefined() {
             return Ok(HeadersInit::default());
         }
@@ -535,7 +523,7 @@ impl TryFromJs for HeadersInit {
             // TODO: Expose `enumerable_own_property_names` in Boa
             // TODO: also should throw if there are any own property
             // symbols, because we should try to ToString them
-            let arr = builtins::object::Object::entries(
+            let arr = builtins::object::OrdinaryObject::entries(
                 &JsValue::undefined(),
                 &[value.clone()],
                 context,
@@ -561,7 +549,7 @@ impl NativeClass for HeadersClass {
     fn data_constructor(
         _target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut Context,
     ) -> JsResult<Headers> {
         match args.first() {
             None => Ok(Headers::default()),
@@ -572,7 +560,7 @@ impl NativeClass for HeadersClass {
         }
     }
 
-    fn init(class: &mut ClassBuilder<'_, '_>) -> JsResult<()> {
+    fn init(class: &mut ClassBuilder<'_>) -> JsResult<()> {
         class
             .method(
                 js_string!("append"),
@@ -617,7 +605,7 @@ impl PairIterable for Headers {
     fn pair_iterable_get(
         &self,
         index: usize,
-        context: &mut Context<'_>,
+        context: &mut Context,
     ) -> JsResult<jstz_core::iterators::PairValue> {
         let cached_iteration = self.get_cached_iteration()?;
         match cached_iteration.get(index) {
@@ -643,7 +631,7 @@ impl PairIteratorClass for HeadersIteratorClass {
 pub struct HeadersApi;
 
 impl jstz_core::Api for HeadersApi {
-    fn init(self, context: &mut Context<'_>) {
+    fn init(self, context: &mut Context) {
         register_global_class::<HeadersClass>(context)
             .expect("The `Headers` class shouldn't exist yet");
         register_global_class::<HeadersIteratorClass>(context)

--- a/crates/jstz_api/src/http/mod.rs
+++ b/crates/jstz_api/src/http/mod.rs
@@ -10,7 +10,7 @@ pub mod response;
 pub struct HttpApi;
 
 impl jstz_core::Api for HttpApi {
-    fn init(self, context: &mut Context<'_>) {
+    fn init(self, context: &mut Context) {
         HeadersApi.init(context);
         RequestApi.init(context);
         ResponseApi.init(context);

--- a/crates/jstz_api/src/js_log.rs
+++ b/crates/jstz_api/src/js_log.rs
@@ -44,7 +44,7 @@ pub struct LogData {
 
 // The implementor of this trait controls how console.log/warn/error etc is handled.
 pub trait JsLog {
-    fn log(&self, log_data: LogData, context: &mut Context<'_>);
+    fn log(&self, log_data: LogData, context: &mut Context);
     fn flush(&self) {}
 }
 
@@ -57,7 +57,7 @@ pub fn set_js_logger(logger: &'static dyn JsLog) {
     CONSOLE_LOGGER.set(Some(logger));
 }
 
-pub(crate) fn log(log_data: LogData, context: &mut Context<'_>) -> JsResult<()> {
+pub(crate) fn log(log_data: LogData, context: &mut Context) -> JsResult<()> {
     CONSOLE_LOGGER.with(|logger| {
         if let Some(logger) = logger.get() {
             logger.log(log_data, context);

--- a/crates/jstz_api/src/random.rs
+++ b/crates/jstz_api/src/random.rs
@@ -1,17 +1,17 @@
 use boa_engine::{
     js_string,
-    object::{FunctionObjectBuilder, Object, ObjectInitializer},
-    Context, JsNativeError, JsResult, JsValue, NativeFunction,
+    object::{ErasedObject, FunctionObjectBuilder, ObjectInitializer},
+    Context, JsData, JsNativeError, JsResult, JsValue, NativeFunction,
 };
 use boa_gc::{Finalize, GcRefMut, Trace};
 
-#[derive(Trace, Finalize)]
+#[derive(Trace, Finalize, JsData)]
 struct RandomGen {
     seed: u64,
 }
 
 impl RandomGen {
-    fn from_js_value(value: &JsValue) -> JsResult<GcRefMut<'_, Object, Self>> {
+    fn from_js_value(value: &JsValue) -> JsResult<GcRefMut<'_, ErasedObject, Self>> {
         value
             .as_object()
             .and_then(|obj| obj.downcast_mut::<Self>())
@@ -45,7 +45,7 @@ impl RandomApi {
 impl jstz_core::Api for RandomApi {
     fn init(self, context: &mut Context) {
         let generator =
-            ObjectInitializer::with_native(RandomGen { seed: self.seed }, context)
+            ObjectInitializer::with_native_data(RandomGen { seed: self.seed }, context)
                 .build()
                 .into();
         let random_method = FunctionObjectBuilder::new(

--- a/crates/jstz_api/src/stream/mod.rs
+++ b/crates/jstz_api/src/stream/mod.rs
@@ -14,7 +14,7 @@ type Chunk = idl::Any;
 pub struct StreamApi;
 
 impl jstz_core::Api for StreamApi {
-    fn init(self, context: &mut Context<'_>) {
+    fn init(self, context: &mut Context) {
         ReadableStreamApi.init(context);
         QueuingStrategyApi.init(context);
     }

--- a/crates/jstz_api/src/stream/queuing_strategy/builtin.rs
+++ b/crates/jstz_api/src/stream/queuing_strategy/builtin.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 /// [Streams Standard - § 7.1.][https://streams.spec.whatwg.org/#qs-api]
-/// > ```
+/// > ```notrust
 /// > dictionary QueuingStrategyInit {
 /// >   required unrestricted double highWaterMark;
 /// > };
@@ -48,7 +48,7 @@ impl TryFromJs for QueuingStrategyInit {
 /// > A common queuing strategy when dealing with streams of generic objects is to simply count the number of chunks that have been accumulated so far, waiting until this number reaches a specified high-water mark. As such, this strategy is also provided out of the box.
 ///
 /// [Streams Standard - § 7.3.1.][https://streams.spec.whatwg.org/#countqueuingstrategy]
-/// > ```
+/// > ```notrust
 /// > [Exposed=*]
 /// > interface CountQueuingStrategy {
 /// >   constructor(QueuingStrategyInit init);

--- a/crates/jstz_api/src/stream/queuing_strategy/mod.rs
+++ b/crates/jstz_api/src/stream/queuing_strategy/mod.rs
@@ -43,7 +43,7 @@ impl Default for QueuingStrategy {
 }
 
 impl TryFromJs for QueuingStrategy {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut Context) -> JsResult<Self> {
         if JsNativeObject::<CountQueuingStrategy>::is(value) {
             JsNativeObject::<CountQueuingStrategy>::try_from(value.clone())
                 .map(Into::into)
@@ -59,7 +59,7 @@ impl TryFromJs for QueuingStrategy {
 pub struct QueuingStrategyApi;
 
 impl jstz_core::Api for QueuingStrategyApi {
-    fn init(self, context: &mut Context<'_>) {
+    fn init(self, context: &mut Context) {
         register_global_class::<CountQueuingStrategyClass>(context)
             .expect("The `CountQueuingStrategy` class shouldn't exist yet");
         register_global_class::<ByteLengthQueuingStrategyClass>(context)

--- a/crates/jstz_api/src/stream/queuing_strategy/size.rs
+++ b/crates/jstz_api/src/stream/queuing_strategy/size.rs
@@ -36,7 +36,7 @@ impl JsCallableWithoutThis<(Chunk,), idl::UnrestrictedDouble>
     fn call_without_this(
         &self,
         _inputs: (Chunk,),
-        _context: &mut Context<'_>,
+        _context: &mut Context,
     ) -> JsResult<idl::UnrestrictedDouble> {
         match self {
             CountQueuingStrategySizeAlgorithm::ReturnOne => {
@@ -66,7 +66,7 @@ impl JsCallableWithoutThis<(Chunk,), idl::UnrestrictedDouble>
     fn call_without_this(
         &self,
         _inputs: (Chunk,),
-        _context: &mut Context<'_>,
+        _context: &mut Context,
     ) -> JsResult<idl::UnrestrictedDouble> {
         match self {
             ByteLengthQueuingStrategySizeAlgorithm::ReturnByteLengthOfChunk => {
@@ -105,7 +105,7 @@ impl JsCallableWithoutThis<(Chunk,), idl::UnrestrictedDouble>
     fn call_without_this(
         &self,
         inputs: (Chunk,),
-        context: &mut Context<'_>,
+        context: &mut Context,
     ) -> JsResult<idl::UnrestrictedDouble> {
         match self {
             QueuingStrategySizeAlgorithm::Count(size_algorithm) => {

--- a/crates/jstz_api/src/stream/readable/mod.rs
+++ b/crates/jstz_api/src/stream/readable/mod.rs
@@ -1,4 +1,4 @@
-use boa_engine::{value::TryFromJs, Context, JsArgs, JsResult, JsValue};
+use boa_engine::{value::TryFromJs, Context, JsArgs, JsData, JsResult, JsValue};
 use boa_gc::{custom_trace, Finalize, Trace};
 use jstz_core::native::{register_global_class, ClassBuilder, NativeClass};
 
@@ -13,6 +13,7 @@ use crate::stream::{
 
 pub mod underlying_source;
 
+#[derive(JsData)]
 pub struct ReadableStream {
     // TODO
 }
@@ -24,7 +25,7 @@ impl Finalize for ReadableStream {
 }
 
 unsafe impl Trace for ReadableStream {
-    custom_trace!(this, {
+    custom_trace!(this, _mark, {
         let _ = this;
         todo!()
     });
@@ -40,7 +41,7 @@ impl NativeClass for ReadableStreamClass {
     fn data_constructor(
         _target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut Context,
     ) -> JsResult<Self::Instance> {
         let underlying_source =
             Option::<UnderlyingSource>::try_from_js(args.get_or_undefined(0), context)?
@@ -67,7 +68,7 @@ impl NativeClass for ReadableStreamClass {
         }
     }
 
-    fn init(class: &mut ClassBuilder<'_, '_>) -> JsResult<()> {
+    fn init(class: &mut ClassBuilder<'_>) -> JsResult<()> {
         // TODO
         let _ = class;
         Ok(())
@@ -77,7 +78,7 @@ impl NativeClass for ReadableStreamClass {
 pub struct ReadableStreamApi;
 
 impl jstz_core::Api for ReadableStreamApi {
-    fn init(self, context: &mut Context<'_>) {
+    fn init(self, context: &mut Context) {
         register_global_class::<ReadableStreamClass>(context)
             .expect("The `ReadableStream` class shouldn't exist yet")
         // TODO

--- a/crates/jstz_api/src/stream/readable/underlying_source.rs
+++ b/crates/jstz_api/src/stream/readable/underlying_source.rs
@@ -17,7 +17,7 @@ use jstz_core::{
 use crate::{idl, stream::tmp::*};
 
 /// [Streams Standard - § 4.2.3.][https://streams.spec.whatwg.org/#underlying-source-api]
-/// > ```
+/// > ```notrust
 /// > dictionary UnderlyingSource {
 /// >   UnderlyingSourceStartCallback start;
 /// >   UnderlyingSourcePullCallback pull;

--- a/crates/jstz_api/src/stream/tmp.rs
+++ b/crates/jstz_api/src/stream/tmp.rs
@@ -14,7 +14,7 @@ pub type ReadableByteStreamController = Todo;
 pub fn get_jsobject_property(
     obj: &JsObject,
     name: &str,
-    context: &mut Context<'_>,
+    context: &mut Context,
 ) -> JsResult<JsValue> {
     let key = PropertyKey::from(js_string!(name));
     let has_prop = obj.has_property(key.clone(), context)?;

--- a/crates/jstz_api/src/todo.rs
+++ b/crates/jstz_api/src/todo.rs
@@ -1,4 +1,4 @@
-use boa_engine::value::TryFromJs;
+use boa_engine::{value::TryFromJs, Context, JsResult, JsValue};
 use boa_gc::{custom_trace, Finalize, Trace};
 use jstz_core::value::IntoJs;
 
@@ -16,25 +16,19 @@ impl Finalize for Todo {
 
 #[allow(unused_variables)]
 unsafe impl Trace for Todo {
-    custom_trace!(this, todo!());
+    custom_trace!(this, mark, todo!());
 }
 
 #[allow(unused_variables)]
 impl IntoJs for Todo {
-    fn into_js(
-        self,
-        context: &mut boa_engine::prelude::Context<'_>,
-    ) -> boa_engine::prelude::JsValue {
+    fn into_js(self, context: &mut Context) -> JsValue {
         todo!()
     }
 }
 
 #[allow(unused_variables)]
 impl TryFromJs for Todo {
-    fn try_from_js(
-        value: &boa_engine::prelude::JsValue,
-        context: &mut boa_engine::prelude::Context<'_>,
-    ) -> boa_engine::prelude::JsResult<Self> {
+    fn try_from_js(value: &JsValue, context: &mut Context) -> JsResult<Self> {
         todo!()
     }
 }

--- a/crates/jstz_api/src/url/search_params.rs
+++ b/crates/jstz_api/src/url/search_params.rs
@@ -2,11 +2,11 @@ use std::fmt::{self, Display};
 
 use boa_engine::{
     builtins, js_string,
-    object::{builtins::JsArray, Object},
+    object::{builtins::JsArray, ErasedObject},
     property::Attribute,
     value::TryFromJs,
-    Context, JsArgs, JsError, JsNativeError, JsObject, JsResult, JsString, JsValue,
-    NativeFunction,
+    Context, JsArgs, JsData, JsError, JsNativeError, JsObject, JsResult, JsString,
+    JsValue, NativeFunction,
 };
 use boa_gc::{empty_trace, Finalize, GcRefMut, Trace};
 use jstz_core::{
@@ -28,7 +28,7 @@ pub type Value = String;
 /// the query string of a `Url`.
 ///
 /// [spec] https://url.spec.whatwg.org/#urlsearchparams
-#[derive(Default)]
+#[derive(JsData, Default)]
 pub struct UrlSearchParams {
     values: Vec<(Name, Value)>,
     pub(crate) url: Option<JsNativeObject<Url>>,
@@ -46,7 +46,7 @@ unsafe impl Trace for UrlSearchParams {
 impl JsNativeObjectToString for UrlSearchParams {
     fn to_string(
         this: &JsNativeObject<Self>,
-        context: &mut Context<'_>,
+        context: &mut Context,
     ) -> JsResult<JsValue> {
         Ok(this.deref().to_string().into_js(context))
     }
@@ -251,7 +251,7 @@ pub enum UrlSearchParamsInit {
 
 fn js_array_into_url_search_params_values(
     obj: JsObject,
-    context: &mut Context<'_>,
+    context: &mut Context,
 ) -> JsResult<Vec<(Name, Value)>> {
     let arr = JsArray::from_object(obj)?;
 
@@ -278,10 +278,10 @@ impl UrlSearchParams {
             .collect()
     }
 
-    fn from_init(init: UrlSearchParamsInit, context: &mut Context<'_>) -> JsResult<Self> {
+    fn from_init(init: UrlSearchParamsInit, context: &mut Context) -> JsResult<Self> {
         match init {
             UrlSearchParamsInit::Object(obj) => {
-                let arr = builtins::object::Object::entries(
+                let arr = builtins::object::OrdinaryObject::entries(
                     &JsValue::undefined(),
                     &[obj.into()],
                     context,
@@ -308,7 +308,7 @@ impl UrlSearchParams {
 }
 
 impl TryFromJs for UrlSearchParamsInit {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut Context) -> JsResult<Self> {
         if let Some(string) = value.as_string() {
             Ok(Self::String(string.clone()))
         } else {
@@ -329,7 +329,7 @@ impl TryFromJs for UrlSearchParamsInit {
 }
 
 impl TryFromJs for UrlSearchParams {
-    fn try_from_js(value: &JsValue, context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, context: &mut Context) -> JsResult<Self> {
         let init: UrlSearchParamsInit = value.try_js_into(context)?;
 
         Self::from_init(init, context)
@@ -339,7 +339,7 @@ impl TryFromJs for UrlSearchParams {
 pub struct UrlSearchParamsClass;
 
 impl UrlSearchParams {
-    fn try_from_js(value: &JsValue) -> JsResult<GcRefMut<'_, Object, Self>> {
+    fn try_from_js(value: &JsValue) -> JsResult<GcRefMut<'_, ErasedObject, Self>> {
         value
             .as_object()
             .and_then(|obj| obj.downcast_mut::<Self>())
@@ -354,7 +354,7 @@ impl UrlSearchParams {
 }
 
 impl UrlSearchParamsClass {
-    fn size(context: &mut Context<'_>) -> Accessor {
+    fn size(context: &mut Context) -> Accessor {
         accessor!(
             context,
             UrlSearchParams,
@@ -366,7 +366,7 @@ impl UrlSearchParamsClass {
     fn append(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut Context,
     ) -> JsResult<JsValue> {
         let mut search_params = UrlSearchParams::try_from_js(this)?;
         let name: String = args.get_or_undefined(0).try_js_into(context)?;
@@ -380,7 +380,7 @@ impl UrlSearchParamsClass {
     fn delete(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut Context,
     ) -> JsResult<JsValue> {
         let mut search_params = UrlSearchParams::try_from_js(this)?;
         let name: String = args.get_or_undefined(0).try_js_into(context)?;
@@ -391,11 +391,7 @@ impl UrlSearchParamsClass {
         Ok(JsValue::undefined())
     }
 
-    fn get(
-        this: &JsValue,
-        args: &[JsValue],
-        context: &mut Context<'_>,
-    ) -> JsResult<JsValue> {
+    fn get(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let search_params = UrlSearchParams::try_from_js(this)?;
         let name: String = args.get_or_undefined(0).try_js_into(context)?;
 
@@ -408,7 +404,7 @@ impl UrlSearchParamsClass {
     fn get_all(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut Context,
     ) -> JsResult<JsValue> {
         let search_params = UrlSearchParams::try_from_js(this)?;
         let name: String = args.get_or_undefined(0).try_js_into(context)?;
@@ -422,11 +418,7 @@ impl UrlSearchParamsClass {
         Ok(JsArray::from_iter(values, context).into())
     }
 
-    fn has(
-        this: &JsValue,
-        args: &[JsValue],
-        context: &mut Context<'_>,
-    ) -> JsResult<JsValue> {
+    fn has(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let search_params = UrlSearchParams::try_from_js(this)?;
         let name: String = args.get_or_undefined(0).try_js_into(context)?;
         let value: Option<String> = args.get_or_undefined(1).try_js_into(context)?;
@@ -434,11 +426,7 @@ impl UrlSearchParamsClass {
         Ok(search_params.contains(name, value).into())
     }
 
-    fn set(
-        this: &JsValue,
-        args: &[JsValue],
-        context: &mut Context<'_>,
-    ) -> JsResult<JsValue> {
+    fn set(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let mut search_params = UrlSearchParams::try_from_js(this)?;
         let name: String = args.get_or_undefined(0).try_js_into(context)?;
         let value: String = args.get_or_undefined(1).try_js_into(context)?;
@@ -451,7 +439,7 @@ impl UrlSearchParamsClass {
     fn sort(
         this: &JsValue,
         _args: &[JsValue],
-        _context: &mut Context<'_>,
+        _context: &mut Context,
     ) -> JsResult<JsValue> {
         let mut search_params = UrlSearchParams::try_from_js(this)?;
 
@@ -469,7 +457,7 @@ impl NativeClass for UrlSearchParamsClass {
     fn data_constructor(
         _target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut Context,
     ) -> JsResult<UrlSearchParams> {
         match args.first() {
             None => Ok(UrlSearchParams::default()),
@@ -477,7 +465,7 @@ impl NativeClass for UrlSearchParamsClass {
         }
     }
 
-    fn init(class: &mut ClassBuilder<'_, '_>) -> JsResult<()> {
+    fn init(class: &mut ClassBuilder<'_>) -> JsResult<()> {
         let size = UrlSearchParamsClass::size(class.context());
 
         class
@@ -537,7 +525,7 @@ impl PairIterable for UrlSearchParams {
     fn pair_iterable_get(
         &self,
         index: usize,
-        context: &mut Context<'_>,
+        context: &mut Context,
     ) -> JsResult<PairValue> {
         let pair = self.values.get(index).ok_or::<JsError>(
             JsNativeError::typ()
@@ -560,7 +548,7 @@ impl PairIteratorClass for UrlSearchParamsIteratorClass {
 pub struct UrlSearchParamsApi;
 
 impl jstz_core::Api for UrlSearchParamsApi {
-    fn init(self, context: &mut Context<'_>) {
+    fn init(self, context: &mut Context) {
         register_global_class::<UrlSearchParamsClass>(context)
             .expect("The `URLSearchParams` class shouldn't exist yet");
         // TODO should not really be a global class, remove from

--- a/crates/jstz_api/tests/wptreport.json
+++ b/crates/jstz_api/tests/wptreport.json
@@ -857,14 +857,14 @@
                   },
                   {
                     "name": "Error seen with fatal does not prevent future decodes",
-                    "status": "Fail",
-                    "message": "assert_throws_js: decode() should throw on incomplete sequence function \"function () { [native code] }\" did not throw"
+                    "status": "Pass",
+                    "message": null
                   }
                 ],
                 "status": "Null",
                 "metrics": {
-                  "passed": 35,
-                  "failed": 1,
+                  "passed": 36,
+                  "failed": 0,
                   "timed_out": 0
                 }
               }

--- a/crates/jstz_cli/src/repl/debug_api/account.rs
+++ b/crates/jstz_cli/src/repl/debug_api/account.rs
@@ -86,7 +86,7 @@ impl AccountApi {
         Ok(JsValue::undefined())
     }
 
-    pub fn namespace(context: &mut boa_engine::Context<'_>) -> JsObject {
+    pub fn namespace(context: &mut boa_engine::Context) -> JsObject {
         let storage = ObjectInitializer::new(context)
             .function(
                 NativeFunction::from_fn_ptr(Self::balance),

--- a/crates/jstz_cli/src/repl/debug_api/kv.rs
+++ b/crates/jstz_cli/src/repl/debug_api/kv.rs
@@ -76,7 +76,7 @@ impl KvApi {
         Ok(result.into())
     }
 
-    pub fn namespace(context: &mut boa_engine::Context<'_>) -> JsObject {
+    pub fn namespace(context: &mut boa_engine::Context) -> JsObject {
         let storage = ObjectInitializer::new(context)
             .function(NativeFunction::from_fn_ptr(Self::get), js_string!("get"), 2)
             .function(NativeFunction::from_fn_ptr(Self::set), js_string!("set"), 3)

--- a/crates/jstz_cli/src/repl/debug_api/mod.rs
+++ b/crates/jstz_cli/src/repl/debug_api/mod.rs
@@ -1,4 +1,4 @@
-use boa_engine::{js_string, object::ObjectInitializer, property::Attribute};
+use boa_engine::{js_string, object::ObjectInitializer, property::Attribute, Context};
 
 mod account;
 mod kv;
@@ -10,7 +10,7 @@ impl DebugApi {
 }
 
 impl jstz_core::Api for DebugApi {
-    fn init(self, context: &mut boa_engine::Context<'_>) {
+    fn init(self, context: &mut Context) {
         let kv_api = kv::KvApi::namespace(context);
         let account_api = account::AccountApi::namespace(context);
 

--- a/crates/jstz_cli/src/repl/js_logger.rs
+++ b/crates/jstz_cli/src/repl/js_logger.rs
@@ -6,7 +6,7 @@ use tezos_smart_rollup::prelude::debug_msg;
 pub(crate) struct PrettyLogger;
 
 impl JsLog for PrettyLogger {
-    fn log(&self, log_data: LogData, _context: &mut Context<'_>) {
+    fn log(&self, log_data: LogData, _context: &mut Context) {
         let LogData {
             level,
             text,

--- a/crates/jstz_cli/src/repl/mod.rs
+++ b/crates/jstz_cli/src/repl/mod.rs
@@ -169,7 +169,7 @@ pub fn exec(account: Option<AddressOrAlias>) -> Result<()> {
     }
 }
 
-fn print_rt_result(result: JsResult<JsValue>, context: &mut Context<'_>) {
+fn print_rt_result(result: JsResult<JsValue>, context: &mut Context) {
     match result {
         Ok(res) => {
             if !res.is_undefined() {

--- a/crates/jstz_cli/src/sandbox/daemon.rs
+++ b/crates/jstz_cli/src/sandbox/daemon.rs
@@ -187,7 +187,7 @@ impl Sandbox {
                             }
                         }
 
-                        if let Some(signal)= signals.pending().next() {
+                        if let Some(signal) = signals.pending().next() {
                             match signal {
                                 SIGINT | SIGTERM => {
                                     info!(

--- a/crates/jstz_core/src/lib.rs
+++ b/crates/jstz_core/src/lib.rs
@@ -16,7 +16,7 @@ pub mod value;
 /// A generic runtime API
 pub trait Api {
     /// Initialize a runtime API
-    fn init(self, context: &mut Context<'_>);
+    fn init(self, context: &mut Context);
 }
 
 pub use realm::{Module, Realm};

--- a/crates/jstz_core/src/runtime.rs
+++ b/crates/jstz_core/src/runtime.rs
@@ -2,7 +2,6 @@ use std::{
     cell::RefCell,
     collections::VecDeque,
     future::poll_fn,
-    io::Read,
     num::NonZeroU32,
     ops::{Deref, DerefMut},
     rc::Rc,
@@ -11,10 +10,9 @@ use std::{
 
 use boa_engine::{
     builtins::promise::PromiseState, context::HostHooks, job::NativeJob,
-    object::builtins::JsPromise, Context, JsError, JsNativeError, JsResult, JsValue,
-    Source,
+    object::builtins::JsPromise, parser::source::ReadChar, Context, JsError,
+    JsNativeError, JsResult, JsValue, Source,
 };
-use chrono::{DateTime, FixedOffset, LocalResult, NaiveDateTime};
 use getrandom::{register_custom_getrandom, Error as RandomError};
 
 use crate::{
@@ -48,25 +46,16 @@ impl HostHooks for Hooks {
     //     false
     // }
 
-    fn utc_now(&self) -> NaiveDateTime {
-        DateTime::from_timestamp(UTC_NOW, 0)
-            .expect("Failed to create `NaiveDateTime` from `UTC_NOW`")
-            .naive_utc()
+    fn utc_now(&self) -> i64 {
+        UTC_NOW
     }
 
-    fn local_from_utc(&self, utc: NaiveDateTime) -> DateTime<FixedOffset> {
-        DateTime::from_naive_utc_and_offset(utc, FixedOffset::east_opt(0).unwrap())
-    }
-
-    fn local_from_naive_local(
-        &self,
-        _local: NaiveDateTime,
-    ) -> LocalResult<DateTime<FixedOffset>> {
-        LocalResult::None
+    fn local_timezone_offset_seconds(&self, _unix_time_seconds: i64) -> i32 {
+        0
     }
 }
 
-pub const HOOKS: &'static dyn HostHooks = &Hooks;
+const HOOKS: &Hooks = &Hooks;
 
 // custom getrandom
 const GETRANDOM_ERROR_CODE: u32 = RandomError::CUSTOM_START + 42;
@@ -90,31 +79,27 @@ impl JobQueue {
         self.0.borrow_mut().pop_front()
     }
 
-    pub fn call_next(&self, context: &mut Context<'_>) -> Option<JsResult<JsValue>> {
+    pub fn call_next(&self, context: &mut Context) -> Option<JsResult<JsValue>> {
         let job = self.next()?;
         Some(job.call(context))
     }
 }
 
 impl boa_engine::job::JobQueue for JobQueue {
-    fn enqueue_promise_job(
-        &self,
-        job: NativeJob,
-        _context: &mut boa_engine::Context<'_>,
-    ) {
+    fn enqueue_promise_job(&self, job: NativeJob, _context: &mut boa_engine::Context) {
         self.0.borrow_mut().push_back(job);
     }
 
     fn enqueue_future_job(
         &self,
         future: boa_engine::job::FutureJob,
-        context: &mut boa_engine::Context<'_>,
+        context: &mut boa_engine::Context,
     ) {
         let job = future::block_on(future);
         self.enqueue_promise_job(job, context);
     }
 
-    fn run_jobs(&self, context: &mut boa_engine::Context<'_>) {
+    fn run_jobs(&self, context: &mut boa_engine::Context) {
         while let Some(job) = self.next() {
             // Jobs can fail, it is the final result that determines the value
             let _ = job.call(context);
@@ -189,29 +174,29 @@ where
 }
 
 #[derive(Debug)]
-pub struct Runtime<'host> {
-    context: Context<'host>,
+pub struct Runtime {
+    context: Context,
     realm: Realm,
     // There will only ever be 2 references to the `job_queue`.
     // The context's internal reference and the runtime's reference.
     job_queue: Rc<JobQueue>,
 }
 
-impl<'host> Deref for Runtime<'host> {
-    type Target = Context<'host>;
+impl Deref for Runtime {
+    type Target = Context;
 
     fn deref(&self) -> &Self::Target {
         &self.context
     }
 }
 
-impl<'host> DerefMut for Runtime<'host> {
+impl DerefMut for Runtime {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.context
     }
 }
 
-impl<'host> Runtime<'host> {
+impl Runtime {
     pub fn new(gas_limit: usize) -> JsResult<Self> {
         // 1. Initialize job queue
         let job_queue = Rc::new(JobQueue::new());
@@ -220,7 +205,7 @@ impl<'host> Runtime<'host> {
         // NB: At this point, the context contains a 'default' realm
         let mut context = Context::builder()
             .host_hooks(HOOKS)
-            .job_queue(job_queue.clone() as Rc<dyn boa_engine::job::JobQueue>)
+            .job_queue(job_queue.clone())
             .instructions_remaining(gas_limit)
             .build()?;
 
@@ -241,16 +226,16 @@ impl<'host> Runtime<'host> {
     /// Returns the module instance and the module promise. Implementors must manually
     /// call `Runtime::run_event_loop` or poll/resolve the promise to drive the
     /// module's evaluation.
-    pub fn eval_module(&mut self, module: &Module) -> JsResult<JsPromise> {
+    pub fn eval_module(&mut self, module: &Module) -> JsPromise {
         self.realm.eval_module(module, &mut self.context)
     }
 
     /// Parses, compiles and evaluates the script `src`.
-    pub fn eval<R: Read>(&mut self, src: Source<'_, R>) -> JsResult<JsValue> {
+    pub fn eval<R: ReadChar>(&mut self, src: Source<'_, R>) -> JsResult<JsValue> {
         self.realm.eval(src, &mut self.context)
     }
 
-    pub fn context(&mut self) -> &mut Context<'host> {
+    pub fn context(&mut self) -> &mut Context {
         self.deref_mut()
     }
 
@@ -275,7 +260,7 @@ impl<'host> Runtime<'host> {
     }
 
     fn poll_promise(promise: JsPromise) -> Poll<JsResult<JsValue>> {
-        match promise.state()? {
+        match promise.state() {
             PromiseState::Pending => Poll::Pending,
             PromiseState::Fulfilled(result) => Poll::Ready(Ok(result)),
             PromiseState::Rejected(err) => Poll::Ready(Err(JsError::from_opaque(err))),
@@ -285,18 +270,15 @@ impl<'host> Runtime<'host> {
     /// Polls a given value to resolve by stepping the event loop
     pub fn poll_value(&mut self, value: &JsValue) -> Poll<JsResult<JsValue>> {
         match value.as_promise() {
-            Some(promise) => {
-                let promise = JsPromise::from_object(promise.clone())?;
-                match Self::poll_promise(promise) {
-                    Poll::Ready(val) => Poll::Ready(val),
-                    Poll::Pending => match self.poll_event_loop() {
-                        Poll::Ready(()) => Poll::Ready(Err(JsNativeError::error()
-                            .with_message("Event loop did not resolve the promise")
-                            .into())),
-                        Poll::Pending => Poll::Pending,
-                    },
-                }
-            }
+            Some(promise) => match Self::poll_promise(promise) {
+                Poll::Ready(val) => Poll::Ready(val),
+                Poll::Pending => match self.poll_event_loop() {
+                    Poll::Ready(()) => Poll::Ready(Err(JsNativeError::error()
+                        .with_message("Event loop did not resolve the promise")
+                        .into())),
+                    Poll::Pending => Poll::Pending,
+                },
+            },
             None => Poll::Ready(Ok(value.clone())),
         }
     }

--- a/crates/jstz_node/src/services/logs/mod.rs
+++ b/crates/jstz_node/src/services/logs/mod.rs
@@ -165,6 +165,7 @@ impl Service for LogsService {
 pub enum Line {
     #[cfg(feature = "persistent-logging")]
     // Indicates the start and end of a smart function call (request).
+    #[cfg(feature = "persistent-logging")]
     Request(RequestEvent),
     // Indicates the js log message from the smart function (e.g. log).
     Js(LogRecord),

--- a/crates/jstz_proto/src/api/ledger.rs
+++ b/crates/jstz_proto/src/api/ledger.rs
@@ -2,9 +2,9 @@ use std::ops::Deref;
 
 use boa_engine::{
     js_string,
-    object::{Object, ObjectInitializer},
+    object::{ErasedObject, ObjectInitializer},
     property::Attribute,
-    Context, JsArgs, JsNativeError, JsResult, JsString, JsValue, NativeFunction,
+    Context, JsArgs, JsData, JsNativeError, JsResult, JsString, JsValue, NativeFunction,
 };
 use boa_gc::{empty_trace, Finalize, GcRefMut, Trace};
 
@@ -22,6 +22,7 @@ use crate::{
 // Ledger.balance(pkh)
 // Ledger.transfer(dst, amount)
 
+#[derive(JsData)]
 struct Ledger {
     address: Address,
 }
@@ -77,7 +78,7 @@ pub(crate) fn js_value_to_pkh(value: &JsValue) -> Result<Address> {
 }
 
 impl Ledger {
-    fn try_from_js(value: &JsValue) -> JsResult<GcRefMut<'_, Object, Self>> {
+    fn try_from_js(value: &JsValue) -> JsResult<GcRefMut<'_, ErasedObject, Self>> {
         value
             .as_object()
             .and_then(|obj| obj.downcast_mut::<Self>())
@@ -92,7 +93,7 @@ impl Ledger {
 impl LedgerApi {
     const NAME: &'static str = "Ledger";
 
-    fn self_address(context: &mut Context<'_>) -> Accessor {
+    fn self_address(context: &mut Context) -> Accessor {
         accessor!(
             context,
             Ledger,
@@ -104,7 +105,7 @@ impl LedgerApi {
     fn balance(
         _this: &JsValue,
         args: &[JsValue],
-        _context: &mut Context<'_>,
+        _context: &mut Context,
     ) -> JsResult<JsValue> {
         let pkh = js_value_to_pkh(args.get_or_undefined(0))?;
 
@@ -118,7 +119,7 @@ impl LedgerApi {
     fn transfer(
         this: &JsValue,
         args: &[JsValue],
-        _context: &mut Context<'_>,
+        _context: &mut Context,
     ) -> JsResult<JsValue> {
         let ledger = Ledger::try_from_js(this)?;
         let dst = js_value_to_pkh(args.get_or_undefined(0))?;
@@ -136,10 +137,10 @@ impl LedgerApi {
 }
 
 impl jstz_core::Api for LedgerApi {
-    fn init(self, context: &mut boa_engine::Context<'_>) {
+    fn init(self, context: &mut boa_engine::Context) {
         let self_address = LedgerApi::self_address(context);
 
-        let ledger = ObjectInitializer::with_native(
+        let ledger = ObjectInitializer::with_native_data(
             Ledger {
                 address: self.address,
             },

--- a/crates/jstz_proto/src/js_logger.rs
+++ b/crates/jstz_proto/src/js_logger.rs
@@ -28,7 +28,7 @@ impl Display for LogRecord {
 }
 
 impl LogRecord {
-    pub fn new(log_data: LogData, context: &mut Context<'_>) -> Self {
+    pub fn new(log_data: LogData, context: &mut Context) -> Self {
         host_defined!(context, host_defined);
         let trace_data = host_defined
             .get::<TraceData>()
@@ -57,7 +57,7 @@ impl LogRecord {
 pub(crate) struct JsonLogger;
 
 impl JsLog for JsonLogger {
-    fn log(&self, log_data: LogData, context: &mut Context<'_>) {
+    fn log(&self, log_data: LogData, context: &mut Context) {
         let log_record = LogRecord::new(log_data, context).to_string();
         runtime::with_js_hrt(|hrt| {
             hrt.write_debug(&(LOG_PREFIX.to_string() + &log_record + "\n"));

--- a/flake.nix
+++ b/flake.nix
@@ -198,6 +198,9 @@
                 # Code coverage
                 cargo-llvm-cov
                 octez
+
+                # For running the web platform tests
+                python39
               ]
               ++ lib.optionals stdenv.isLinux [pkg-config openssl.dev]
               ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [Security SystemConfiguration]);


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
**Related Tasks**: [Update `boa_engine` to 0.19.0](https://linear.app/tezos/issue/JSTZ-179/update-boa-engine-to-v0190)

**Depends on**: #594 

The Rust bindings to SpiderMonkey, `mozjs`,  has a dependency `icu_capi`, which in turn depends on `icu_provider, icu_collections, ...`. However, Boa also relies on `icu_*` crates. Since our build of Boa uses older versions, this results in a version clash.

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

Updating Boa solves the dependency issue. This PR is fairly substantial, but most of the changes are fairly mechanical:
- `Context` no-longer has a lifetime parameter: `Context<'_> -> Context`
- `Object` -> `ErasedObject`
- `boa_gc::custom_trace` now has a binder for the `marker` function. So `custom_trace!(this, { ... }) -> custom_trace!(this, mark, { ... })`. 
- `JsData` trait constraint now added to `NativeObject`, usually fixed by adding `#[derive(JsData)]`
- `Read` trait replaced with `ReadChar` for parsing JavaScript code
- Renamed function `ObjectInitializer::with_native -> ObjectInitializer::with_native_data`

Some more subtle changes
- `JsObject` is now parameterised by `T` (the inner object type)
- `JsPromise` functions no-longer error, simplifying error handling logic
- Interface for `JsBufferSource` updated to clone underlying data (handles issues that arise with `SharedBufferArray`s)

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

Run the WPT tests:
```
cargo test --package jstz_api
```
