### PR TITLE
fix(sandbox): activate parisC in sandbox

### DIFF
--- a/crates/jstz_cli/src/sandbox/daemon.rs
+++ b/crates/jstz_cli/src/sandbox/daemon.rs
@@ -428,7 +428,7 @@ fn init_client(log_file: &mut File, progress: &mut u32, cfg: &Config) -> Result<
     progress_step(log_file, progress);
     debug!(log_file, "Activating alpha...");
     cfg.octez_client_sandbox()?.activate_protocol(
-        "PtParisBxoLz5gzMmn3d9WBQNoPSZakgnkMC2VNuQ3KXfUtUQeZ",
+        "PsParisCZo7KAh1Z1smVd9ZMZ1HHn5gkzbM94V3PLCpknFWhUAi",
         "1",
         "activator",
         sandbox_params_path().to_str().expect("Invalid path"),


### PR DESCRIPTION
# Context
Bake for command is available only on latest protocols of a 'version' of the protocol. Since we upgraded to the latest octez release, ParisC is now the latest protocol

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
`cargo run -- sandbox start` 
<!-- Describe how reviewers and approvers can test this PR. -->
