### PR TITLE
feat(nix): update octez in nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,6 +20,20 @@
         "type": "github"
       }
     },
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "revCount": 57,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.0.1/018afb31-abd1-7bff-a5e4-cff7e18efb7a/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -30,6 +44,42 @@
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1687709756,
+        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
         "type": "github"
       },
       "original": {
@@ -49,6 +99,53 @@
       },
       "original": {
         "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1717179513,
+        "narHash": "sha256-vboIEwIQojofItm2xGCdZCzW96U85l9nDW3ifMuAIdM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "63dacb46bf939521bdc93981b4cbb7ecb58427a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1688587528,
+        "narHash": "sha256-a1WlbVZyFtXVwqU/Ut+tl8aTgexp/GKloQtGA1Hfwjw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "08c696c8d702e98d6693efea6d0be94b54849a16",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1718428119,
+        "narHash": "sha256-WdWDpNaq6u1IPtxtYHHWpl5BmabtpmLnMAx0RdJ/vo8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e6cea36f83499eb4e9cd184c8a8e823296b50ad5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -75,51 +172,43 @@
     },
     "octez-v21": {
       "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "opam-nix-integration": [
-          "opam-nix-integration"
-        ],
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2",
+        "opam-nix-integration": "opam-nix-integration",
         "opam-repository": "opam-repository",
-        "rust-overlay": [
-          "rust-overlay"
-        ]
+        "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1726495500,
-        "narHash": "sha256-LxIn3uvqOrNdlcUnbSvHGnVTn47rREvVqdvA4+AL8D0=",
+        "lastModified": 1729167219,
+        "narHash": "sha256-/C7YMgvhiC03dGL+BBG88EEN0t/Fhk+3bB9U/Idobs4=",
         "owner": "tezos",
         "repo": "tezos",
