### PR TITLE
feat(jstzd): implement wait_for

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2736,6 +2736,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tezos_crypto_rs 0.6.0",
  "tokio",
 ]
 

--- a/crates/jstzd/Cargo.toml
+++ b/crates/jstzd/Cargo.toml
@@ -23,6 +23,7 @@ tokio.workspace = true
 
 [dev-dependencies]
 rand.workspace = true
+tezos_crypto_rs.workspace = true
 
 [[bin]]
 name = "jstzd"

--- a/crates/jstzd/tests/utils.rs
+++ b/crates/jstzd/tests/utils.rs
@@ -9,6 +9,7 @@ use octez::r#async::{
 };
 use regex::Regex;
 use std::path::{Path, PathBuf};
+use tezos_crypto_rs::hash::BlockHash;
 
 pub const SECRET_KEY: &str =
     "unencrypted:edsk31vznjHSSpGExDMHYASz45VZqXN4DPxvsa4hAyY8dHM28cZzp6";
@@ -109,6 +110,23 @@ fn extract_level(input: &str) -> i32 {
         .get(1)
         .map(|level_match| level_match.as_str().parse::<i32>().unwrap())
         .unwrap()
+}
+
+pub async fn get_head_block_hash(rpc_endpoint: &str) -> BlockHash {
+    let blocks_head_endpoint =
+        format!("{}/chains/main/blocks/head", rpc_endpoint.to_owned());
+    let response = get_request(&blocks_head_endpoint).await;
+    BlockHash::from_base58_check(
+        serde_json::from_str::<serde_json::Value>(&response)
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .get("hash")
+            .unwrap()
+            .as_str()
+            .unwrap(),
+    )
+    .unwrap()
 }
 
 pub async fn import_bootstrap_keys(octez_client: &OctezClient) {

--- a/crates/octez/Cargo.toml
+++ b/crates/octez/Cargo.toml
@@ -27,5 +27,4 @@ signal-hook.workspace = true
 tempfile.workspace = true
 tezos_crypto_rs.workspace = true
 tezos-smart-rollup-encoding.workspace = true
-tezos_crypto_rs.workspace = true
 tokio.workspace = true


### PR DESCRIPTION
# Context

Completes JSTZ-142.
[JSTZ-142](https://linear.app/tezos/issue/JSTZ-142/implement-octezclientwait-for)

# Description

Implements `octez-client wait for <op_hash>`.

# Manually testing the PR

* Integration test: added one test case
```sh
$ cargo test --test octez_client_test originate_contract_and_wait_for
running 1 test                                                                                                                                                        
< truncated baker logs >
test originate_contract_and_wait_for ... ok                                                               
                                                                                                                                                                      
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 14 filtered out; finished in 6.69s
```
