### PR TITLE
fix(octez): allow float in octez rollup node

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -72,6 +72,7 @@
               (old.patches or [])
               ++ [
                 ./nix/patches/0001-fix-octez-rust-deps-for-nix.patch
+                ./nix/patches/0002-allow-floats-in-wasm-rollup.patch
               ];
 
             # Network access for fetching cargo dependencies is disabled in sandboxed

--- a/nix/patches/0002-allow-floats-in-wasm-rollup.patch
+++ b/nix/patches/0002-allow-floats-in-wasm-rollup.patch
@@ -1,0 +1,66 @@
+diff --git a/src/lib_scoru_wasm/fast/module_cache.ml b/src/lib_scoru_wasm/fast/module_cache.ml
+index 92ab9996c8..42960b9bd9 100644
+--- a/src/lib_scoru_wasm/fast/module_cache.ml
++++ b/src/lib_scoru_wasm/fast/module_cache.ml
+@@ -55,7 +55,7 @@ let load_parse_module ~hooks store key durable =
+           (fun () ->
+             let* _ast =
+               Tezos_webassembly_interpreter.Decode.decode
+-                ~allow_floats:false
++                ~allow_floats:true
+                 ~name:"boot.wasm"
+                 ~bytes:kernel
+             in
+diff --git a/src/lib_scoru_wasm/wasm_vm.ml b/src/lib_scoru_wasm/wasm_vm.ml
+index 62b8ef3104..3cc1efb96f 100644
+--- a/src/lib_scoru_wasm/wasm_vm.ml
++++ b/src/lib_scoru_wasm/wasm_vm.ml
+@@ -220,7 +220,7 @@ let unsafe_next_tick_state ~wasm_entrypoint ~version ~stack_size_limit
+       let* kernel = Durable.find_value_exn durable Constants.kernel_key in
+       let* m =
+         Tezos_webassembly_interpreter.Decode.module_step
+-          ~allow_floats:false
++          ~allow_floats:true
+           kernel
+           m
+       in
+diff --git a/src/lib_wasm_debugger/wasm_debugger.ml b/src/lib_wasm_debugger/wasm_debugger.ml
+index 4a0748f917..612bd3e500 100644
+--- a/src/lib_wasm_debugger/wasm_debugger.ml
++++ b/src/lib_wasm_debugger/wasm_debugger.ml
+@@ -28,7 +28,7 @@ module Make (Wasm : Wasm_utils_intf.S) = struct
+ 
+   let parse_binary_module name module_ =
+     let bytes = Tezos_lazy_containers.Chunked_byte_vector.of_string module_ in
+-    Tezos_webassembly_interpreter.Decode.decode ~allow_floats:false ~name ~bytes
++    Tezos_webassembly_interpreter.Decode.decode ~allow_floats:true ~name ~bytes
+ 
+   (* [typecheck_module module_ast] runs the typechecker on the module, which is
+      not done by the PVM. *)
+diff --git a/src/lib_wasmer/api_funcs_desc.ml b/src/lib_wasmer/api_funcs_desc.ml
+index 40e1a1612c..8b3f776f2e 100644
+--- a/src/lib_wasmer/api_funcs_desc.ml
++++ b/src/lib_wasmer/api_funcs_desc.ml
+@@ -160,6 +160,12 @@ module Functions (S : FOREIGN) = struct
+         "wasm_config_set_features"
+         (ptr Types.Config.t @-> ptr Types.Wasmer.Features.t @-> returning void)
+ 
++    let canonicalize_nans =
++      foreign
++        "wasm_config_canonicalize_nans"
++        (ptr Types.Config.t @-> bool @-> returning void)
++    
++
+     let delete =
+       foreign "wasm_config_delete" (ptr Types.Config.t @-> returning void)
+   end
+diff --git a/src/lib_wasmer/config.ml b/src/lib_wasmer/config.ml
+index e32b7203bc..8f5fbca586 100644
+--- a/src/lib_wasmer/config.ml
++++ b/src/lib_wasmer/config.ml
+@@ -62,4 +62,5 @@ let to_owned desc =
+   if not has_compiler then raise (Compiler_unavailable desc.compiler) ;
+   Functions.Config.set_compiler conf desc.compiler ;
+   Functions.Config.set_features conf (make_features ()) ;
++  Functions.Config.canonicalize_nans conf true ;
+   conf


### PR DESCRIPTION
# Context
Floats are disallowed by default in the wasmer run by the rollup due to an Etherlink constraint. This PR adds a patch to allow that within jstz. 

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->