-        "rev": "44643df827aa2d745c3d8a09a6649fe175ff77d7",
+        "rev": "c6c7373f31917d1bcf1fbc6550937b3ae1d3d748",
         "type": "gitlab"
       },
       "original": {
         "owner": "tezos",
-        "ref": "octez-v21.0-rc2",
         "repo": "tezos",
+        "rev": "c6c7373f31917d1bcf1fbc6550937b3ae1d3d748",
         "type": "gitlab"
       }
     },
     "opam-nix-integration": {
       "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "opam-repository": "opam-repository_2"
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_3",
+        "opam-repository": [
+          "octez-v21",
+          "opam-repository"
+        ]
       },
       "locked": {
-        "lastModified": 1716561961,
-        "narHash": "sha256-SgeZItYuUZV7WSaoX4G7J1ZpmwgeI3ocQCLP95E+O1U=",
+        "lastModified": 1728662094,
+        "narHash": "sha256-tOAquEaPr15wNWbfsxNqV6s6oCfC0yQvC5D5MRKm+ig=",
         "owner": "vapourismo",
         "repo": "opam-nix-integration",
-        "rev": "0f98236c75cdb436be7669ccaa249264456baa37",
+        "rev": "576bfd60b8fc1cf548ae71b842496a15a797f4fd",
         "type": "github"
       },
       "original": {
@@ -131,27 +220,11 @@
     "opam-repository": {
       "flake": false,
       "locked": {
-        "lastModified": 1723381368,
-        "narHash": "sha256-fN8jaeSfK8lbIQcvPXk96FeH8i7sjGjkwqnf0C9ZCog=",
+        "lastModified": 1727454553,
+        "narHash": "sha256-9p5c2qV5IfRGrYEnHNFw7hHCYgD2jAnTumJStUr8dPE=",
         "owner": "ocaml",
         "repo": "opam-repository",
-        "rev": "0f4d0ee5b69b496a4e26f305891c31400f0b4b5f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ocaml",
-        "repo": "opam-repository",
-        "type": "github"
-      }
-    },
-    "opam-repository_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1688548241,
-        "narHash": "sha256-cmk1kCLtcL9GJplfl4J7t0r8g0N25O4G0ctycV4eyPo=",
-        "owner": "ocaml",
-        "repo": "opam-repository",
-        "rev": "860072345fa2f234ff10ffeee88db6906e138e92",
+        "rev": "a70ac3366bdaaf354374c8ac8929d09c17e6f494",
         "type": "github"
       },
       "original": {
@@ -167,26 +240,41 @@
         "nixpkgs": "nixpkgs",
         "npm-buildpackage": "npm-buildpackage",
         "octez-v21": "octez-v21",
-        "opam-nix-integration": "opam-nix-integration",
-        "rust-overlay": "rust-overlay",
+        "rust-overlay": "rust-overlay_2",
         "treefmt": "treefmt"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
+        "nixpkgs": "nixpkgs_4"
+      },
+      "locked": {
+        "lastModified": 1722305989,
+        "narHash": "sha256-ljiuTGSFuEtudqFqp/5Wr1OuEsVCjur/F2CmlNujSjc=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "38c2f156fca1868c8be7195ddac150522752f6ab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "38c2f156fca1868c8be7195ddac150522752f6ab",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
+      "inputs": {
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1701656211,
-        "narHash": "sha256-lfFXsLWH4hVbEKR6K+UcDiKxeS6Lz4FkC1DZ9LHqf9Y=",
+        "lastModified": 1729132166,
+        "narHash": "sha256-Mhl4T7gDGknG4nPbHNSGWynfSjZeoWBdsaIzhUYuIlU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "47a276e820ae4ae1b8d98a503bf09d2ceb52dfd8",
+        "rev": "32d889f9b9fc65cb65aa2d5db282d60ed06f348e",
         "type": "github"
       },
       "original": {
@@ -196,6 +284,36 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -35,19 +35,9 @@
 
     # Octez
 
-    # We explicitly have opam-nix-integration as an input to avoid having two versions of nixpkgs
-    opam-nix-integration = {
-      url = "github:vapourismo/opam-nix-integration";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-utils.follows = "flake-utils";
-    };
-
     octez-v21 = {
-      url = "gitlab:tezos/tezos/octez-v21.0-rc2";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-utils.follows = "flake-utils";
-      inputs.rust-overlay.follows = "rust-overlay";
-      inputs.opam-nix-integration.follows = "opam-nix-integration";
+      # pin octez-v21 to a specific commit until the next release is available
+      url = "gitlab:tezos/tezos/c6c7373f31917d1bcf1fbc6550937b3ae1d3d748";
     };
   };
 

--- a/nix/patches/0001-fix-octez-rust-deps-for-nix.patch
+++ b/nix/patches/0001-fix-octez-rust-deps-for-nix.patch
@@ -1,10 +1,10 @@
 diff --git a/manifest/product_octez.ml b/manifest/product_octez.ml
-index f4336a077a..6ab49b65cf 100644
+index b99bf82156..3bcb1d9129 100644
 --- a/manifest/product_octez.ml
 +++ b/manifest/product_octez.ml
-@@ -522,7 +522,7 @@ let octez_rust_deps =
-               [S "source_tree"; S "../riscv"];
-               [S "source_tree"; S "../kernel_sdk"];
+@@ -575,7 +575,7 @@ let octez_rust_deps =
+               [S "file"; S "../../src/lib_wasm_runtime/build.rs"];
+               [S "glob_files_rec"; S "../../src/lib_wasm_runtime/src/**.rs"];
              ];
 -            [S "action"; [S "no-infer"; [S "bash"; S "./build.sh"]]];
 +            [S "action"; [S "no-infer"; [S "system"; S "bash ./build.sh"]]];
@@ -12,12 +12,12 @@ index f4336a077a..6ab49b65cf 100644
          ]
  
 diff --git a/src/rust_deps/dune b/src/rust_deps/dune
-index de48dbfde8..20934e2e21 100644
+index 4e6bc21230..094f4f0d1e 100644
 --- a/src/rust_deps/dune
 +++ b/src/rust_deps/dune
-@@ -22,4 +22,4 @@
-   (source_tree src)
-   (source_tree ../riscv)
-   (source_tree ../kernel_sdk))
+@@ -25,4 +25,4 @@
+   (file ../../src/lib_wasm_runtime/Cargo.toml)
+   (file ../../src/lib_wasm_runtime/build.rs)
+   (glob_files_rec ../../src/lib_wasm_runtime/src/**.rs))
 - (action (no-infer (bash ./build.sh))))
-+ (action (no-infer (system "bash ./build.sh"))))
++  (action (no-infer (system "bash ./build.sh"))))


### PR DESCRIPTION
# Context
Updates octez in nix. 
Initially, I thought there was a bug in octez client causing `bake for` command to be missing but turns out we don't need to upgrade octez client for it to work. Since the work has been done anyway, we might as well upgrade as there has been a lot of changes since the previous version.

# Manually testing the PR
```
nix build -j auto
```
<!-- Describe how reviewers and approvers can test this PR. -->
