### PR TITLE
remove default trait, endpoint for octez node

### DIFF
--- a/crates/jstzd/src/task/octez_node.rs
+++ b/crates/jstzd/src/task/octez_node.rs
@@ -9,7 +9,7 @@ use octez::r#async::node_config::OctezNodeConfig;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct OctezNode {
     inner: SharedChildWrapper,
     config: OctezNodeConfig,

--- a/crates/jstzd/tests/octez_client_test.rs
+++ b/crates/jstzd/tests/octez_client_test.rs
@@ -32,9 +32,8 @@ async fn config_init() {
     let expected_endpoint = Endpoint::localhost(3000);
     let config_file = NamedTempFile::new().unwrap();
     let _ = remove_file(config_file.path());
-    let octez_client = OctezClientBuilder::new()
+    let octez_client = OctezClientBuilder::new(expected_endpoint.clone())
         .set_base_dir(expected_base_dir.clone())
-        .set_endpoint(expected_endpoint.clone())
         .build()
         .unwrap();
     let res = octez_client.config_init(config_file.path()).await;

--- a/crates/jstzd/tests/utils.rs
+++ b/crates/jstzd/tests/utils.rs
@@ -88,8 +88,7 @@ pub async fn spawn_octez_node() -> OctezNode {
 }
 
 pub fn create_client(node_endpoint: &Endpoint) -> OctezClient {
-    OctezClientBuilder::new()
-        .set_endpoint(node_endpoint.clone())
+    OctezClientBuilder::new(node_endpoint.clone())
         .build()
         .unwrap()
 }

--- a/crates/octez/src/async/node.rs
+++ b/crates/octez/src/async/node.rs
@@ -8,8 +8,6 @@ use anyhow::Result;
 
 use super::{endpoint::Endpoint, node_config::OctezNodeRunOptions};
 
-pub const DEFAULT_RPC_ENDPOINT: &str = "localhost:8732";
-
 pub struct OctezNode {
     /// Path to the octez-node binary
     /// If None, the binary will inside PATH will be used

--- a/crates/octez/src/async/node_config.rs
+++ b/crates/octez/src/async/node_config.rs
@@ -94,7 +94,7 @@ impl OctezNodeRunOptionsBuilder {
     }
 }
 
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct OctezNodeConfig {
     /// Path to the octez node binary.
     pub binary_path: PathBuf,


### PR DESCRIPTION
# Context

 It’s simpler to make the node endpoint of the client builder required so we don’t have to think about the default behavior. 
 Will make a separate PR for the baker 
 
# Description

* clean up the config builder 
* the client will not have a fallback default endpoint


# Manually testing the PR

existing tests pass
