### PR TITLE
docs: fix typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,11 +19,11 @@ In the `jstz_core` crates, `jstz` uses Boa and enables Rust types to be passed a
 
 When writing smart functions, we need a way to store data across different calls of the functions. Therefore, `jstz` _smart functions_ implement a persistent key-value store used for storing and retrieval of arbitrary JSON blobs. This store can be accessed through a global _Kv_ object.
 
-The key-value store implements _optimistic concurrency control scheme_. It is optimistically assumed that conflicts between different transactions (snapshots of the persistent kv store) are sufficiently rare thus not interfering each other. Before commiting, the transaction verifies whether no other transaction has modified the data it has read.
+The key-value store implements _optimistic concurrency control scheme_. It is optimistically assumed that conflicts between different transactions (snapshots of the persistent kv store) are sufficiently rare thus not interfering each other. Before committing, the transaction verifies whether no other transaction has modified the data it has read.
 
-The transactions performed over the KV store offer ACID guarantees and serializability, therefore any transaction can be commited only if it does not conflict with any previously commited ones.
+The transactions performed over the KV store offer ACID guarantees and serializability, therefore any transaction can be committed only if it does not conflict with any previously committed ones.
 
-In each transaction, the repeated access to the same key is optimized through caching. Similarly, writes are buffered until the transaction is commited at which point it gets flushed to the persistent KV storage.
+In each transaction, the repeated access to the same key is optimized through caching. Similarly, writes are buffered until the transaction is committed at which point it gets flushed to the persistent KV storage.
 
 `jstz` implements several `jstz`-specific APIs such as `Kv`, `Ledger`, and `SmartFunction`. Additionally, `jstz` provides implementations for many web standard APIs in the `jstz_api` crate.
 
@@ -35,7 +35,7 @@ _Kv_ store is implemented on top of jstz\*core::kv. The API provides access to a
 
 ### Ledger
 
-A specialised type of the KV store is the Ledger that provides access to the balances of the L2 tez. Additionally it also stores so-called 'self address' - the address of the smart function itself. Similarly to the KV store, all operations on the ledger are synchronous and atomic, commited only if the request to the smart function succeeds.
+A specialised type of the KV store is the Ledger that provides access to the balances of the L2 tez. Additionally it also stores so-called 'self address' - the address of the smart function itself. Similarly to the KV store, all operations on the ledger are synchronous and atomic, committed only if the request to the smart function succeeds.
 
 ### SmartFunction
 
@@ -110,7 +110,7 @@ cd tezos
 nix-build -j auto
 ```
 
-After Nix successfully builds Octez (it takes a long time 🕣), the Octez binaries will be accessable from `result`.
+After Nix successfully builds Octez (it takes a long time 🕣), the Octez binaries will be accessible from `result`.
 
 Once Octez has been built, copy the following binaries to `jstz`:
 

--- a/docs/api/console.md
+++ b/docs/api/console.md
@@ -101,38 +101,38 @@ group: x = 2
 ### `console.log(...message : unknown[]) : void`{#log}
 
 Outputs a general logging message.
-String reresentations of each of the arguments will be concatenated, separated by spaces and written to the logs.
+String representations of each of the arguments will be concatenated, separated by spaces and written to the logs.
 
 ### `console.info(...message : unknown[]) : void`{#info}
 
 Outputs a informative logging message.
-String reresentations of each of the arguments will be concatenated, separated by spaces and written to the logs.
+String representations of each of the arguments will be concatenated, separated by spaces and written to the logs.
 
 ### `console.warn(...message : unknown[]) : void`{#warn}
 
 Outputs a warning logging message.
-String reresentations of each of the arguments will be concatenated, separated by spaces and written to the logs.
+String representations of each of the arguments will be concatenated, separated by spaces and written to the logs.
 
 ### `console.error(...message : unknown[]) : void`{#error}
 
 Outputs a warning message.
-String reresentations of each of the arguments will be concatenated, separated by spaces and written to the logs.
+String representations of each of the arguments will be concatenated, separated by spaces and written to the logs.
 
 ### `console.assert(assertion: unknown, ...message : unknown[]) : void`{#assert}
 
 Outputs an error message if the first argument is falsy.
-String reresentations of each of the arguments will be concatenated, separated by spaces and written to the logs.
+String representations of each of the arguments will be concatenated, separated by spaces and written to the logs.
 Has no effect if the first argument is truthy.
 
 ### `console.debug(...message : unknown[]) : void`{#debug}
 
 Outputs a debug logging message.
-String reresentations of each of the arguments will be concatenated, separated by spaces and written to the logs.
+String representations of each of the arguments will be concatenated, separated by spaces and written to the logs.
 
 ### `console.group(...label : unknown[]) : void`{#group}
 
 Begins a group and pushes the label to the group stack.
-The group label will consist of the string reresentations of each of the arguments, concatenated and separated by spaces.
+The group label will consist of the string representations of each of the arguments, concatenated and separated by spaces.
 Subsequent messages will be indented at the level of the group.
 
 ### `console.groupCollapsed(...message : unknown[]) : void`

--- a/docs/api/ledger.md
+++ b/docs/api/ledger.md
@@ -4,7 +4,7 @@ The `Ledger` object maintains a persistent ledger of all accounts and their
 balances of L2 tez (stored as mutez). Additionally, the `Ledger` object stores the 'self address' of
 the smart function, which is the address of the smart function itself.
 
-All operations on `Ledger` are synchronous and atomic, committed if the request to the smart function suceeds.
+All operations on `Ledger` are synchronous and atomic, committed if the request to the smart function succeeds.
 
 ## Quick Start
 

--- a/docs/api/request.md
+++ b/docs/api/request.md
@@ -31,7 +31,7 @@ The possible settings are:
 
 - `headers` (`HeadersInit`, optional)
 
-  Any headers that should be attatched to the request. Either a [`Headers`](./headers.md) object, an `Array` of key-value pairs, or a `Record<string, string>`.
+  Any headers that should be attached to the request. Either a [`Headers`](./headers.md) object, an `Array` of key-value pairs, or a `Record<string, string>`.
 
 - `body` (`BodyInit | null`, optional)
 

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -26,7 +26,7 @@ jstz bridge deposit --from tz1faswCTDciRzE4oJ9jn2Vm2dvjeyA9fUzU \
     --amount 42
 ```
 
