### PR TITLE
feat(jstzd): implement add_address

### DIFF
--- a/crates/jstzd/src/task/octez_client.rs
+++ b/crates/jstzd/src/task/octez_client.rs
@@ -285,6 +285,21 @@ impl OctezClient {
         self.spawn_and_wait_command(args).await?;
         Ok(())
     }
+
+    pub async fn add_address(
+        &self,
+        alias: &str,
+        public_key_hash: &PublicKeyHash,
+        overwrite: bool,
+    ) -> Result<()> {
+        let hash_string = public_key_hash.to_string();
+        let mut args = vec!["add", "address", alias, &hash_string];
+        if overwrite {
+            args.push("-f");
+        }
+        self.spawn_and_wait_command(args).await?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/jstzd/tests/octez_client_test.rs
+++ b/crates/jstzd/tests/octez_client_test.rs
@@ -1,4 +1,5 @@
 use http::Uri;
+use jstz_crypto::public_key_hash::PublicKeyHash;
 use jstzd::task::{
     endpoint::Endpoint, octez_client::OctezClientBuilder, octez_node, Task,
 };
@@ -267,4 +268,26 @@ async fn get_response_text(endpoint: &str) -> String {
         .text()
         .await
         .expect("Failed to get response text")
+}
+
+#[tokio::test]
+async fn add_address() {
+    let address =
+        PublicKeyHash::from_base58("tz1cMWTNwecApUicCrHfTRwHEhBcZGjkUwCw").unwrap();
+    let temp_dir = TempDir::new().unwrap();
+    let base_dir = temp_dir.path().to_path_buf();
+    let octez_client = OctezClientBuilder::new()
+        .set_base_dir(base_dir.clone())
+        .build()
+        .unwrap();
+    let alias = "test_alias".to_string();
+    let res = octez_client.add_address(&alias, &address, false).await;
+    assert!(res.is_ok());
+    let res = octez_client.add_address(&alias, &address, false).await;
+    assert!(res
+        .unwrap_err()
+        .to_string()
+        .contains("test_alias already exists"));
+    let res = octez_client.add_address(&alias, &address, true).await;
+    assert!(res.is_ok());
 }


### PR DESCRIPTION
# Context

Closes JSTZ-137.
[JSTZ-137](https://linear.app/tezos/issue/JSTZ-137/implement-octezclientadd-address)

# Description

Implemented `octez-client add address`.

# Manually testing the PR

Added one integration test:
```sh
$ cargo test --test octez_client_test add_address
running 1 test
test add_address ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 10 filtered out; finished in 1.01s
```
