### PR TITLE
feat(jstz_node): implement openapi for operations service

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,3 +12,5 @@
 
 # Lock files
 **/*.lock
+
+crates/jstz_node/openapi.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,6 +2753,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tezos_crypto_rs 0.6.0",
+ "utoipa",
 ]
 
 [[package]]
@@ -2855,6 +2856,7 @@ dependencies = [
  "tezos-smart-rollup-mock",
  "tezos_crypto_rs 0.6.0",
  "tezos_data_encoding 0.6.0",
+ "utoipa",
 ]
 
 [[package]]
@@ -5630,6 +5632,7 @@ dependencies = [
  "quote",
  "regex",
  "syn 2.0.85",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ tokio-util = "0.7.10"
 tower-http = { version = "0.6.1", features = ["cors"] }
 url = "2.4.1"
 urlpattern = "0.2.0"
-utoipa = { version = "5.1.3", features = ["axum_extras"] }
+utoipa = { version = "5.1.3", features = ["axum_extras", "url"] }
 utoipa-axum = "0.1.1"
 utoipa-scalar = { version = "0.2.0", features = ["axum"] }
 wasm-bindgen = "0.2.92"

--- a/crates/jstz_cli/src/deploy.rs
+++ b/crates/jstz_cli/src/deploy.rs
@@ -2,7 +2,7 @@ use boa_engine::JsError;
 use jstz_proto::{
     context::account::ParsedCode,
     operation::{Content, DeployFunction, Operation, SignedOperation},
-    receipt::Content as ReceiptContent,
+    receipt::ReceiptContent,
 };
 use log::{debug, info};
 

--- a/crates/jstz_cli/src/run.rs
+++ b/crates/jstz_cli/src/run.rs
@@ -6,7 +6,7 @@ use jstz_proto::context::account::Address;
 use jstz_proto::executor::JSTZ_HOST;
 use jstz_proto::{
     operation::{Content as OperationContent, Operation, RunFunction, SignedOperation},
-    receipt::Content as ReceiptContent,
+    receipt::ReceiptContent,
 };
 use log::{debug, info};
 use spinners::{Spinner, Spinners};

--- a/crates/jstz_crypto/Cargo.toml
+++ b/crates/jstz_crypto/Cargo.toml
@@ -18,6 +18,7 @@ hex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tezos_crypto_rs.workspace = true
+utoipa.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/jstz_crypto/src/public_key.rs
+++ b/crates/jstz_crypto/src/public_key.rs
@@ -3,13 +3,30 @@ use std::fmt::{self, Display};
 
 use serde::{Deserialize, Serialize};
 use tezos_crypto_rs::hash::{PublicKeyEd25519, PublicKeyP256, PublicKeySecp256k1};
+use utoipa::ToSchema;
 
 // FIXME: https://linear.app/tezos/issue/JSTZ-169/support-bls-in-risc-v
 // Add BLS support
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+/// Tezos public key
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, ToSchema)]
 pub enum PublicKey {
+    #[schema(
+        title = "Ed25519",
+        value_type = String,
+        example = json!({ "Ed25519": "edpkukK9ecWxib28zi52nvbXTdsYt8rYcvmt5bdH8KjipWXm8sH3Qi" })
+    )]
     Ed25519(PublicKeyEd25519),
+    #[schema(
+        title = "Secp256k1",
+        value_type = String,
+        example = json!({ "Secp256k1": "sppk7aMwoVDiMGXkzwqPMrqHNE6QrZ1vAJ2CvTEeGZRLSSTM8jogmKY" })
+    )]
     Secp256k1(PublicKeySecp256k1),
+    #[schema(
+        title = "P256",
+        value_type = String,
+        example = json!({ "P256": "p2pk67ArUx3aDGyFgRco8N3pTnnnbodpP2FMZLAewV6ZAVvCxKjW3Q1" })
+    )]
     P256(PublicKeyP256),
 }
 

--- a/crates/jstz_crypto/src/public_key_hash.rs
+++ b/crates/jstz_crypto/src/public_key_hash.rs
@@ -7,18 +7,45 @@ use tezos_crypto_rs::{
     hash::{ContractTz1Hash, ContractTz2Hash, ContractTz3Hash, HashTrait},
     PublicKeyWithHash,
 };
+use utoipa::ToSchema;
 
 use crate::{
     error::{Error, Result},
     public_key::PublicKey,
 };
 
+/// Tezos Address
 #[derive(
-    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Finalize,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    Finalize,
+    ToSchema,
 )]
 pub enum PublicKeyHash {
+    #[schema(
+        title = "Tz1",
+        value_type = String,
+        example = json!({ "Tz1": "tz1cD5CuvAALcxgypqBXcBQEA8dkLJivoFjU" })
+    )]
     Tz1(ContractTz1Hash),
+    #[schema(
+        title = "Tz2",
+        value_type = String,
+        example =  json!({ "Tz2": "tz2KDvEL9fuvytRfe1cVVDo1QfDfaBktGNkh" })
+    )]
     Tz2(ContractTz2Hash),
+    #[schema(
+        title = "Tz3",
+        value_type = String,
+        example = json!({ "Tz3": "tz3QxNCB8HgxJyp5V9ZmCVGcTm6BzYc14k9C" })
+    )]
     Tz3(ContractTz3Hash),
 }
 

--- a/crates/jstz_crypto/src/signature.rs
+++ b/crates/jstz_crypto/src/signature.rs
@@ -1,14 +1,31 @@
 use std::fmt::Display;
 
+use crate::{public_key::PublicKey, Error, Result};
 use serde::{Deserialize, Serialize};
 use tezos_crypto_rs::{CryptoError, PublicKeySignatureVerifier};
+use utoipa::ToSchema;
 
-use crate::{public_key::PublicKey, Error, Result};
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, ToSchema,
+)]
 pub enum Signature {
+    #[schema(
+        title = "Ed25519 signature", 
+        value_type = String,
+        example = json!({ "Ed25519": "edsigtpe2oRBMFdrrwf99ETNjmBaRzNDexDjhancfQdz5phrwyPPhRi9L7kzJD4cAW1fFcsyTJcTDPP8W4H168QPQdGPKe7jrZB" }
+    ))]
     Ed25519(tezos_crypto_rs::hash::Ed25519Signature),
+    #[schema(
+        title = "Secp256k1 signature", 
+        value_type = String,
+        example = json!({ "Secp256k1": "spsig1NajZUT4nSiWU7UiV98fmmsjApFFYwPHtiDiJfGMgGL6oP3U9SPEccTfhAPdnAcvJ6AUSQ8EBPxYNX4UeNNDLBxVg9qv5H" })
+    )]
     Secp256k1(tezos_crypto_rs::hash::Secp256k1Signature),
+    #[schema(
+        title = "P256 signature", 
+        value_type = String,
+        example = json!({ "P256": "p2signEdtYeHXyWfCaGej9AFv7QraDsunRimyK47YGBQRNDEPXPQctwjPxbyFbTUtVLsACzG8QTrLAxddjjTRikF3nThwKL8nH" })
+    )]
     P256(tezos_crypto_rs::hash::P256Signature),
 }
 

--- a/crates/jstz_node/Cargo.toml
+++ b/crates/jstz_node/Cargo.toml
@@ -25,8 +25,8 @@ env_logger.workspace = true
 futures-util.workspace = true
 hex.workspace = true
 jstz_api = { path = "../jstz_api" }
-jstz_crypto = { path = "../jstz_crypto" }
-jstz_proto = { path = "../jstz_proto" }
+jstz_crypto = { path = "../jstz_crypto", features = ["openapi"] }
+jstz_proto = { path = "../jstz_proto", features = ["openapi"] }
 log.workspace = true
 octez = { path = "../octez" }
 parking_lot.workspace = true

--- a/crates/jstz_node/Cargo.toml
+++ b/crates/jstz_node/Cargo.toml
@@ -25,8 +25,8 @@ env_logger.workspace = true
 futures-util.workspace = true
 hex.workspace = true
 jstz_api = { path = "../jstz_api" }
-jstz_crypto = { path = "../jstz_crypto", features = ["openapi"] }
-jstz_proto = { path = "../jstz_proto", features = ["openapi"] }
+jstz_crypto = { path = "../jstz_crypto" }
+jstz_proto = { path = "../jstz_proto" }
 log.workspace = true
 octez = { path = "../octez" }
 parking_lot.workspace = true

--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -13,6 +13,551 @@
     },
     "version": "0.1.0-alpha.0"
   },
-  "paths": {},
-  "components": {}
+  "paths": {
+    "/operations": {
+      "post": {
+        "tags": [
+          "Operations"
+        ],
+        "summary": "Inject an operation into Jstz",
+        "operationId": "inject",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SignedOperation"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Operation successfully injectedd"
+          },
+          "400": {
+            "description": ""
+          },
+          "500": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/operations/{operation_hash}/receipt": {
+      "get": {
+        "tags": [
+          "Operations"
+        ],
+        "summary": "Get the receipt of an operation",
+        "operationId": "receipt",
+        "parameters": [
+          {
+            "name": "operation_hash",
+            "in": "path",
+            "description": "Operation hash",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Receipt"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": ""
+          },
+          "500": {
+            "description": ""
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Content": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "DeployFunction"
+            ],
+            "properties": {
+              "DeployFunction": {
+                "$ref": "#/components/schemas/DeployFunction"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "RunFunction"
+            ],
+            "properties": {
+              "RunFunction": {
+                "$ref": "#/components/schemas/RunFunction"
+              }
+            }
+          }
+        ]
+      },
+      "DeployFunction": {
+        "type": "object",
+        "required": [
+          "function_code",
+          "account_credit"
+        ],
+        "properties": {
+          "account_credit": {
+            "$ref": "#/components/schemas/u64",
+            "description": "Amount of tez to credit to the smart function account, debited from the sender"
+          },
+          "function_code": {
+            "$ref": "#/components/schemas/ParsedCode",
+            "description": "Smart function code"
+          }
+        }
+      },
+      "DeployFunctionReceipt": {
+        "type": "object",
+        "required": [
+          "address"
+        ],
+        "properties": {
+          "address": {
+            "$ref": "#/components/schemas/PublicKeyHash"
+          }
+        }
+      },
+      "FaDepositReceipt": {
+        "type": "object",
+        "required": [
+          "receiver",
+          "ticket_balance"
+        ],
+        "properties": {
+          "receiver": {
+            "$ref": "#/components/schemas/PublicKeyHash"
+          },
+          "run_function": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RunFunctionReceipt"
+              }
+            ]
+          },
+          "ticket_balance": {
+            "$ref": "#/components/schemas/u64"
+          }
+        }
+      },
+      "FaWithdrawReceipt": {
+        "type": "object",
+        "required": [
+          "source",
+          "outbox_message_id"
+        ],
+        "properties": {
+          "outbox_message_id": {
+            "$ref": "#/components/schemas/String"
+          },
+          "source": {
+            "$ref": "#/components/schemas/PublicKeyHash"
+          }
+        }
+      },
+      "Nonce": {
+        "type": "integer",
+        "format": "int64",
+        "minimum": 0
+      },
+      "Operation": {
+        "type": "object",
+        "required": [
+          "source",
+          "nonce",
+          "content"
+        ],
+        "properties": {
+          "content": {
+            "$ref": "#/components/schemas/Content"
+          },
+          "nonce": {
+            "$ref": "#/components/schemas/Nonce"
+          },
+          "source": {
+            "$ref": "#/components/schemas/PublicKeyHash"
+          }
+        }
+      },
+      "ParsedCode": {
+        "type": "string",
+        "format": "javascript",
+        "example": "export default (request) => new Response('Hello world!')"
+      },
+      "PublicKey": {
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "Ed25519",
+            "required": [
+              "Ed25519"
+            ],
+            "properties": {
+              "Ed25519": {
+                "type": "string"
+              }
+            },
+            "example": {
+              "Ed25519": "edpkukK9ecWxib28zi52nvbXTdsYt8rYcvmt5bdH8KjipWXm8sH3Qi"
+            }
+          },
+          {
+            "type": "object",
+            "title": "Secp256k1",
+            "required": [
+              "Secp256k1"
+            ],
+            "properties": {
+              "Secp256k1": {
+                "type": "string"
+              }
+            },
+            "example": {
+              "Secp256k1": "sppk7aMwoVDiMGXkzwqPMrqHNE6QrZ1vAJ2CvTEeGZRLSSTM8jogmKY"
+            }
+          },
+          {
+            "type": "object",
+            "title": "P256",
+            "required": [
+              "P256"
+            ],
+            "properties": {
+              "P256": {
+                "type": "string"
+              }
+            },
+            "example": {
+              "P256": "p2pk67ArUx3aDGyFgRco8N3pTnnnbodpP2FMZLAewV6ZAVvCxKjW3Q1"
+            }
+          }
+        ],
+        "description": "Tezos public key"
+      },
+      "PublicKeyHash": {
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "Tz1",
+            "required": [
+              "Tz1"
+            ],
+            "properties": {
+              "Tz1": {
+                "type": "string"
+              }
+            },
+            "example": {
+              "Tz1": "tz1cD5CuvAALcxgypqBXcBQEA8dkLJivoFjU"
+            }
+          },
+          {
+            "type": "object",
+            "title": "Tz2",
+            "required": [
+              "Tz2"
+            ],
+            "properties": {
+              "Tz2": {
+                "type": "string"
+              }
+            },
+            "example": {
+              "Tz2": "tz2KDvEL9fuvytRfe1cVVDo1QfDfaBktGNkh"
+            }
+          },
+          {
+            "type": "object",
+            "title": "Tz3",
+            "required": [
+              "Tz3"
+            ],
+            "properties": {
+              "Tz3": {
+                "type": "string"
+              }
+            },
+            "example": {
+              "Tz3": "tz3QxNCB8HgxJyp5V9ZmCVGcTm6BzYc14k9C"
+            }
+          }
+        ],
+        "description": "Tezos Address"
+      },
+      "Receipt": {
+        "type": "object",
+        "required": [
+          "hash",
+          "inner"
+        ],
+        "properties": {
+          "hash": {
+            "type": "string"
+          },
+          "inner": {
+            "$ref": "#/components/schemas/ReceiptResult_ReceiptContent"
+          }
+        }
+      },
+      "ReceiptResult_ReceiptContent": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "Ok"
+            ],
+            "properties": {
+              "Ok": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "required": [
+                      "DeployFunction"
+                    ],
+                    "properties": {
+                      "DeployFunction": {
+                        "$ref": "#/components/schemas/DeployFunctionReceipt"
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "required": [
+                      "RunFunction"
+                    ],
+                    "properties": {
+                      "RunFunction": {
+                        "$ref": "#/components/schemas/RunFunctionReceipt"
+                      }
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "enum": [
+                      "Deposit"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "required": [
+                      "FaDeposit"
+                    ],
+                    "properties": {
+                      "FaDeposit": {
+                        "$ref": "#/components/schemas/FaDepositReceipt"
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "required": [
+                      "FaWithdraw"
+                    ],
+                    "properties": {
+                      "FaWithdraw": {
+                        "$ref": "#/components/schemas/FaWithdrawReceipt"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "Err"
+            ],
+            "properties": {
+              "Err": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "RunFunction": {
+        "type": "object",
+        "description": "Request used to run a smart function. The target smart function is given by the host part of the uri. The rest of the attributes will be handled by the smart function itself.",
+        "required": [
+          "uri",
+          "method",
+          "headers",
+          "body",
+          "gas_limit"
+        ],
+        "properties": {
+          "body": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          "gas_limit": {
+            "type": "integer",
+            "description": "Maximum amount of gas that is allowed for the execution of this operation",
+            "minimum": 0
+          },
+          "headers": {
+            "type": "object",
+            "description": "Any valid HTTP headers"
+          },
+          "method": {
+            "type": "string",
+            "description": "Any valid HTTP method",
+            "examples": [
+              "GET",
+              "POST",
+              "PUT",
+              "UPDATE",
+              "DELETE"
+            ]
+          },
+          "uri": {
+            "type": "string",
+            "format": "uri",
+            "description": "Smart function URI in the form tezos://{smart_function_address}/rest/of/path",
+            "examples": [
+              "tezos://tz1cD5CuvAALcxgypqBXcBQEA8dkLJivoFjU/nfts?status=sold"
+            ]
+          }
+        }
+      },
+      "RunFunctionReceipt": {
+        "type": "object",
+        "required": [
+          "body",
+          "status_code",
+          "headers"
+        ],
+        "properties": {
+          "body": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          "headers": {
+            "type": "object",
+            "description": "Any valid HTTP headers"
+          },
+          "status_code": {
+            "type": "integer",
+            "description": "Valid status code",
+            "minimum": 0
+          }
+        }
+      },
+      "Signature": {
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "Ed25519 signature",
+            "required": [
+              "Ed25519"
+            ],
+            "properties": {
+              "Ed25519": {
+                "type": "string"
+              }
+            },
+            "example": {
+              "Ed25519": "edsigtpe2oRBMFdrrwf99ETNjmBaRzNDexDjhancfQdz5phrwyPPhRi9L7kzJD4cAW1fFcsyTJcTDPP8W4H168QPQdGPKe7jrZB"
+            }
+          },
+          {
+            "type": "object",
+            "title": "Secp256k1 signature",
+            "required": [
+              "Secp256k1"
+            ],
+            "properties": {
+              "Secp256k1": {
+                "type": "string"
+              }
+            },
+            "example": {
+              "Secp256k1": "spsig1NajZUT4nSiWU7UiV98fmmsjApFFYwPHtiDiJfGMgGL6oP3U9SPEccTfhAPdnAcvJ6AUSQ8EBPxYNX4UeNNDLBxVg9qv5H"
+            }
+          },
+          {
+            "type": "object",
+            "title": "P256 signature",
+            "required": [
+              "P256"
+            ],
+            "properties": {
+              "P256": {
+                "type": "string"
+              }
+            },
+            "example": {
+              "P256": "p2signEdtYeHXyWfCaGej9AFv7QraDsunRimyK47YGBQRNDEPXPQctwjPxbyFbTUtVLsACzG8QTrLAxddjjTRikF3nThwKL8nH"
+            }
+          }
+        ]
+      },
+      "SignedOperation": {
+        "type": "object",
+        "required": [
+          "public_key",
+          "signature",
+          "inner"
+        ],
+        "properties": {
+          "inner": {
+            "$ref": "#/components/schemas/Operation"
+          },
+          "public_key": {
+            "$ref": "#/components/schemas/PublicKey"
+          },
+          "signature": {
+            "$ref": "#/components/schemas/Signature"
+          }
+        }
+      },
+      "String": {
+        "type": "string"
+      },
+      "u64": {
+        "type": "integer",
+        "format": "int64",
+        "minimum": 0
+      }
+    }
+  }
 }

--- a/crates/jstz_proto/Cargo.toml
+++ b/crates/jstz_proto/Cargo.toml
@@ -26,6 +26,7 @@ serde_json.workspace = true
 tezos_crypto_rs.workspace = true
 tezos_data_encoding.workspace = true
 tezos-smart-rollup.workspace = true
+utoipa.workspace = true
 
 [dev-dependencies]
 jstz_mock = { path = "../jstz_mock" }

--- a/crates/jstz_proto/src/context/account.rs
+++ b/crates/jstz_proto/src/context/account.rs
@@ -3,6 +3,7 @@ use std::{
     result,
 };
 
+use crate::error::{Error, Result};
 use boa_engine::{Context, JsError, JsResult, Module, Source};
 use jstz_core::{
     host::HostRuntime,
@@ -11,14 +12,15 @@ use jstz_core::{
 use jstz_crypto::public_key_hash::PublicKeyHash;
 use serde::{Deserialize, Serialize};
 use tezos_smart_rollup::storage::path::{self, OwnedPath, RefPath};
-
-use crate::error::{Error, Result};
+use utoipa::ToSchema;
 
 pub type Address = PublicKeyHash;
 
 pub type Amount = u64;
 
-#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(
+    Clone, Copy, Default, Debug, PartialEq, Eq, Serialize, Deserialize, ToSchema,
+)]
 pub struct Nonce(u64);
 
 impl Nonce {
@@ -37,8 +39,12 @@ impl Display for Nonce {
     }
 }
 
-/// Invariant: if code is present it parses successfully
-#[derive(Default, PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
+// Invariant: if code is present it parses successfully
+#[derive(Default, PartialEq, Eq, Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[schema(
+    format = "javascript",
+    example = "export default (request) => new Response('Hello world!')"
+)]
 pub struct ParsedCode(String);
 impl From<ParsedCode> for String {
     fn from(ParsedCode(code): ParsedCode) -> Self {

--- a/crates/jstz_proto/src/executor/deposit.rs
+++ b/crates/jstz_proto/src/executor/deposit.rs
@@ -14,5 +14,8 @@ pub fn execute(
 
     let result = Account::add_balance(hrt, tx, &receiver, amount);
     let hash = Blake2b::from(deposit.inbox_id.to_be_bytes().as_slice());
-    Receipt::new(hash, result.map(|_| crate::receipt::Content::Deposit))
+    Receipt::new(
+        hash,
+        result.map(|_| crate::receipt::ReceiptContent::Deposit),
+    )
 }

--- a/crates/jstz_proto/src/executor/mod.rs
+++ b/crates/jstz_proto/src/executor/mod.rs
@@ -19,7 +19,7 @@ fn execute_operation_inner(
     tx: &mut Transaction,
     signed_operation: SignedOperation,
     ticketer: &ContractKt1Hash,
-) -> Result<receipt::Content> {
+) -> Result<receipt::ReceiptContent> {
     let operation = signed_operation.verify()?;
     let operation_hash = operation.hash();
 
@@ -33,7 +33,7 @@ fn execute_operation_inner(
         } => {
             let result = smart_function::deploy::execute(hrt, tx, &source, deployment)?;
 
-            Ok(receipt::Content::DeployFunction(result))
+            Ok(receipt::ReceiptContent::DeployFunction(result))
         }
 
         Operation {
@@ -47,7 +47,7 @@ fn execute_operation_inner(
                 }
                 _ => smart_function::run::execute(hrt, tx, &source, run, operation_hash)?,
             };
-            Ok(receipt::Content::RunFunction(result))
+            Ok(receipt::ReceiptContent::RunFunction(result))
         }
     }
 }

--- a/crates/jstz_proto/src/executor/smart_function.rs
+++ b/crates/jstz_proto/src/executor/smart_function.rs
@@ -372,7 +372,7 @@ impl HostScript {
     }
 
     fn create_response_from_run_receipt(
-        run_receipt: receipt::RunFunction,
+        run_receipt: receipt::RunFunctionReceipt,
         context: &mut Context,
     ) -> JsResult<Response> {
         let body = Body::from_http_body(run_receipt.body, context)?;
@@ -449,7 +449,7 @@ pub mod run {
         source: &Address,
         run: operation::RunFunction,
         operation_hash: OperationHash,
-    ) -> Result<receipt::RunFunction> {
+    ) -> Result<receipt::RunFunctionReceipt> {
         let operation::RunFunction {
             uri,
             method,
@@ -510,7 +510,7 @@ pub mod run {
 
         let (http_parts, body) = Response::to_http_response(&response).into_parts();
 
-        Ok(receipt::RunFunction {
+        Ok(receipt::RunFunctionReceipt {
             body,
             status_code: http_parts.status,
             headers: http_parts.headers,
@@ -562,7 +562,7 @@ pub mod jstz_run {
         ticketer: &ContractKt1Hash,
         source: &Address,
         run: RunFunction,
-    ) -> Result<receipt::RunFunction> {
+    ) -> Result<receipt::RunFunctionReceipt> {
         let uri = run.uri.clone();
         if uri.host() != Some(JSTZ_HOST) {
             return Err(Error::InvalidHost);
@@ -576,7 +576,7 @@ pub mod jstz_run {
                 crate::executor::withdraw::execute_withdraw(
                     hrt, tx, source, withdrawal, ticketer,
                 )?;
-                let receipt = receipt::RunFunction {
+                let receipt = receipt::RunFunctionReceipt {
                     body: None,
                     status_code: http::StatusCode::OK,
                     headers: http::HeaderMap::new(),
@@ -588,7 +588,7 @@ pub mod jstz_run {
                 let fa_withdraw_receipt_content = fa_withdraw.execute(
                     hrt, tx, source, 1000, // fake gas limit
                 )?;
-                let receipt = receipt::RunFunction {
+                let receipt = receipt::RunFunctionReceipt {
                     body: fa_withdraw_receipt_content.to_http_body(),
                     status_code: http::StatusCode::OK,
                     headers: http::HeaderMap::new(),
@@ -604,7 +604,7 @@ pub mod jstz_run {
         tx: &mut Transaction,
         source: &Address,
         run: RunFunction,
-    ) -> Result<receipt::RunFunction> {
+    ) -> Result<receipt::RunFunctionReceipt> {
         let ticketer_path = OwnedPath::from(&RefPath::assert_from(b"/ticketer"));
         let ticketer: ContractKt1Hash =
             Storage::get(hrt, &ticketer_path)?.expect("ticketer should be set");
@@ -907,7 +907,7 @@ pub mod deploy {
         tx: &mut Transaction,
         source: &Address,
         deployment: operation::DeployFunction,
-    ) -> Result<receipt::DeployFunction> {
+    ) -> Result<receipt::DeployFunctionReceipt> {
         let operation::DeployFunction {
             function_code,
             account_credit,
@@ -915,6 +915,6 @@ pub mod deploy {
 
         let address = Script::deploy(hrt, tx, source, function_code, account_credit)?;
 
-        Ok(receipt::DeployFunction { address })
+        Ok(receipt::DeployFunctionReceipt { address })
     }
 }

--- a/crates/jstz_proto/src/receipt.rs
+++ b/crates/jstz_proto/src/receipt.rs
@@ -1,26 +1,27 @@
 use http::{HeaderMap, StatusCode};
 use jstz_api::http::body::HttpBody;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use crate::{
     context::account::Address,
-    executor::{
-        fa_deposit::FaDepositReceiptContent, fa_withdraw::FaWithdrawReceiptContent,
-    },
+    executor::{fa_deposit::FaDepositReceipt, fa_withdraw::FaWithdrawReceipt},
     operation::OperationHash,
     Result,
 };
 
 pub type ReceiptResult<T> = std::result::Result<T, String>;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct Receipt {
+    #[schema(value_type = String)]
     hash: OperationHash,
-    pub inner: ReceiptResult<Content>,
+    #[schema(value_type = openapi::ReceiptResult<ReceiptContent>)]
+    pub inner: ReceiptResult<ReceiptContent>,
 }
 
 impl Receipt {
-    pub fn new(hash: OperationHash, inner: Result<Content>) -> Self {
+    pub fn new(hash: OperationHash, inner: Result<ReceiptContent>) -> Self {
         let inner = inner.map_err(|e| e.to_string());
         Self { hash, inner }
     }
@@ -30,25 +31,41 @@ impl Receipt {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DeployFunction {
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct DeployFunctionReceipt {
     pub address: Address,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RunFunction {
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct RunFunctionReceipt {
+    #[schema(schema_with = crate::operation::openapi::http_body_schema)]
     pub body: HttpBody,
+    /// Valid status code
     #[serde(with = "http_serde::status_code")]
+    #[schema(value_type = usize)]
     pub status_code: StatusCode,
+    /// Any valid HTTP headers
     #[serde(with = "http_serde::header_map")]
+    #[schema(value_type = Object, additional_properties)]
     pub headers: HeaderMap,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum Content {
-    DeployFunction(DeployFunction),
-    RunFunction(RunFunction),
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub enum ReceiptContent {
+    DeployFunction(DeployFunctionReceipt),
+    RunFunction(RunFunctionReceipt),
     Deposit,
-    FaDeposit(FaDepositReceiptContent),
-    FaWithdraw(FaWithdrawReceiptContent),
+    FaDeposit(FaDepositReceipt),
+    FaWithdraw(FaWithdrawReceipt),
+}
+
+mod openapi {
+    use utoipa::ToSchema;
+
+    #[allow(dead_code)]
+    #[derive(ToSchema)]
+    pub enum ReceiptResult<T: ToSchema> {
+        Ok(T),
+        Err(String),
+    }
 }


### PR DESCRIPTION
# Context
Adds OpenAPI schema for paths in `OperationService`

# Description
Added `ToSchema` definitions to types that used in the request and response objects of the `OperationService`, namely `SignedOperation` and `Receipt`. The `ToSchema` trait was auto derived where it made sense but for many types, this was not possible and annotating fields was the cleanest way to do it. Annotations also force developers to update the schema when the type changes in the future.

Type names in `jstz_proto` for `receipt` module had to be changed because they would override the types of similar names in the `operation` module.

Added `ToSchema` derivation for types in `jstz_crypto` crate.

# Manual testing
```
cargo test -p jstz_nodecargo test -p jstz_node
```

```
cargo run -- sandbox start 
# browse to localhost:8933/scalar to view Scalar API doc
```