### PR TITLE
refactor(jstzd): refactor tests

### DIFF
--- a/crates/jstzd/tests/octez_baker_test.rs
+++ b/crates/jstzd/tests/octez_baker_test.rs
@@ -1,140 +1,18 @@
-use jstzd::task::{octez_baker::OctezBaker, Task};
-use octez::r#async::{
-    baker::{BakerBinaryPath, OctezBakerConfigBuilder},
-    client::{OctezClient, OctezClientBuilder},
-    node_config::{OctezNodeConfigBuilder, OctezNodeRunOptionsBuilder},
-    protocol::Protocol,
-};
-use regex::Regex;
-use std::path::Path;
-use tempfile::TempDir;
 mod utils;
-use std::path::PathBuf;
-use utils::{get_request, retry};
+use jstzd::task::Task;
+use utils::{get_block_level, setup};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_baker() {
-    // 1. start octez node
-    let mut octez_node = spawn_octez_node().await;
-    // 2. setup octez client
-    let temp_dir = TempDir::new().unwrap();
-    let base_dir: std::path::PathBuf = temp_dir.path().to_path_buf();
-    let node_endpoint = octez_node.rpc_endpoint().clone();
-    let octez_client = OctezClientBuilder::new()
-        .set_endpoint(node_endpoint.clone())
-        .set_base_dir(base_dir.clone())
-        .build()
-        .unwrap();
-    // 3. activate alpha protocol, the block level is 1 after activation
-    activate_alpha(&octez_client).await;
-    import_bootstrap_keys(&octez_client).await;
-    // 4. start baker
-    let baker_config = OctezBakerConfigBuilder::new()
-        .set_binary_path(BakerBinaryPath::Env(Protocol::Alpha))
-        .set_octez_client_base_dir(
-            PathBuf::try_from(octez_client.base_dir())
-                .unwrap()
-                .to_str()
-                .unwrap(),
-        )
-        .set_octez_node_data_dir(octez_node.data_dir().to_str().unwrap())
-        .set_octez_node_endpoint(octez_node.rpc_endpoint())
-        .build()
-        .expect("Failed to build baker config");
-    // check if the block is baked
-    let mut baker_node = OctezBaker::spawn(baker_config).await.expect("SHOULD RUN");
-    assert!(baker_node.health_check().await.unwrap());
-    let block_baked = retry(10, 1000, || async {
-        let level = get_block_level(&node_endpoint.to_string()).await;
-        Ok(level > 1)
-    })
-    .await;
-    assert!(block_baked);
-    // 5. kill the baker node
-    let _ = baker_node.kill().await;
-    assert!(!baker_node.health_check().await.unwrap());
+    let (mut octez_node, _, mut baker) = setup().await;
+    let node_endpoint = octez_node.rpc_endpoint();
+
+    let _ = baker.kill().await;
+    assert!(!baker.health_check().await.unwrap());
     // check if the block level stops increasing after killing
     let last_level = get_block_level(&node_endpoint.to_string()).await;
     tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
     let current_level = get_block_level(&node_endpoint.to_string()).await;
     assert_eq!(last_level, current_level);
     let _ = octez_node.kill().await;
-}
-
-async fn spawn_octez_node() -> jstzd::task::octez_node::OctezNode {
-    let mut config_builder = OctezNodeConfigBuilder::new();
-    let run_options = OctezNodeRunOptionsBuilder::new()
-        .set_synchronisation_threshold(0)
-        .build();
-    config_builder
-        .set_binary_path("octez-node")
-        .set_network("sandbox")
-        .set_run_options(&run_options);
-    let octez_node =
-        jstzd::task::octez_node::OctezNode::spawn(config_builder.build().unwrap())
-            .await
-            .unwrap();
-    let node_ready = retry(10, 1000, || async { octez_node.health_check().await }).await;
-    assert!(node_ready);
-    octez_node
-}
-
-async fn import_bootstrap_keys(octez_client: &OctezClient) {
-    for (idx, key) in [
-        "unencrypted:edsk3gUfUPyBSfrS9CCgmCiQsTCHGkviBDusMxDJstFtojtc1zcpsh",
-        "unencrypted:edsk39qAm1fiMjgmPkw1EgQYkMzkJezLNewd7PLNHTkr6w9XA2zdfo",
-        "unencrypted:edsk4ArLQgBTLWG5FJmnGnT689VKoqhXwmDPBuGx3z4cvwU9MmrPZZ",
-        "unencrypted:edsk2uqQB9AY4FvioK2YMdfmyMrer5R8mGFyuaLLFfSRo8EoyNdht3",
-    ]
-    .iter()
-    .enumerate()
-    {
-        let alias = format!("bootstrap{}", idx + 1);
-        octez_client
-            .import_secret_key(&alias, key)
-            .await
-            .expect("Failed to generate bootstrap key");
-    }
-}
-
-async fn activate_alpha(octez_client: &OctezClient) {
-    // 3. import activator key
-    let activator = "activator".to_string();
-    octez_client
-        .import_secret_key(
-            &activator,
-            "unencrypted:edsk31vznjHSSpGExDMHYASz45VZqXN4DPxvsa4hAyY8dHM28cZzp6",
-        )
-        .await
-        .expect("Failed to generate activator key");
-    // 4. activate the alpha protocol
-    let params_file =
-        Path::new(std::env!("CARGO_MANIFEST_DIR")).join("tests/sandbox-params.json");
-    let protocol_activated = octez_client
-        .activate_protocol(
-            "ProtoALphaALphaALphaALphaALphaALphaALphaALphaDdp3zK",
-            "0",
-            &activator,
-            &params_file,
-        )
-        .await;
-    assert!(protocol_activated.is_ok());
-}
-
-async fn get_block_level(rpc_endpoint: &str) -> i32 {
-    let blocks_head_endpoint =
-        format!("{}/chains/main/blocks/head", rpc_endpoint.to_owned());
-    let response = get_request(&blocks_head_endpoint).await;
-    extract_level(&response)
-}
-
-fn extract_level(input: &str) -> i32 {
-    // Create a regex to match "level": followed by a number
-    let re = Regex::new(r#""level":\s*(\d+)"#).unwrap();
-    // Extract the number as a string and parse it to i32
-    re.captures(input)
-        .unwrap()
-        .get(1)
-        .map(|level_match| level_match.as_str().parse::<i32>().unwrap())
-        .unwrap()
 }

--- a/crates/jstzd/tests/octez_client_test.rs
+++ b/crates/jstzd/tests/octez_client_test.rs
@@ -1,10 +1,8 @@
 use jstz_crypto::public_key_hash::PublicKeyHash;
-use jstzd::task::{octez_node, Task};
-use octez::r#async::{
-    client::{OctezClientBuilder, Signature},
-    endpoint::Endpoint,
-    node_config::{OctezNodeConfigBuilder, OctezNodeRunOptionsBuilder},
-};
+use jstzd::task::Task;
+use octez::r#async::client::OctezClientBuilder;
+use octez::r#async::client::Signature;
+use octez::r#async::endpoint::Endpoint;
 use serde_json::Value;
 use std::{
     fs::{read_to_string, remove_file},
@@ -12,7 +10,11 @@ use std::{
 };
 use tempfile::{NamedTempFile, TempDir};
 mod utils;
-use utils::{get_request, retry};
+use std::path::PathBuf;
+use utils::{
+    activate_alpha, create_client, get_request, import_activator, spawn_octez_node,
+    SECRET_KEY,
+};
 
 fn read_file(path: &Path) -> Value {
     serde_json::from_str(&read_to_string(path).expect("Unable to read file"))
@@ -22,9 +24,6 @@ fn read_file(path: &Path) -> Value {
 fn first_item(json: Value) -> Value {
     json.as_array().unwrap()[0].clone()
 }
-
-const SECRET_KEY: &str =
-    "unencrypted:edsk31vznjHSSpGExDMHYASz45VZqXN4DPxvsa4hAyY8dHM28cZzp6";
 
 #[tokio::test]
 async fn config_init() {
@@ -52,12 +51,8 @@ async fn config_init() {
 
 #[tokio::test]
 async fn generates_keys() {
-    let temp_dir = TempDir::new().unwrap();
-    let base_dir = temp_dir.path().to_path_buf();
-    let octez_client = OctezClientBuilder::new()
-        .set_base_dir(base_dir.clone())
-        .build()
-        .unwrap();
+    let octez_client = create_client(&Endpoint::default());
+    let base_dir = PathBuf::try_from(octez_client.base_dir()).unwrap();
     let alias = "test_alias".to_string();
     let res = octez_client.gen_keys(&alias, None).await;
     assert!(res.is_ok());
@@ -71,12 +66,7 @@ async fn generates_keys() {
 
 #[tokio::test]
 async fn show_address() {
-    let temp_dir = TempDir::new().unwrap();
-    let base_dir = temp_dir.path().to_path_buf();
-    let octez_client = OctezClientBuilder::new()
-        .set_base_dir(base_dir.clone())
-        .build()
-        .unwrap();
+    let octez_client = create_client(&Endpoint::default());
     let alias = "test_alias".to_string();
     let _ = octez_client.gen_keys(&alias, None).await;
     let res = octez_client.show_address(&alias, false).await;
@@ -89,12 +79,7 @@ async fn show_address() {
 
 #[tokio::test]
 async fn show_address_with_secret_key() {
-    let temp_dir = TempDir::new().unwrap();
-    let base_dir = temp_dir.path().to_path_buf();
-    let octez_client = OctezClientBuilder::new()
-        .set_base_dir(base_dir.clone())
-        .build()
-        .unwrap();
+    let octez_client = create_client(&Endpoint::default());
     let alias = "test_alias".to_string();
     let _ = octez_client.gen_keys(&alias, None).await;
     let res = octez_client.show_address(&alias, true).await;
@@ -105,12 +90,7 @@ async fn show_address_with_secret_key() {
 
 #[tokio::test]
 async fn show_address_fails_for_non_existing_alias() {
-    let temp_dir = TempDir::new().unwrap();
-    let base_dir = temp_dir.path().to_path_buf();
-    let octez_client = OctezClientBuilder::new()
-        .set_base_dir(base_dir.clone())
-        .build()
-        .unwrap();
+    let octez_client = create_client(&Endpoint::default());
     let res = octez_client.show_address("test_alias", true).await;
     assert!(res.is_err_and(|e| e
         .to_string()
@@ -119,12 +99,8 @@ async fn show_address_fails_for_non_existing_alias() {
 
 #[tokio::test]
 async fn generates_keys_with_custom_signature() {
-    let temp_dir = TempDir::new().unwrap();
-    let base_dir = temp_dir.path().to_path_buf();
-    let octez_client = OctezClientBuilder::new()
-        .set_base_dir(base_dir.clone())
-        .build()
-        .unwrap();
+    let octez_client = create_client(&Endpoint::default());
+    let base_dir = PathBuf::try_from(octez_client.base_dir()).unwrap();
     let alias = "test_alias".to_string();
     let res = octez_client.gen_keys(&alias, Some(Signature::BLS)).await;
     assert!(res.is_ok());
@@ -146,12 +122,7 @@ async fn generates_keys_with_custom_signature() {
 
 #[tokio::test]
 async fn generates_keys_throws() {
-    let temp_dir = TempDir::new().unwrap();
-    let base_dir = temp_dir.path().to_path_buf();
-    let octez_client = OctezClientBuilder::new()
-        .set_base_dir(base_dir.clone())
-        .build()
-        .unwrap();
+    let octez_client = create_client(&Endpoint::default());
     let alias = "test_alias".to_string();
     let _ = octez_client.gen_keys(&alias, None).await;
     let res = octez_client.gen_keys(&alias, None).await;
@@ -160,12 +131,8 @@ async fn generates_keys_throws() {
 
 #[tokio::test]
 async fn imports_secret_key() {
-    let temp_dir = TempDir::new().unwrap();
-    let base_dir = temp_dir.path().to_path_buf();
-    let octez_client = OctezClientBuilder::new()
-        .set_base_dir(base_dir.clone())
-        .build()
-        .unwrap();
+    let octez_client = create_client(&Endpoint::default());
+    let base_dir = PathBuf::try_from(octez_client.base_dir()).unwrap();
     let alias = "test_alias".to_string();
     let res = octez_client.import_secret_key(&alias, SECRET_KEY).await;
     assert!(res.is_ok());
@@ -179,12 +146,7 @@ async fn imports_secret_key() {
 
 #[tokio::test]
 async fn imports_secret_key_throws() {
-    let temp_dir = TempDir::new().unwrap();
-    let base_dir = temp_dir.path().to_path_buf();
-    let octez_client = OctezClientBuilder::new()
-        .set_base_dir(base_dir.clone())
-        .build()
-        .unwrap();
+    let octez_client = create_client(&Endpoint::default());
     let alias = "test_alias".to_string();
     let _ = octez_client.import_secret_key(&alias, SECRET_KEY).await;
     let res = octez_client.import_secret_key(&alias, SECRET_KEY).await;
@@ -198,14 +160,7 @@ async fn get_balance() {
     // 1. start octez node
     let mut octez_node = spawn_octez_node().await;
     // 2. setup octez client
-    let temp_dir = TempDir::new().unwrap();
-    let base_dir = temp_dir.path().to_path_buf();
-    let rpc_endpoint = octez_node.rpc_endpoint();
-    let octez_client = OctezClientBuilder::new()
-        .set_endpoint(rpc_endpoint.clone())
-        .set_base_dir(base_dir.clone())
-        .build()
-        .unwrap();
+    let octez_client = create_client(octez_node.rpc_endpoint());
     // 3. import secret key for bootstrap1
     let bootstrap1 = "bootstrap1".to_string();
     octez_client
@@ -216,22 +171,9 @@ async fn get_balance() {
         .await
         .expect("Failed to generate activator key");
     // 4. activate the alpha protocol
-    let activator = "activator".to_string();
-    octez_client
-        .import_secret_key(&activator, SECRET_KEY)
-        .await
-        .expect("Failed to generate activator key");
-    let params_file =
-        Path::new(std::env!("CARGO_MANIFEST_DIR")).join("tests/sandbox-params.json");
-    let protocol_activated = octez_client
-        .activate_protocol(
-            "ProtoALphaALphaALphaALphaALphaALphaALphaALphaDdp3zK",
-            "0",
-            &activator,
-            &params_file,
-        )
-        .await;
-    assert!(protocol_activated.is_ok());
+    import_activator(&octez_client).await;
+    activate_alpha(&octez_client).await;
+
     // 5. check balance for bootstrap1
     let balance = octez_client.get_balance(&bootstrap1).await;
     assert!(balance.is_ok_and(|balance| balance == 3800000f64));
@@ -249,38 +191,20 @@ async fn activate_protocol() {
     // 1. start octez node
     let mut octez_node = spawn_octez_node().await;
     // 2. setup octez client
-    let temp_dir = TempDir::new().unwrap();
-    let base_dir = temp_dir.path().to_path_buf();
-    let rpc_endpoint = octez_node.rpc_endpoint();
-    let octez_client = OctezClientBuilder::new()
-        .set_endpoint(rpc_endpoint.clone())
-        .set_base_dir(base_dir.clone())
-        .build()
-        .unwrap();
+    let octez_client = create_client(octez_node.rpc_endpoint());
     // 3. import activator key
-    let activator = "activator".to_string();
-    octez_client
-        .import_secret_key(&activator, SECRET_KEY)
-        .await
-        .expect("Failed to generate activator key");
-    let params_file =
-        Path::new(std::env!("CARGO_MANIFEST_DIR")).join("tests/sandbox-params.json");
-    let blocks_head_endpoint = format!("{}/chains/main/blocks/head", rpc_endpoint);
+    import_activator(&octez_client).await;
+
+    let blocks_head_endpoint =
+        format!("{}/chains/main/blocks/head", octez_node.rpc_endpoint());
     let response = get_request(&blocks_head_endpoint).await;
     assert!(response.contains(
         "\"protocol\":\"PrihK96nBAFSxVL1GLJTVhu9YnzkMFiBeuJRPA8NwuZVZCE1L6i\""
     ));
     assert!(response.contains("\"level\":0"));
     // 4. activate the alpha protocol
-    let protocol_activated = octez_client
-        .activate_protocol(
-            "ProtoALphaALphaALphaALphaALphaALphaALphaALphaDdp3zK",
-            "0",
-            &activator,
-            &params_file,
-        )
-        .await;
-    assert!(protocol_activated.is_ok());
+    activate_alpha(&octez_client).await;
+
     // 5. check if the protocol is activated and the block is baked.
     // The block level progress indicates that the protocol has been activated.
     let response = get_request(&blocks_head_endpoint).await;
@@ -291,31 +215,11 @@ async fn activate_protocol() {
     let _ = octez_node.kill().await;
 }
 
-async fn spawn_octez_node() -> octez_node::OctezNode {
-    let mut config_builder = OctezNodeConfigBuilder::new();
-    let mut run_option_builder = OctezNodeRunOptionsBuilder::new();
-    config_builder
-        .set_binary_path("octez-node")
-        .set_network("sandbox")
-        .set_run_options(&run_option_builder.set_synchronisation_threshold(0).build());
-    let octez_node = octez_node::OctezNode::spawn(config_builder.build().unwrap())
-        .await
-        .unwrap();
-    let node_ready = retry(10, 1000, || async { octez_node.health_check().await }).await;
-    assert!(node_ready);
-    octez_node
-}
-
 #[tokio::test]
 async fn add_address() {
     let address =
         PublicKeyHash::from_base58("tz1cMWTNwecApUicCrHfTRwHEhBcZGjkUwCw").unwrap();
-    let temp_dir = TempDir::new().unwrap();
-    let base_dir = temp_dir.path().to_path_buf();
-    let octez_client = OctezClientBuilder::new()
-        .set_base_dir(base_dir.clone())
-        .build()
-        .unwrap();
+    let octez_client = create_client(&Endpoint::default());
     let alias = "test_alias".to_string();
     let res = octez_client.add_address(&alias, &address, false).await;
     assert!(res.is_ok());

--- a/crates/jstzd/tests/utils.rs
+++ b/crates/jstzd/tests/utils.rs
@@ -1,3 +1,18 @@
+#![allow(dead_code)]
+use jstzd::task::{octez_baker, octez_node::OctezNode, Task};
+use octez::r#async::{
+    baker::{BakerBinaryPath, OctezBakerConfigBuilder},
+    client::{OctezClient, OctezClientBuilder},
+    endpoint::Endpoint,
+    node_config::{OctezNodeConfigBuilder, OctezNodeRunOptionsBuilder},
+    protocol::Protocol,
+};
+use regex::Regex;
+use std::path::{Path, PathBuf};
+
+pub const SECRET_KEY: &str =
+    "unencrypted:edsk31vznjHSSpGExDMHYASz45VZqXN4DPxvsa4hAyY8dHM28cZzp6";
+
 pub async fn retry<'a, F>(retries: u16, interval_ms: u64, f: impl Fn() -> F) -> bool
 where
     F: std::future::Future<Output = anyhow::Result<bool>> + Send + 'a,
@@ -14,7 +29,130 @@ where
     false
 }
 
-#[allow(dead_code)]
+pub async fn setup() -> (OctezNode, OctezClient, octez_baker::OctezBaker) {
+    let octez_node = spawn_octez_node().await;
+    let octez_client = create_client(octez_node.rpc_endpoint());
+
+    import_bootstrap_keys(&octez_client).await;
+    import_activator(&octez_client).await;
+    activate_alpha(&octez_client).await;
+
+    let baker = spawn_baker(&octez_node, &octez_client).await;
+    (octez_node, octez_client, baker)
+}
+
+pub async fn spawn_baker(
+    octez_node: &OctezNode,
+    octez_client: &OctezClient,
+) -> octez_baker::OctezBaker {
+    let baker_config = OctezBakerConfigBuilder::new()
+        .set_binary_path(BakerBinaryPath::Env(Protocol::Alpha))
+        .set_octez_client_base_dir(
+            PathBuf::try_from(octez_client.base_dir())
+                .unwrap()
+                .to_str()
+                .unwrap(),
+        )
+        .set_octez_node_data_dir(octez_node.data_dir().to_str().unwrap())
+        .set_octez_node_endpoint(octez_node.rpc_endpoint())
+        .build()
+        .expect("Failed to build baker config");
+    // check if the block is baked
+    let baker_node = octez_baker::OctezBaker::spawn(baker_config)
+        .await
+        .expect("SHOULD RUN");
+    assert!(baker_node.health_check().await.unwrap());
+    let node_endpoint = octez_node.rpc_endpoint();
+    let block_baked = retry(10, 1000, || async {
+        let level = get_block_level(&node_endpoint.to_string()).await;
+        Ok(level > 1)
+    })
+    .await;
+    assert!(block_baked);
+    baker_node
+}
+
+pub async fn spawn_octez_node() -> OctezNode {
+    let mut config_builder = OctezNodeConfigBuilder::new();
+    let mut run_option_builder = OctezNodeRunOptionsBuilder::new();
+    config_builder
+        .set_binary_path("octez-node")
+        .set_network("sandbox")
+        .set_run_options(&run_option_builder.set_synchronisation_threshold(0).build());
+    let octez_node = OctezNode::spawn(config_builder.build().unwrap())
+        .await
+        .unwrap();
+    let node_ready = retry(10, 1000, || async { octez_node.health_check().await }).await;
+    assert!(node_ready);
+    octez_node
+}
+
+pub fn create_client(node_endpoint: &Endpoint) -> OctezClient {
+    OctezClientBuilder::new()
+        .set_endpoint(node_endpoint.clone())
+        .build()
+        .unwrap()
+}
+
+pub async fn get_block_level(rpc_endpoint: &str) -> i32 {
+    let blocks_head_endpoint =
+        format!("{}/chains/main/blocks/head", rpc_endpoint.to_owned());
+    let response = get_request(&blocks_head_endpoint).await;
+    extract_level(&response)
+}
+
+fn extract_level(input: &str) -> i32 {
+    // Create a regex to match "level": followed by a number
+    let re = Regex::new(r#""level":\s*(\d+)"#).unwrap();
+    // Extract the number as a string and parse it to i32
+    re.captures(input)
+        .unwrap()
+        .get(1)
+        .map(|level_match| level_match.as_str().parse::<i32>().unwrap())
+        .unwrap()
+}
+
+pub async fn import_bootstrap_keys(octez_client: &OctezClient) {
+    for (idx, key) in [
+        "unencrypted:edsk3gUfUPyBSfrS9CCgmCiQsTCHGkviBDusMxDJstFtojtc1zcpsh",
+        "unencrypted:edsk39qAm1fiMjgmPkw1EgQYkMzkJezLNewd7PLNHTkr6w9XA2zdfo",
+        "unencrypted:edsk4ArLQgBTLWG5FJmnGnT689VKoqhXwmDPBuGx3z4cvwU9MmrPZZ",
+        "unencrypted:edsk2uqQB9AY4FvioK2YMdfmyMrer5R8mGFyuaLLFfSRo8EoyNdht3",
+        "unencrypted:edsk4QLrcijEffxV31gGdN2HU7UpyJjA8drFoNcmnB28n89YjPNRFm",
+    ]
+    .iter()
+    .enumerate()
+    {
+        let alias = format!("bootstrap{}", idx + 1);
+        octez_client
+            .import_secret_key(&alias, key)
+            .await
+            .expect("Failed to generate bootstrap key");
+    }
+}
+
+pub async fn import_activator(octez_client: &OctezClient) {
+    let activator = "activator".to_string();
+    octez_client
+        .import_secret_key(&activator, SECRET_KEY)
+        .await
+        .expect("Failed to generate activator key");
+}
+
+pub async fn activate_alpha(octez_client: &OctezClient) {
+    let params_file =
+        Path::new(std::env!("CARGO_MANIFEST_DIR")).join("tests/sandbox-params.json");
+    let protocol_activated = octez_client
+        .activate_protocol(
+            "ProtoALphaALphaALphaALphaALphaALphaALphaALphaDdp3zK",
+            "0",
+            "activator",
+            &params_file,
+        )
+        .await;
+    assert!(protocol_activated.is_ok());
+}
+
 pub async fn get_request(endpoint: &str) -> String {
     reqwest::get(endpoint).await.unwrap().text().await.unwrap()
 }


### PR DESCRIPTION
# Context

Pulling common parts out of integration test cases since we have too many of them now.

# Description

Test cases for octez-client usually require setting up the node and the client. These steps are pretty much identical for those test cases and thus can be moved into the utils module, which makes those test cases neater.

Somehow clippy complains that the utils module is not used, so `#![allow(dead_code)]` is added to that entire module.

# Manually testing the PR

All existing test cases should pass.
