### PR TITLE
feat: add `jstz_engine` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,6 +309,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.6.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.85",
+ "which",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,7 +423,7 @@ dependencies = [
  "icu_normalizer",
  "indexmap 2.6.0",
  "intrusive-collections",
- "itertools",
+ "itertools 0.13.0",
  "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
@@ -596,12 +617,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
+name = "calendrical_calculations"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cec493b209a1b81fa32312d7ceca1b547d341c7b5f16a3edbf32b1d8b455bbdf"
+dependencies = [
+ "core_maths",
+ "displaydoc",
+]
+
+[[package]]
 name = "cc"
 version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -635,6 +675,17 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -741,6 +792,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "colored"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "console"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,6 +835,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core_maths"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b02505ccb8c50b0aa21ace0fc08c3e53adebd4e58caa18a36152803c7709a3"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -1056,6 +1126,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "diplomat"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3137c640d2bac491dbfca7f9945c948f888dd8c95bdf7ee6b164fbdfa5d3efc2"
+dependencies = [
+ "diplomat_core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+]
+
+[[package]]
+name = "diplomat-runtime"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29f9efe348e178ba77b6035bc6629138486f8b461654e7ac7ad8afaa61bd4d98"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "diplomat_core"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7aca1d8f9e7b73ad61785beedc9556ad79f84b15c15abaa7041377e42284c1"
+dependencies = [
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "smallvec",
+ "strck_ident",
+ "syn 2.0.85",
+]
+
+[[package]]
 name = "dirs"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,6 +1316,24 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding_c"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9af727805f3b0d79956bde5b35732669fb5c5d45a94893798e7b7e70cfbf9cc1"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
+name = "encoding_c_mem"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a80a16821fe8c7cab96e0c67b57cd7090e021e9615e6ce6ab0cf866c44ed1f0"
+dependencies = [
+ "encoding_rs",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -1394,6 +1518,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixed_decimal"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0febbeb1118a9ecdee6e4520ead6b54882e843dd0592ad233247dbee84c53db8"
+dependencies = [
+ "displaydoc",
+ "ryu",
+ "smallvec",
+ "writeable",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,6 +1702,12 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "group"
@@ -1928,6 +2070,109 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_calendar"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7265b2137f9a36f7634a308d91f984574bbdba8cfd95ceffe1c345552275a8ff"
+dependencies = [
+ "calendrical_calculations",
+ "displaydoc",
+ "icu_calendar_data",
+ "icu_locid",
+ "icu_locid_transform",
+ "icu_provider",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_calendar_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e009b7f0151ee6fb28c40b1283594397e0b7183820793e9ace3dcd13db126d0"
+
+[[package]]
+name = "icu_capi"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f73a82a8307633c08ca119631cd90b006e448009da2d4466f7d76ca8fedf3b1"
+dependencies = [
+ "diplomat",
+ "diplomat-runtime",
+ "fixed_decimal",
+ "icu_calendar",
+ "icu_casemap",
+ "icu_collator",
+ "icu_collections",
+ "icu_datetime",
+ "icu_decimal",
+ "icu_experimental",
+ "icu_list",
+ "icu_locid",
+ "icu_locid_transform",
+ "icu_normalizer",
+ "icu_plurals",
+ "icu_properties",
+ "icu_provider",
+ "icu_provider_adapters",
+ "icu_segmenter",
+ "icu_timezone",
+ "log",
+ "simple_logger",
+ "tinystr",
+ "unicode-bidi",
+ "writeable",
+]
+
+[[package]]
+name = "icu_casemap"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff0c8ae9f8d31b12e27fc385ff9ab1f3cd9b17417c665c49e4ec958c37da75f"
+dependencies = [
+ "displaydoc",
+ "icu_casemap_data",
+ "icu_collections",
+ "icu_locid",
+ "icu_properties",
+ "icu_provider",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_casemap_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d57966d5ab748f74513be4046867f9a20e801e2775d41f91d04a0f560b61f08"
+
+[[package]]
+name = "icu_collator"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d370371887d31d56f361c3eaa15743e54f13bc677059c9191c77e099ed6966b2"
+dependencies = [
+ "displaydoc",
+ "icu_collator_data",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_normalizer",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_collator_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee3f88741364b7d6269cce6827a3e6a8a2cf408a78f766c9224ab479d5e4ae5"
+
+[[package]]
 name = "icu_collections"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1938,6 +2183,111 @@ dependencies = [
  "zerofrom",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_datetime"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d115efb85e08df3fd77e77f52e7e087545a783fffba8be80bfa2102f306b1780"
+dependencies = [
+ "displaydoc",
+ "either",
+ "fixed_decimal",
+ "icu_calendar",
+ "icu_datetime_data",
+ "icu_decimal",
+ "icu_locid",
+ "icu_locid_transform",
+ "icu_plurals",
+ "icu_provider",
+ "icu_timezone",
+ "smallvec",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_datetime_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ba7e7f7a01269b9afb0a39eff4f8676f693b55f509b3120e43a0350a9f88bea"
+
+[[package]]
+name = "icu_decimal"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb8fd98f86ec0448d85e1edf8884e4e318bb2e121bd733ec929a05c0a5e8b0eb"
+dependencies = [
+ "displaydoc",
+ "fixed_decimal",
+ "icu_decimal_data",
+ "icu_locid_transform",
+ "icu_provider",
+ "writeable",
+]
+
+[[package]]
+name = "icu_decimal_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d424c994071c6f5644f999925fc868c85fec82295326e75ad5017bc94b41523"
+
+[[package]]
+name = "icu_experimental"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "844ad7b682a165c758065d694bc4d74ac67f176da1c499a04d85d492c0f193b7"
+dependencies = [
+ "displaydoc",
+ "fixed_decimal",
+ "icu_collections",
+ "icu_decimal",
+ "icu_experimental_data",
+ "icu_locid",
+ "icu_locid_transform",
+ "icu_normalizer",
+ "icu_pattern",
+ "icu_plurals",
+ "icu_properties",
+ "icu_provider",
+ "litemap",
+ "num-bigint 0.4.6",
+ "num-rational",
+ "num-traits",
+ "smallvec",
+ "tinystr",
+ "writeable",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_experimental_data"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c178b9a34083fca5bd70d61f647575335e9c197d0f30c38e8ccd187babc69d0"
+
+[[package]]
+name = "icu_list"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfeda1d7775b6548edd4e8b7562304a559a91ed56ab56e18961a053f367c365"
+dependencies = [
+ "displaydoc",
+ "icu_list_data",
+ "icu_locid_transform",
+ "icu_provider",
+ "regex-automata 0.2.0",
+ "writeable",
+]
+
+[[package]]
+name = "icu_list_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1825170d2c6679cb20dbd96a589d034e49f698aed9a2ef4fafc9a0101ed298f"
 
 [[package]]
 name = "icu_locid"
@@ -1997,6 +2347,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
 
 [[package]]
+name = "icu_pattern"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f36aafd098d6717de34e668a8120822275c1fba22b936e757b7de8a2fd7e4"
+dependencies = [
+ "displaydoc",
+ "either",
+ "writeable",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "icu_plurals"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a70e7c025dbd5c501b0a5c188cd11666a424f0dadcd4f0a95b7dafde3b114"
+dependencies = [
+ "displaydoc",
+ "fixed_decimal",
+ "icu_locid_transform",
+ "icu_plurals_data",
+ "icu_provider",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_plurals_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3e8f775b215d45838814a090a2227247a7431d74e9156407d9c37f6ef0f208"
+
+[[package]]
 name = "icu_properties"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2008,6 +2391,7 @@ dependencies = [
  "icu_properties_data",
  "icu_provider",
  "tinystr",
+ "unicode-bidi",
  "zerovec",
 ]
 
@@ -2026,11 +2410,25 @@ dependencies = [
  "displaydoc",
  "icu_locid",
  "icu_provider_macros",
+ "log",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_adapters"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6324dfd08348a8e0374a447ebd334044d766b1839bb8d5ccf2482a99a77c0bc"
+dependencies = [
+ "icu_locid",
+ "icu_locid_transform",
+ "icu_provider",
+ "tinystr",
  "zerovec",
 ]
 
@@ -2044,6 +2442,49 @@ dependencies = [
  "quote",
  "syn 2.0.85",
 ]
+
+[[package]]
+name = "icu_segmenter"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a717725612346ffc2d7b42c94b820db6908048f39434504cb130e8b46256b0de"
+dependencies = [
+ "core_maths",
+ "displaydoc",
+ "icu_collections",
+ "icu_locid",
+ "icu_provider",
+ "icu_segmenter_data",
+ "utf8_iter",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_segmenter_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f739ee737260d955e330bc83fdeaaf1631f7fb7ed218761d3c04bb13bb7d79df"
+
+[[package]]
+name = "icu_timezone"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa91ba6a585939a020c787235daa8aee856d9bceebd6355e283c0c310bc6de96"
+dependencies = [
+ "displaydoc",
+ "icu_calendar",
+ "icu_provider",
+ "icu_timezone_data",
+ "tinystr",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_timezone_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c588878c508a3e2ace333b3c50296053e6483c6a7541251b546cc59dcd6ced8e"
 
 [[package]]
 name = "ident_case"
@@ -2154,6 +2595,15 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2303,6 +2753,13 @@ dependencies = [
  "serde",
  "serde_json",
  "tezos_crypto_rs 0.6.0",
+]
+
+[[package]]
+name = "jstz_engine"
+version = "0.1.0-alpha.0"
+dependencies = [
+ "mozjs",
 ]
 
 [[package]]
@@ -2477,6 +2934,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2487,6 +2950,16 @@ name = "libc"
 version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+
+[[package]]
+name = "libloading"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "libm"
@@ -2556,6 +3029,18 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
 dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -2667,6 +3152,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "mozjs"
+version = "0.14.1"
+source = "git+https://github.com/servo/mozjs.git?tag=mozjs-sys-v0.128.3-0#d9b283cbc2e8d464bef0d32ffc3514915525e56d"
+dependencies = [
+ "bindgen",
+ "cc",
+ "lazy_static",
+ "libc",
+ "log",
+ "mozjs_sys",
+]
+
+[[package]]
+name = "mozjs_sys"
+version = "0.128.3-0"
+source = "git+https://github.com/servo/mozjs.git?tag=mozjs-sys-v0.128.3-0#d9b283cbc2e8d464bef0d32ffc3514915525e56d"
+dependencies = [
+ "bindgen",
+ "cc",
+ "encoding_c",
+ "encoding_c_mem",
+ "flate2",
+ "icu_capi",
+ "libc",
+ "libz-sys",
+ "tar",
+ "walkdir",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2773,6 +3288,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-integer",
  "num-traits",
 ]
 
@@ -3451,8 +3977,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
+ "regex-automata 0.4.8",
  "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9368763f5a9b804326f3af749e16f9abf378d227bcdee7634b13d8f17793782"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -4016,6 +4551,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 
 [[package]]
+name = "simple_logger"
+version = "4.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e7e46c8c90251d47d08b28b8a419ffb4aede0f87c2eea95e17d1d5bacbf3ef1"
+dependencies = [
+ "colored",
+ "log",
+ "time",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "simplelog"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4091,6 +4638,22 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strck"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be91090ded9d8f979d9fe921777342d37e769e0b6b7296843a7a38247240e917"
+
+[[package]]
+name = "strck_ident"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c3802b169b3858a44667f221c9a0b3136e6019936ea926fc97fbad8af77202"
+dependencies = [
+ "strck",
+ "unicode-ident",
+]
 
 [[package]]
 name = "strsim"
@@ -5245,6 +5808,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+]
+
+[[package]]
 name = "widestring"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5489,6 +6064,9 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "wyz"
@@ -5609,6 +6187,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.85",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb594dd55d87335c5f60177cee24f19457a5ec10a065e0a3014722ad252d0a1f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "crates/jstz_cli",
   "crates/jstz_core",
   "crates/jstz_crypto",
+  "crates/jstz_engine",
   "crates/jstz_kernel",
   "crates/jstz_mock",
   "crates/jstz_node",
@@ -68,6 +69,7 @@ http-serde = "2.0.0"
 in-container = "^1"
 indicatif = "0.17.0"
 log = "0.4.20"
+mozjs = "0.14.1"
 nix = { version = "^0.27.1", features = ["process", "signal"] }
 nom = "7.1.3"
 num-traits = "0.2.16"
@@ -150,6 +152,15 @@ version = "0.6.0"
 default-features = false
 
 [patch.crates-io]
+boa_ast = { git = "https://github.com/trilitech/boa.git", branch = "ryutamago/fix-undefined-to-json" }
+boa_engine = { git = "https://github.com/trilitech/boa.git", branch = "ryutamago/fix-undefined-to-json" }
+boa_gc = { git = "https://github.com/trilitech/boa.git", branch = "ryutamago/fix-undefined-to-json" }
+boa_interner = { git = "https://github.com/trilitech/boa.git", branch = "ryutamago/fix-undefined-to-json" }
+boa_macros = { git = "https://github.com/trilitech/boa.git", branch = "ryutamago/fix-undefined-to-json" }
+boa_parser = { git = "https://github.com/trilitech/boa.git", branch = "ryutamago/fix-undefined-to-json" }
+boa_profiler = { git = "https://github.com/trilitech/boa.git", branch = "ryutamago/fix-undefined-to-json" }
+# NOTE: When updating `tag`, also update the `tag` in the `mozjs_archive` derivation in `nix/crates.nix`
+mozjs = { git = "https://github.com/servo/mozjs.git", tag = "mozjs-sys-v0.128.3-0" }
 tezos-smart-rollup = { git = "https://gitlab.com/tezos/tezos.git" }
 tezos-smart-rollup-host = { git = "https://gitlab.com/tezos/tezos.git" }
 tezos-smart-rollup-core = { git = "https://gitlab.com/tezos/tezos.git" }
@@ -159,10 +170,3 @@ tezos-smart-rollup-entrypoint = { git = "https://gitlab.com/tezos/tezos.git" }
 tezos-smart-rollup-debug = { git = "https://gitlab.com/tezos/tezos.git" }
 tezos-smart-rollup-panic-hook = { git = "https://gitlab.com/tezos/tezos.git" }
 tezos-smart-rollup-storage = { git = "https://gitlab.com/tezos/tezos.git" }
-boa_ast = { git = "https://github.com/trilitech/boa.git", branch = "ryutamago/fix-undefined-to-json" }
-boa_engine = { git = "https://github.com/trilitech/boa.git", branch = "ryutamago/fix-undefined-to-json" }
-boa_gc = { git = "https://github.com/trilitech/boa.git", branch = "ryutamago/fix-undefined-to-json" }
-boa_interner = { git = "https://github.com/trilitech/boa.git", branch = "ryutamago/fix-undefined-to-json" }
-boa_macros = { git = "https://github.com/trilitech/boa.git", branch = "ryutamago/fix-undefined-to-json" }
-boa_parser = { git = "https://github.com/trilitech/boa.git", branch = "ryutamago/fix-undefined-to-json" }
-boa_profiler = { git = "https://github.com/trilitech/boa.git", branch = "ryutamago/fix-undefined-to-json" }

--- a/crates/jstz_engine/Cargo.toml
+++ b/crates/jstz_engine/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "jstz_engine"
+edition.workspace = true
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+readme.workspace = true
+license-file.workspace = true
+description = "A memory-safe JavaScript engine API in Rust"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+mozjs.workspace = true

--- a/crates/jstz_engine/src/lib.rs
+++ b/crates/jstz_engine/src/lib.rs
@@ -1,0 +1,56 @@
+pub fn hello() {
+    println!("Hello, world!");
+}
+
+#[cfg(test)]
+mod test {
+
+    use ::std::ptr;
+
+    use mozjs::jsapi::*;
+    use mozjs::jsval::UndefinedValue;
+    use mozjs::rooted;
+    use mozjs::rust::SIMPLE_GLOBAL_CLASS;
+    use mozjs::rust::{JSEngine, RealmOptions, Runtime};
+
+    #[test]
+    fn test_eval() {
+        let engine = JSEngine::init().unwrap();
+        let rt = Runtime::new(engine.handle());
+
+        let options = RealmOptions::default();
+        rooted!(in(rt.cx()) let global = unsafe {
+            JS_NewGlobalObject(rt.cx(), &SIMPLE_GLOBAL_CLASS, ptr::null_mut(),
+                               OnNewGlobalHookOption::FireOnNewGlobalHook,
+                               &*options)
+        });
+
+        /* These should indicate source location for diagnostics. */
+        let filename: &'static str = "inline.js";
+        let lineno: u32 = 1;
+
+        /*
+         * The return value comes back here. If it could be a GC thing, you must add it to the
+         * GC's "root set" with the rooted! macro.
+         */
+        rooted!(in(rt.cx()) let mut rval = UndefinedValue());
+
+        /*
+         * Some example source in a string. This is equivalent to JS_EvaluateScript in C++.
+         */
+        let source: &'static str = "40 + 2";
+
+        let res = rt.evaluate_script(
+            global.handle(),
+            source,
+            filename,
+            lineno,
+            rval.handle_mut(),
+        );
+
+        assert!(res.is_ok());
+        /* Should get a number back from the example source. */
+        assert!(rval.get().is_int32());
+        assert_eq!(rval.get().to_int32(), 42);
+    }
+}

--- a/nix/crates.nix
+++ b/nix/crates.nix
@@ -1,10 +1,11 @@
 {
   pkgs,
-  crane,
   lib,
   stdenv,
+  crane,
   rust-toolchain,
   octez,
+  mozjs,
 }: let
   craneLib = (crane.mkLib pkgs).overrideToolchain (_: rust-toolchain);
 
@@ -34,6 +35,8 @@
       ++ lib.optionals
       stdenv.isDarwin
       (with darwin.apple_sdk.frameworks; [Security SystemConfiguration]);
+
+    MOZJS_ARCHIVE = mozjs;
   };
 
   # Build *just* the workspace dependencies.
@@ -97,11 +100,12 @@ in {
       });
     jstz_core = crate "jstz_core";
     jstz_crypto = crate "jstz_crypto";
+    jstz_engine = crate "jstz_engine";
+    inherit jstz_kernel;
     jstz_mock = crate "jstz_mock";
     jstz_node = crate "jstz_node";
     jstz_proto = crate "jstz_proto";
     jstz_rollup = crate "jstz_rollup";
-    inherit jstz_kernel;
     jstz_wpt = crate "jstz_wpt";
     jstzd = crate "jstzd";
     octez = crate "octez";
@@ -116,8 +120,9 @@ in {
 
     cargo-test-unit = craneLib.cargoNextest (commonWorkspace
       // {
+        doCheck = true;
         # Run the unit tests
-        cargoNextestExtraArg = "--bins --lib";
+        cargoNextestExtraArgs = "--bins --lib";
       });
 
     cargo-test-int = craneLib.cargoNextest (commonWorkspace
@@ -126,7 +131,7 @@ in {
         doCheck = true;
         # Run the integration tests
         #
-        # FIXME():
+        # FIXME(https://linear.app/tezos/issue/JSTZ-186):
         # Don't run the `jstz_api` integration tests until they've been paralellized
         #
         # Note: --workspace is required for --exclude. Once --exclude is removed, remove --workspace

--- a/nix/mozjs.nix
+++ b/nix/mozjs.nix
@@ -1,0 +1,26 @@
+{
+  fetchurl,
+  stdenv,
+}: let
+  # `mozjs` builds SpiderMonkey automatically unless given an archive.
+  # Building SpiderMonkey is rather slow, so instead we rely on a pre-build
+  # archive distributed here: https://github.com/servo/mozjs/releases/tag
+  #
+  # See https://github.com/jstz-dev/jstz/pull/?? for more information
+  # on how we could build mozjs ourselves (and some of the issues we ran into).
+  # TODO():
+  # Extract the tag from our Cargo.toml file
+  #
+  # NOTE: This tag must be updated when the `mozjs-sys` crate is updated
+  tag = "mozjs-sys-v0.128.3-0";
+  target = stdenv.hostPlatform.rust.rustcTarget;
+  hashes = {
+    "x86_64-apple-darwin" = "sha256-kt+vfs1qZJ9lcwBwINvMq6Jm4DtNa3aqcNdd9gFLb+o=";
+    "aarch64-apple-darwin" = "sha256-sFi3zl03t9dZxpqdYPyS4yAzY1OozdP0aw9lKiG47lk=";
+    "x86_64-unknown-linux-gnu" = "sha256-mbzLtbSMsLSfmqJp2Sy8PdwWV2bVaeTRePNsL6QQlS8=";
+  };
+in
+  fetchurl {
+    url = "https://github.com/servo/mozjs/releases/download/${tag}/libmozjs-${target}.tar.gz";
+    hash = hashes.${target};
+  }


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

This PR adds the skeleton for the much long-awaited `jstz_engine` crate -- the crate that
will provide memory-safe wrappers on SpiderMonkey's `mozjs` crate. 

There is a simple unit test in `jstz_engine` demonstrating that SpiderMonkey does correctly
work in our CI. 

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

## Part 1. Adding `mozjs` from crates.io

Initially I tried adding `mozjs` from crates.io, but this backfired since the released version of mozjs is
**5 years old**. 

## Part 2. Building `mozjs` in Nix

So we'll need to use `patch.crates-io` 😔

An initial goal of this PR was to add the patched `mozjs` in such a way that would avoid 
us rebuilding SpiderMonkey each time (~10-15 minutes on a reasonably powerful machine). 

`mozjs-sys`'s build system luckily provides such an approach, where one builds an 'archive' 
containing `libjs_static.a` (statically compiled SpiderMonkey) and some autogenerated Rust files. 

Unfortunately, the compilation of `libjs_static.a` (orchestrated by `mozjs-sys`'s build script) doesn't
work on MacOS (in a Nix environment). The following was the initial attempt:

```nix
  # `mozjs` builds SpiderMonkey automatically. However, this is quite slow. To avoid re-building
  # SpiderMonkey each time, we create a single derivation that builds an archive with all
  # the necessary build artifacts from SpiderMonkey. `mozjs` can then link against these artifacts
  # when we build the crate as part of `cargoDeps`.
  mozjs = let
    src = pkgs.fetchFromGitHub {
      owner = "servo";
      repo = "mozjs";
      # TODO():
      # We should the revision from our Cargo.toml file (since we specify
      # it for `patch.crates-io`)
      rev = "a02aaf1e11fd275f2f129d0c7ca80a9d07460036";
      hash = "sha256-SghYDAnUr2BEuzt/j1NcExqNMxLgCCXttkTnTbreoas=";
    };
    common = {
      pname = "mozjs";
      version = "0.14.1";
      inherit src;
      doCheck = false;
      # mozjs (for some reason?) doesn't use a `Cargo.lock` file
      # so we need to provide one explicitly.
      #
      # Note: We generate this by simply running `cargo build` on the `mozjs` crate
      # (at the given revision). This MUST be updated whenever the `mozjs` crate is
      # updated.
      cargoLock = ./patches/mozjs/Cargo.lock;
    };
  in
    craneLib.cargoBuild (common
      // {
        cargoArtifacts = craneLib.buildDepsOnly common;

        MOZJS_CREATE_ARCHIVE = 1;
        postConfigure =
          ''
            # Build process requires a $HOME directory
            export HOME=$(mktemp -d)
          ''
          + lib.optionalString stdenv.isDarwin ''
            # standalone as(1) doesn't correctly handle `-D` flags for preprocessor `#define`s
            # This ensures we override the environment variables set in `cc-wrapper/setup-hook.sh`
            export AS="$CC -c"
          '';

        buildInputs = lib.optionals stdenv.isDarwin [
          apple-sdk_15
        ];

        nativeBuildInputs = with pkgs;
          [
            python3 # for mozbuild
            gnum4 # for m4
            llvmPackages.llvm # for llvm-objdump
          ]
          ++ lib.optionals stdenv.isDarwin [
            xcbuild # for xcrun
          ];

        installPhase =
          # Building with `MOZJS_CREATE_ARCHIVE=1` creates a tarball at
          # `target/libmozjs-<target>.tar.gz`
          ''
            mkdir $out
            cp target/libmozjs-${stdenv.hostPlatform.rust.rustcTarget}.tar.gz $out/libmozjs.tar.gz
          '';
      });

```

Unfortunately this derivation suffers from two issues (despite building):
1. Linking the `mozjs` archive results in the following error:
    ```
      ld: too many compact unwind infos in anon function '...(RegExp.o)'
      clang: error: linker command failed with exit code 1 (use -v to see invocation)
    ```
    This is due to the use of labels starting with `L` being treated as local by the 
    assembler. When targeting aarch64-darwin (Mach-O), having local labels 
    break the generation of compact (stack) unwinding info. 
  
    This happens because local labels are not seen as function
    boundaries and multiple .cfi_startproc/.cfi_endproc are
    mashed into a single function.
  
    The solution is to force Rust (and clang) to generate dwarf unwind info
    using the clang option: `-femit-dwarf-unwind=always`. Once we have
    the dwarf unwinding infos, we can strip the compact unwind sections using
    `strip --remove-section __LD,__compact_unwind` and link with
    `-Wl,-keep_dwarf_unwind -Wl,-no_compact_unwind`. 

2. The objects in `libjs_static.a` have no symbols, resulting in a missing symbol error when linking.
    *At this point I gave up and back tracked, this still remains a mystery to me* 

Unfortunately, we *will* need to solve this problem in future when targeting `riscv64gc-unknown-linux-musl`, but that is a problem for later I guess 🤷‍♂️

## Part 3. Using external builds for `mozjs`

Instead I decided to look if `mozjs` packages these archives anywhere (since the released `mozjs`)
Trying this manually (using several local builds) worked very nicely!

After looking at the [`mozjs` CI](https://github.com/servo/mozjs/blob/main/.github/workflows/build.yml) I found that these archives are indeed uploaded to GitHub, found with each release [here](https://github.com/servo/mozjs/releases/tag/mozjs-sys-v0.128.3-1). 

Hooray! A reproducible (but note very hermetic) way for including `mozjs` in `jstz_engine`.  


# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

```sh
cargo nextest --package "jstz_engine"
```
