### PR TITLE
feat(jstzd): originate contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3140,6 +3140,7 @@ dependencies = [
  "signal-hook",
  "tempfile",
  "tezos-smart-rollup-encoding",
+ "tezos_crypto_rs 0.6.0",
  "tokio",
 ]
 

--- a/crates/jstzd/tests/octez_client_test.rs
+++ b/crates/jstzd/tests/octez_client_test.rs
@@ -6,14 +6,15 @@ use octez::r#async::endpoint::Endpoint;
 use serde_json::Value;
 use std::{
     fs::{read_to_string, remove_file},
+    io::Write,
     path::Path,
 };
 use tempfile::{NamedTempFile, TempDir};
 mod utils;
 use std::path::PathBuf;
 use utils::{
-    activate_alpha, create_client, get_request, import_activator, spawn_octez_node,
-    SECRET_KEY,
+    activate_alpha, create_client, get_request, import_activator, setup,
+    spawn_octez_node, SECRET_KEY,
 };
 
 fn read_file(path: &Path) -> Value {
@@ -230,4 +231,26 @@ async fn add_address() {
         .contains("test_alias already exists"));
     let res = octez_client.add_address(&alias, &address, true).await;
     assert!(res.is_ok());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn originate_contract() {
+    let (mut octez_node, octez_client, mut baker) = setup().await;
+
+    let mut config_file = NamedTempFile::new().unwrap();
+    config_file.write_all("parameter (unit %entrypoint_1); storage int; code { CDR; NIL operation; PAIR; };".as_bytes()).unwrap();
+    octez_client
+        .originate_contract(
+            "foo",
+            "bootstrap1",
+            10000.0,
+            config_file.path(),
+            Some("1"),
+            Some(0.5),
+        )
+        .await
+        .unwrap();
+
+    let _ = baker.kill().await;
+    let _ = octez_node.kill().await;
 }

--- a/crates/octez/Cargo.toml
+++ b/crates/octez/Cargo.toml
@@ -25,4 +25,5 @@ serde_json.workspace = true
 signal-hook.workspace = true
 tempfile.workspace = true
 tezos-smart-rollup-encoding.workspace = true
+tezos_crypto_rs.workspace = true
 tokio.workspace = true

--- a/crates/octez/src/async/client.rs
+++ b/crates/octez/src/async/client.rs
@@ -11,6 +11,7 @@ use std::{
     str::FromStr,
 };
 use tempfile::tempdir;
+use tezos_crypto_rs::hash::{ContractKt1Hash, OperationHash};
 use tokio::process::Command;
 
 use super::{directory::Directory, endpoint::Endpoint, node::DEFAULT_RPC_ENDPOINT};
@@ -331,6 +332,80 @@ impl OctezClient {
         self.spawn_and_wait_command(args).await?;
         Ok(())
     }
+
+    pub async fn originate_contract(
+        &self,
+        contract_alias: &str,
+        funding_account_src: &str,
+        fund_tez: f64,
+        contract_path: &Path,
+        init_data: Option<&str>,
+        burn_cap: Option<f64>,
+    ) -> Result<(ContractKt1Hash, OperationHash)> {
+        let fund_str = fund_tez.to_string();
+        let burn_cap_str = burn_cap.map(|v| v.to_string());
+        let mut args = vec![
+            "originate",
+            "contract",
+            contract_alias,
+            "transferring",
+            &fund_str,
+            "from",
+            funding_account_src,
+            "running",
+            contract_path
+                .to_str()
+                .ok_or(anyhow::anyhow!("failed to convert contract path to string"))?,
+        ];
+        if let Some(data) = init_data {
+            args.append(&mut vec!["--init", data]);
+        }
+        if let Some(v) = &burn_cap_str {
+            args.append(&mut vec!["--burn-cap", v]);
+        }
+        let output = self.spawn_and_wait_command(args).await?;
+
+        let operation_hash = parse_operation_hash(&output);
+        if let Err(e) = operation_hash {
+            anyhow::bail!(
+                "failed to parse operation hash from execution output: {:?}",
+                e
+            );
+        }
+        let contract_address = parse_contract_address(&output);
+        if let Err(e) = contract_address {
+            anyhow::bail!(
+                "failed to parse contract address from execution output: {:?}",
+                e
+            );
+        }
+        Ok((contract_address.unwrap(), operation_hash.unwrap()))
+    }
+}
+
+fn parse_regex(pattern_str: &str, output: &str) -> Result<String> {
+    let pattern = regex::Regex::new(pattern_str)?;
+    Ok(pattern
+        .captures(output)
+        .ok_or(anyhow::anyhow!("input string does not match the pattern"))?
+        .get(1)
+        .ok_or(anyhow::anyhow!("cannot find the first match group"))?
+        .as_str()
+        .to_owned())
+}
+
+fn parse_operation_hash(output: &str) -> Result<OperationHash> {
+    let raw_operation_hash =
+        parse_regex("Operation hash is '(o[1-9A-HJ-NP-Za-km-z]{50})'", output)?;
+    Ok(OperationHash::from_base58_check(&raw_operation_hash)?)
+}
+
+fn parse_contract_address(output: &str) -> Result<ContractKt1Hash> {
+    let raw_contract_hash = parse_regex(
+        "New contract (KT1[1-9A-HJ-NP-Za-km-z]{33}) originated.",
+        output,
+    )?;
+    Ok(ContractKt1Hash::from_base58_check(&raw_contract_hash)?)
 }
 
 #[cfg(test)]