-sucessfully deposits 42 XTZ from `tz1faswCTDciRzE4oJ9jn2Vm2dvjeyA9fUzU` to the `tz1ZvXcDBWMAys2ro6kJXrgiWUcUF8RvCHYy` `jstz` address, outputting:
+successfully deposits 42 XTZ from `tz1faswCTDciRzE4oJ9jn2Vm2dvjeyA9fUzU` to the `tz1ZvXcDBWMAys2ro6kJXrgiWUcUF8RvCHYy` `jstz` address, outputting:
 
 ```
 Deposited 42 XTZ to tz4N7y3T2e2dfCyHB1Ama68jnt3Fps7Ufu6d

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -239,7 +239,7 @@ $ jstz deploy examples/logs.js --name my_function
 $ jstz logs trace my_function
 ```
 
-In a new termninal, run the counter function and you will see the following output:
+In a new terminal, run the counter function and you will see the following output:
 
 ```bash
 [🪵]: log

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ import VPButton from "vitepress/dist/client/theme-default/components/VPButton.vu
 
 # 👨‍⚖️ `jstz`
 
-`jstz` (pronouced 'justice') is a JavaScript server runtime for Tezos smart optimistic rollups
+`jstz` (pronounced 'justice') is a JavaScript server runtime for Tezos smart optimistic rollups
 with a great developer experience. It is built on [Boa](https://boajs.dev/) and [Rust](https://www.rust-lang.org/).
 
 `jstz` is free and open source software under the [MIT license](https://github.com/jstz-dev/jstz/blob/main/LICENSE).

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -31,14 +31,14 @@ const ONE_TEZ = 1000000;
 // Maximum amount of tez a requester can receive
 const MAX_TEZ = 10000;
 
-const getRecievedTez = (requester: Address): number => {
+const getReceivedTez = (requester: Address): number => {
   let receivedTez: number | null = Kv.get(`received/${requester}`);
   receivedTez = receivedTez === null ? 0 : receivedTez;
   console.debug(`Requestor already received ${receivedTez} tez`);
   return receivedTez;
 };
 
-const setRecievedTez = (requester: Address, received: number): void => {
+const setReceivedTez = (requester: Address, received: number): void => {
   Kv.set(`received/${requester}`, received + 1);
 };
 
@@ -55,8 +55,8 @@ const handler = async (request: Request): Promise<Response> => {
   }
 
   // If the requester already received too much tez, decline the request
-  const recievedTez = getRecievedTez(requester);
-  if (recievedTez >= MAX_TEZ) {
+  const receivedTez = getReceivedTez(requester);
+  if (receivedTez >= MAX_TEZ) {
     return new Response("Sorry, you already received too much tez");
   }
 
@@ -71,7 +71,7 @@ const handler = async (request: Request): Promise<Response> => {
       "Sorry, I don't have enough tez to fulfill your request",
     );
   }
-  setRecievedTez(requester, recievedTez + 1);
+  setReceivedTez(requester, receivedTez + 1);
 
   return new Response("Thank you for your polite request. You received 1 tez!");
 };
@@ -88,7 +88,7 @@ The smart function consists of:
 
 - An `export default` statement.
 
-  `export default` is JavaScript syntax required for defining an EMCAScript module.
+  `export default` is JavaScript syntax required for defining an ECMAScript module.
   Smart functions _must_ have an default export of a function, which has the following type:
 
   ```typescript
@@ -118,7 +118,7 @@ In addition to several [standard Web APIs](./api/index.md#web-platform-apis), `j
 
 - **`SmartFunction` API**
 
-  Smart functions can invoke other smart functions using `fetch`, similiar to network requests in JavaScript.
+  Smart functions can invoke other smart functions using `fetch`, similar to network requests in JavaScript.
   Additionally, new smart functions can be deployed by a smart function using the [`SmartFunction`](./api/smart_function.md) API.
 
 ## 2. Deploying your Smart Function
@@ -249,7 +249,7 @@ jstz bridge deposit --from bootstrap1 --to tz1Tp5wSRWiVJwLoT8WqN1yRapdq6UmdRf6W 
 
 ## 3. Running and debugging your Smart Function
 
-After a succesful deployment, you will be able to run the smart function with the provided command to run your smart function similarly to the following:
+After a successful deployment, you will be able to run the smart function with the provided command to run your smart function similarly to the following:
 
 ```sh
 jstz run tezos://tz1Tp5wSRWiVJwLoT8WqN1yRapdq6UmdRf6W/ --data '{"message":"Please, give me some tez."}'


### PR DESCRIPTION
# Context

[JSTZ-181](https://linear.app/tezos/issue/JSTZ-181/fix-typos-in-docs)

Closes #595.

# Description

Went through .md files and fixed typos.

# Manually testing the PR

N/A
