### PR TITLE
fix(octez): use fixed default port for octez node

### DIFF
--- a/crates/jstzd/tests/utils.rs
+++ b/crates/jstzd/tests/utils.rs
@@ -1,11 +1,14 @@
 #![allow(dead_code)]
 use jstzd::task::{octez_baker, octez_node::OctezNode, Task};
-use octez::r#async::{
-    baker::{BakerBinaryPath, OctezBakerConfigBuilder},
-    client::{OctezClient, OctezClientBuilder},
-    endpoint::Endpoint,
-    node_config::{OctezNodeConfigBuilder, OctezNodeRunOptionsBuilder},
-    protocol::Protocol,
+use octez::{
+    r#async::{
+        baker::{BakerBinaryPath, OctezBakerConfigBuilder},
+        client::{OctezClient, OctezClientBuilder},
+        endpoint::Endpoint,
+        node_config::{OctezNodeConfigBuilder, OctezNodeRunOptionsBuilder},
+        protocol::Protocol,
+    },
+    unused_port,
 };
 use regex::Regex;
 use std::path::{Path, PathBuf};
@@ -78,6 +81,8 @@ pub async fn spawn_octez_node() -> OctezNode {
     config_builder
         .set_binary_path("octez-node")
         .set_network("sandbox")
+        .set_rpc_endpoint(&Endpoint::localhost(unused_port()))
+        .set_p2p_endpoint(&Endpoint::localhost(unused_port()))
         .set_run_options(&run_option_builder.set_synchronisation_threshold(0).build());
     let octez_node = OctezNode::spawn(config_builder.build().unwrap())
         .await

--- a/crates/octez/src/async/node_config.rs
+++ b/crates/octez/src/async/node_config.rs
@@ -1,4 +1,3 @@
-use crate::unused_port;
 use anyhow::Result;
 use std::{
     fmt::{self, Display, Formatter},
@@ -10,6 +9,8 @@ use super::endpoint::Endpoint;
 
 const DEFAULT_NETWORK: &str = "sandbox";
 const DEFAULT_BINARY_PATH: &str = "octez-node";
+const DEFAULT_RPC_PORT: u16 = 8732;
+const DEFAULT_P2P_PORT: u16 = 9732;
 const LOCAL_ADDRESS: &str = "127.0.0.1";
 
 #[derive(Clone, PartialEq, Debug)]
@@ -181,11 +182,14 @@ impl OctezNodeConfigBuilder {
             rpc_endpoint: self
                 .rpc_endpoint
                 .take()
-                .unwrap_or(Endpoint::localhost(unused_port())),
+                .unwrap_or(Endpoint::localhost(DEFAULT_RPC_PORT)),
             p2p_address: self.p2p_endpoint.take().unwrap_or(
                 Endpoint::try_from(
-                    http::Uri::from_str(&format!("{}:{}", LOCAL_ADDRESS, unused_port()))
-                        .unwrap(),
+                    http::Uri::from_str(&format!(
+                        "{}:{}",
+                        LOCAL_ADDRESS, DEFAULT_P2P_PORT
+                    ))
+                    .unwrap(),
                 )
                 .unwrap(),
             ),
@@ -226,6 +230,11 @@ mod tests {
         let config = OctezNodeConfigBuilder::new().build().unwrap();
         assert_eq!(config.binary_path, PathBuf::from(DEFAULT_BINARY_PATH));
         assert_eq!(config.network, DEFAULT_NETWORK.to_owned());
+        assert_eq!(config.rpc_endpoint, Endpoint::localhost(DEFAULT_RPC_PORT));
+        assert_eq!(
+            config.p2p_address,
+            Endpoint::try_from(http::Uri::from_static("127.0.0.1:9732")).unwrap()
+        );
         assert_eq!(config.run_options, OctezNodeRunOptions::default());
     }
 


### PR DESCRIPTION
# Context

A minor patch for JSTZ-116.

# Description

Use fixed default port numbers for octez node. Previously random port numbers were used as default port numbers to avoid collision during tests, but normally users only run one instance and thus it should be fine to use the default port number `8732`. This also aligns with the client's behaviour where it connects to `localhost:8732` when RPC endpoint is not set in the config builder.

Test cases are updated so that endpoints are manually set.

# Manually testing the PR

All existing test cases should pass.
