### PR TITLE
feat(openapi): switch to openapi router and add scalar API docs to js…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build
         run: nix --accept-flake-config --log-format raw -L build -j auto .#{all,js_jstz}
       - name: Flake check
-        run: nix --accept-flake-config --log-format raw -L flake check -j auto
+        run: nix --accept-flake-config --log-format raw --log-lines 70 -L flake check -j auto
       # Coverage is part of nix flake check, but we want to upload it to Codecov
       # So we run it again (it's cached) and upload the result
       - name: Coverage

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -85,36 +85,36 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -736,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "console"
@@ -1028,6 +1028,12 @@ dependencies = [
  "thiserror",
  "zeroize",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -1866,9 +1872,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2350,6 +2356,7 @@ dependencies = [
  "log",
  "octez",
  "parking_lot",
+ "pretty_assertions",
  "r2d2",
  "r2d2_sqlite",
  "reqwest",
@@ -2365,6 +2372,9 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tower-http",
+ "utoipa",
+ "utoipa-axum",
+ "utoipa-scalar",
 ]
 
 [[package]]
@@ -2480,9 +2490,9 @@ checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libredox"
@@ -3079,18 +3089,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3099,9 +3109,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -3153,6 +3163,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -3425,9 +3445,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3619,9 +3639,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -3787,9 +3807,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.213"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
+checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
 dependencies = [
  "serde_derive",
 ]
@@ -3807,9 +3827,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.213"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
+checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3818,9 +3838,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "itoa",
  "memchr",
@@ -4302,7 +4322,7 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 [[package]]
 name = "tezos-smart-rollup"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#554fe2dcb752cb525661ac35fc99541083ef7428"
+source = "git+https://gitlab.com/tezos/tezos.git#8a755d1327c53bf9e4c313f8b99fb80f6566a24b"
 dependencies = [
  "hermit",
  "hex",
@@ -4321,12 +4341,12 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-constants"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#554fe2dcb752cb525661ac35fc99541083ef7428"
+source = "git+https://gitlab.com/tezos/tezos.git#8a755d1327c53bf9e4c313f8b99fb80f6566a24b"
 
 [[package]]
 name = "tezos-smart-rollup-core"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#554fe2dcb752cb525661ac35fc99541083ef7428"
+source = "git+https://gitlab.com/tezos/tezos.git#8a755d1327c53bf9e4c313f8b99fb80f6566a24b"
 dependencies = [
  "tezos-smart-rollup-constants",
 ]
@@ -4334,7 +4354,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-debug"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#554fe2dcb752cb525661ac35fc99541083ef7428"
+source = "git+https://gitlab.com/tezos/tezos.git#8a755d1327c53bf9e4c313f8b99fb80f6566a24b"
 dependencies = [
  "tezos-smart-rollup-core",
  "tezos-smart-rollup-host",
@@ -4343,7 +4363,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-encoding"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#554fe2dcb752cb525661ac35fc99541083ef7428"
+source = "git+https://gitlab.com/tezos/tezos.git#8a755d1327c53bf9e4c313f8b99fb80f6566a24b"
 dependencies = [
  "hex",
  "nom",
@@ -4362,7 +4382,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-entrypoint"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#554fe2dcb752cb525661ac35fc99541083ef7428"
+source = "git+https://gitlab.com/tezos/tezos.git#8a755d1327c53bf9e4c313f8b99fb80f6566a24b"
 dependencies = [
  "cfg-if",
  "dlmalloc",
@@ -4375,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-host"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#554fe2dcb752cb525661ac35fc99541083ef7428"
+source = "git+https://gitlab.com/tezos/tezos.git#8a755d1327c53bf9e4c313f8b99fb80f6566a24b"
 dependencies = [
  "tezos-smart-rollup-core",
  "tezos_crypto_rs 0.6.0",
@@ -4421,7 +4441,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-macros"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#554fe2dcb752cb525661ac35fc99541083ef7428"
+source = "git+https://gitlab.com/tezos/tezos.git#8a755d1327c53bf9e4c313f8b99fb80f6566a24b"
 dependencies = [
  "proc-macro-error2",
  "quote",
@@ -4432,7 +4452,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-mock"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#554fe2dcb752cb525661ac35fc99541083ef7428"
+source = "git+https://gitlab.com/tezos/tezos.git#8a755d1327c53bf9e4c313f8b99fb80f6566a24b"
 dependencies = [
  "hex",
  "tezos-smart-rollup-core",
@@ -4445,15 +4465,16 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-panic-hook"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#554fe2dcb752cb525661ac35fc99541083ef7428"
+source = "git+https://gitlab.com/tezos/tezos.git#8a755d1327c53bf9e4c313f8b99fb80f6566a24b"
 dependencies = [
+ "rustversion",
  "tezos-smart-rollup-core",
 ]
 
 [[package]]
 name = "tezos-smart-rollup-storage"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#554fe2dcb752cb525661ac35fc99541083ef7428"
+source = "git+https://gitlab.com/tezos/tezos.git#8a755d1327c53bf9e4c313f8b99fb80f6566a24b"
 dependencies = [
  "tezos-smart-rollup-core",
  "tezos-smart-rollup-debug",
@@ -5013,6 +5034,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "utoipa"
+version = "5.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d9ba0ade4e2f024cd1842dfbaf9dbc540639fc082299acf7649d71bd14eaca3"
+dependencies = [
+ "indexmap 2.6.0",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-axum"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1370cc4a8eee751c4d2a729566d83d1568212320a20581c7c72c2d76ab80ed37"
+dependencies = [
+ "axum",
+ "paste",
+ "tower-layer",
+ "tower-service",
+ "utoipa",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf390d6503c9c9eac988447c38ba934a707b0b768b14511a493b4fc0e8ecb00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.85",
+]
+
+[[package]]
+name = "utoipa-scalar"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1291aa7a2223c2f8399d1c6627ca0ba57ca0d7ecac762a2094a9dfd6376445a"
+dependencies = [
+ "axum",
+ "serde",
+ "serde_json",
+ "utoipa",
+]
+
+[[package]]
 name = "uuid"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5147,9 +5217,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
 dependencies = [
  "futures-util",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ nom = "7.1.3"
 num-traits = "0.2.16"
 parking_lot = "0.12.1"
 prettytable = "0.10.0"
+pretty_assertions = "1.4.1"
 proptest = "1.1"
 rand = "0.8"
 regex = "1"
@@ -101,6 +102,9 @@ tokio-util = "0.7.10"
 tower-http = { version = "0.6.1", features = ["cors"] }
 url = "2.4.1"
 urlpattern = "0.2.0"
+utoipa = { version = "5.1.3", features = ["axum_extras"] }
+utoipa-axum = "0.1.1"
+utoipa-scalar = { version = "0.2.0", features = ["axum"] }
 wasm-bindgen = "0.2.92"
 
 [workspace.dependencies.tezos-smart-rollup]

--- a/crates/jstz_node/Cargo.toml
+++ b/crates/jstz_node/Cargo.toml
@@ -9,6 +9,7 @@ documentation.workspace = true
 readme.workspace = true
 license-file.workspace = true
 description.workspace = true
+include = ["openapi.json", "src", "tests"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -44,6 +45,12 @@ tokio-stream.workspace = true
 tokio-util.workspace = true
 tokio.workspace = true
 tower-http.workspace = true
+utoipa.workspace = true
+utoipa-axum.workspace = true
+utoipa-scalar.workspace = true
+
+[dev-dependencies]
+pretty_assertions.workspace = true
 
 [[bin]]
 name = "jstz-node"

--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -1,0 +1,18 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Jstz Node",
+    "description": "JavaScript server runtime for Tezos Smart Rollups",
+    "contact": {
+      "name": "Trilitech",
+      "email": "contact@trili.tech"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "https://github.com/jstz-dev/jstz/blob/main/LICENSE"
+    },
+    "version": "0.1.0-alpha.0"
+  },
+  "paths": {},
+  "components": {}
+}

--- a/crates/jstz_node/src/api_doc.rs
+++ b/crates/jstz_node/src/api_doc.rs
@@ -1,0 +1,13 @@
+use utoipa::OpenApi;
+
+#[derive(OpenApi)]
+#[openapi(info(
+    title = "Jstz Node",
+    description = "JavaScript server runtime for Tezos Smart Rollups",
+    license(
+        name = "MIT",
+        url = "https://github.com/jstz-dev/jstz/blob/main/LICENSE"
+    ),
+    contact(name = "Trilitech", email = "contact@trili.tech"),
+))]
+pub struct ApiDoc;

--- a/crates/jstz_node/src/services/accounts.rs
+++ b/crates/jstz_node/src/services/accounts.rs
@@ -2,11 +2,12 @@ use anyhow::anyhow;
 use axum::{
     extract::{Path, Query, State},
     routing::get,
-    Json, Router,
+    Json,
 };
 use jstz_api::KvValue;
 use jstz_proto::context::account::{Account, Nonce, ParsedCode};
 use serde::Deserialize;
+use utoipa_axum::router::OpenApiRouter;
 
 use super::{
     error::{ServiceError, ServiceResult},
@@ -112,14 +113,14 @@ async fn kv_subkeys(
 }
 
 impl Service for AccountsService {
-    fn router() -> Router<AppState> {
-        let routes = Router::new()
+    fn router_with_openapi() -> OpenApiRouter<AppState> {
+        let routes = OpenApiRouter::new()
             .route("/:address/nonce", get(nonce))
             .route("/:address/code", get(code))
             .route("/:address/balance", get(balance))
             .route("/:address/kv", get(kv))
             .route("/:address/kv/subkeys", get(kv_subkeys));
 
-        Router::new().nest("/accounts", routes)
+        OpenApiRouter::new().nest("/accounts", routes)
     }
 }

--- a/crates/jstz_node/src/services/logs/mod.rs
+++ b/crates/jstz_node/src/services/logs/mod.rs
@@ -5,7 +5,6 @@ use axum::{
     extract::{Path, State},
     response::Sse,
     routing::get,
-    Router,
 };
 use broadcaster::InfallibleSSeStream;
 #[cfg(feature = "persistent-logging")]
@@ -18,6 +17,7 @@ use jstz_proto::{
 };
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
+use utoipa_axum::router::OpenApiRouter;
 
 use crate::{tailed_file::TailedFile, AppState, Service};
 
@@ -138,9 +138,8 @@ use super::error::{ServiceError, ServiceResult};
 pub struct LogsService;
 
 impl Service for LogsService {
-    fn router() -> Router<AppState> {
-        let routes = Router::new().route("/:address/stream", get(stream_log));
-
+    fn router_with_openapi() -> OpenApiRouter<AppState> {
+        let routes = OpenApiRouter::new().route("/:address/stream", get(stream_log));
         #[cfg(feature = "persistent-logging")]
         let routes = routes
             .route("/:address/persistent/requests", get(persistent_logs))
@@ -148,7 +147,7 @@ impl Service for LogsService {
                 "/:address/persistent/requests/:request_id",
                 get(persistent_logs_by_request_id),
             );
-        Router::new().nest("/logs", routes)
+        OpenApiRouter::new().nest("/logs", routes)
     }
 }
 

--- a/crates/jstz_node/src/services/mod.rs
+++ b/crates/jstz_node/src/services/mod.rs
@@ -1,6 +1,6 @@
 use crate::AppState;
 
-use axum::Router;
+use utoipa_axum::router::OpenApiRouter;
 
 pub mod accounts;
 pub mod error;
@@ -8,5 +8,5 @@ pub mod logs;
 pub mod operations;
 
 pub trait Service {
-    fn router() -> Router<AppState>;
+    fn router_with_openapi() -> OpenApiRouter<AppState>;
 }

--- a/crates/jstz_node/src/services/operations.rs
+++ b/crates/jstz_node/src/services/operations.rs
@@ -1,14 +1,17 @@
 use super::error::{ServiceError, ServiceResult};
 use super::{AppState, Service};
 use anyhow::anyhow;
+use axum::routing::{get, post};
 use axum::{
     extract::{Path, State},
-    routing::{get, post},
-    Json, Router,
+    Json,
 };
-use jstz_proto::{operation::SignedOperation, receipt::Receipt};
+use jstz_proto::operation::SignedOperation;
+use jstz_proto::receipt::Receipt;
 use tezos_data_encoding::enc::BinWriter;
 use tezos_smart_rollup::inbox::ExternalMessageFrame;
+
+use utoipa_axum::router::OpenApiRouter;
 
 pub struct OperationsService;
 
@@ -49,11 +52,11 @@ async fn receipt(
 }
 
 impl Service for OperationsService {
-    fn router() -> Router<AppState> {
-        let routes = Router::new()
+    fn router_with_openapi() -> OpenApiRouter<AppState> {
+        let routes = OpenApiRouter::new()
             .route("/", post(inject))
             .route("/:operation_hash/receipt", get(receipt));
 
-        Router::new().nest("/operations", routes)
+        OpenApiRouter::new().nest("/operations", routes)
     }
 }

--- a/crates/jstz_node/tests/api_doc.rs
+++ b/crates/jstz_node/tests/api_doc.rs
@@ -1,0 +1,17 @@
+use std::path::PathBuf;
+
+use pretty_assertions::assert_eq;
+
+#[test]
+fn api_doc_regression() {
+    let _ = include_str!("../openapi.json");
+    let filename = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("openapi.json");
+    let current_spec = std::fs::read_to_string(filename).unwrap();
+    let current_spec = current_spec.trim();
+    let generated_spec = jstz_node::openapi_json_raw().unwrap();
+    assert_eq!(
+        current_spec,
+        generated_spec,
+        "API doc regression detected. Run the 'spec' command to update:\n\tcargo run --bin jstz-node -- spec -o crates/jstz_node/openapi.json"
+    );
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     command: >
       -c "mkdir -p /roots/logs &&
           touch /roots/logs/kernel.log &&
-          usr/bin/jstz-node --rollup-endpoint http://rollup:8932 --kernel-log-path /root/logs/kernel.log --addr 0.0.0.0"
+          usr/bin/jstz-node run --rollup-endpoint http://rollup:8932 --kernel-log-path /root/logs/kernel.log --addr 0.0.0.0"
     restart: always
     ports:
       - 8933:8933


### PR DESCRIPTION
# Context
This PR makes the `OpenApiRouter` as the base router for axum routes and introduces the `ApiDoc` type that will hold top level information about the OAS spec. This PR is in preparation for:

* https://linear.app/tezos/issue/JSTZ-158/implement-openapi-for-operationsservice
* https://linear.app/tezos/issue/JSTZ-157/implement-openapi-for-accountservice
* https://linear.app/tezos/issue/JSTZ-159/implement-openapi-for-logservice

Closes:  [JSTZ-156](https://linear.app/tezos/issue/JSTZ-156/implement-openapi-router-base-struct)

# Description
Besides the changes above, this PR also regression checks the generated `openapi.json` spec. A `jstz-node spec` command has been implemented to make it convenient for generating the spec.

# Manual Testing
Spec can be tested with:
```
cargo test -p jstz_node
```
Scalar docs:
```
cargo run -- sandbox start
# browse to http://localhost:8933/scalar
```