@@ -515,5 +590,67 @@ mod test {
         let input = "15.23453 ꜩ";
         let res = OctezClient::extract_digits(input);
         assert!(res.is_ok_and(|balance| balance == 15.23453));
+    }
+
+    #[test]
+    fn test_parse_contract_address() {
+        let contract_hash = "KT1F3MuqvT9Yz57TgCS3EkDcKNZe9HpiavUJ";
+        assert_eq!(
+            parse_contract_address(&format!("New contract {contract_hash} originated."))
+                .unwrap(),
+            ContractKt1Hash::from_base58_check(contract_hash).unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_contract_address_pattern_mismatch() {
+        let contract_hash = "foobar";
+        assert_eq!(
+            parse_contract_address(&format!("New contract {contract_hash} originated."))
+                .unwrap_err()
+                .to_string(),
+            "input string does not match the pattern"
+        );
+    }
+
+    #[test]
+    fn parse_contract_address_bad_hash() {
+        let contract_hash = format!("KT1{}", "1".repeat(33));
+        assert_eq!(
+            parse_contract_address(&format!("New contract {contract_hash} originated."))
+                .unwrap_err()
+                .to_string(),
+            "invalid checksum"
+        );
+    }
+
+    #[test]
+    fn test_parse_operation_hash() {
+        let operation_hash = "op15fmUF1cypvbX6H5Uu8i1Fwtf2fX3vFk8yxGQLoZDCfvqht2i";
+        assert_eq!(
+            parse_operation_hash(&format!("Operation hash is '{operation_hash}'"))
+                .unwrap(),
+            OperationHash::from_base58_check(operation_hash).unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_operation_hash_pattern_mismatch() {
+        assert_eq!(
+            parse_operation_hash("Operation hash is 'foobar'")
+                .unwrap_err()
+                .to_string(),
+            "input string does not match the pattern"
+        );
+    }
+
+    #[test]
+    fn parse_operation_hash_bad_hash() {
+        assert_eq!(
+            parse_operation_hash(&format!("Operation hash is 'o{}'", "1".repeat(50)))
+                .unwrap_err()
+                .to_string(),
+            "invalid checksum"
+        );
     }
 }


### PR DESCRIPTION
# Context

Closes JSTZ-140.

[JSTZ-140](https://linear.app/tezos/issue/JSTZ-140/implement-octezclientoriginate-contract)

# Description

Implements `octez-client originate contract`. If the execution is successful, the contract address and the hash of the operation where the origination took place are returned.

# Manually testing the PR

* Unit test: new test cases
```sh
$ cargo test --lib task::octez_client::test::parse_

running 6 tests
test task::octez_client::test::parse_operation_hash_pattern_mismatch ... ok
test task::octez_client::test::parse_contract_address_pattern_mismatch ... ok
test task::octez_client::test::parse_operation_hash ... ok
test task::octez_client::test::parse_contract_address_bad_hash ... ok
test task::octez_client::test::parse_operation_hash_bad_hash ... ok
test task::octez_client::test::parse_contract_address ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 23 filtered out; finished in 0.01s
```
* Integration test: one new test case
