### PR TITLE
fix: remove `wasm-bindgen` imports in `jstz_kernel.wasm`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,7 +389,7 @@ dependencies = [
 [[package]]
 name = "boa_ast"
 version = "0.19.0"
-source = "git+https://github.com/trilitech/boa.git?branch=ryutamago/fix-undefined-to-json#c7b9ff04991a4a9dfbc9356e7f92efba93fe9dac"
+source = "git+https://github.com/trilitech/boa.git?branch=ajob410@fix/remove-wasm-bindgen-from-time#c10d6a2fd126eb5a6b9ce06161d201eb9059fad3"
 dependencies = [
  "arbitrary",
  "bitflags 2.6.0",
@@ -404,7 +404,7 @@ dependencies = [
 [[package]]
 name = "boa_engine"
 version = "0.19.0"
-source = "git+https://github.com/trilitech/boa.git?branch=ryutamago/fix-undefined-to-json#c7b9ff04991a4a9dfbc9356e7f92efba93fe9dac"
+source = "git+https://github.com/trilitech/boa.git?branch=ajob410@fix/remove-wasm-bindgen-from-time#c10d6a2fd126eb5a6b9ce06161d201eb9059fad3"
 dependencies = [
  "arrayvec",
  "bitflags 2.6.0",
@@ -448,7 +448,7 @@ dependencies = [
 [[package]]
 name = "boa_gc"
 version = "0.19.0"
-source = "git+https://github.com/trilitech/boa.git?branch=ryutamago/fix-undefined-to-json#c7b9ff04991a4a9dfbc9356e7f92efba93fe9dac"
+source = "git+https://github.com/trilitech/boa.git?branch=ajob410@fix/remove-wasm-bindgen-from-time#c10d6a2fd126eb5a6b9ce06161d201eb9059fad3"
 dependencies = [
  "boa_macros",
  "boa_profiler",
@@ -460,7 +460,7 @@ dependencies = [
 [[package]]
 name = "boa_interner"
 version = "0.19.0"
-source = "git+https://github.com/trilitech/boa.git?branch=ryutamago/fix-undefined-to-json#c7b9ff04991a4a9dfbc9356e7f92efba93fe9dac"
+source = "git+https://github.com/trilitech/boa.git?branch=ajob410@fix/remove-wasm-bindgen-from-time#c10d6a2fd126eb5a6b9ce06161d201eb9059fad3"
 dependencies = [
  "arbitrary",
  "boa_gc",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "boa_macros"
 version = "0.19.0"
-source = "git+https://github.com/trilitech/boa.git?branch=ryutamago/fix-undefined-to-json#c7b9ff04991a4a9dfbc9356e7f92efba93fe9dac"
+source = "git+https://github.com/trilitech/boa.git?branch=ajob410@fix/remove-wasm-bindgen-from-time#c10d6a2fd126eb5a6b9ce06161d201eb9059fad3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -487,7 +487,7 @@ dependencies = [
 [[package]]
 name = "boa_parser"
 version = "0.19.0"
-source = "git+https://github.com/trilitech/boa.git?branch=ryutamago/fix-undefined-to-json#c7b9ff04991a4a9dfbc9356e7f92efba93fe9dac"
+source = "git+https://github.com/trilitech/boa.git?branch=ajob410@fix/remove-wasm-bindgen-from-time#c10d6a2fd126eb5a6b9ce06161d201eb9059fad3"
 dependencies = [
  "bitflags 2.6.0",
  "boa_ast",
@@ -505,12 +505,12 @@ dependencies = [
 [[package]]
 name = "boa_profiler"
 version = "0.19.0"
-source = "git+https://github.com/trilitech/boa.git?branch=ryutamago/fix-undefined-to-json#c7b9ff04991a4a9dfbc9356e7f92efba93fe9dac"
+source = "git+https://github.com/trilitech/boa.git?branch=ajob410@fix/remove-wasm-bindgen-from-time#c10d6a2fd126eb5a6b9ce06161d201eb9059fad3"
 
 [[package]]
 name = "boa_string"
 version = "0.19.0"
-source = "git+https://github.com/trilitech/boa.git?branch=ryutamago/fix-undefined-to-json#c7b9ff04991a4a9dfbc9356e7f92efba93fe9dac"
+source = "git+https://github.com/trilitech/boa.git?branch=ajob410@fix/remove-wasm-bindgen-from-time#c10d6a2fd126eb5a6b9ce06161d201eb9059fad3"
 dependencies = [
  "fast-float",
  "paste",
@@ -5195,7 +5195,6 @@ checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
- "js-sys",
  "libc",
  "num-conv",
  "num_threads",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,13 +152,6 @@ version = "0.6.0"
 default-features = false
 
 [patch.crates-io]
-boa_ast = { git = "https://github.com/trilitech/boa.git", branch = "ryutamago/fix-undefined-to-json" }
-boa_engine = { git = "https://github.com/trilitech/boa.git", branch = "ryutamago/fix-undefined-to-json" }
-boa_gc = { git = "https://github.com/trilitech/boa.git", branch = "ryutamago/fix-undefined-to-json" }
-boa_interner = { git = "https://github.com/trilitech/boa.git", branch = "ryutamago/fix-undefined-to-json" }
-boa_macros = { git = "https://github.com/trilitech/boa.git", branch = "ryutamago/fix-undefined-to-json" }
-boa_parser = { git = "https://github.com/trilitech/boa.git", branch = "ryutamago/fix-undefined-to-json" }
-boa_profiler = { git = "https://github.com/trilitech/boa.git", branch = "ryutamago/fix-undefined-to-json" }
 # NOTE: When updating `tag`, also update the `tag` in the `mozjs_archive` derivation in `nix/crates.nix`
 mozjs = { git = "https://github.com/servo/mozjs.git", tag = "mozjs-sys-v0.128.3-0" }
 tezos-smart-rollup = { git = "https://gitlab.com/tezos/tezos.git" }
@@ -170,3 +163,10 @@ tezos-smart-rollup-entrypoint = { git = "https://gitlab.com/tezos/tezos.git" }
 tezos-smart-rollup-debug = { git = "https://gitlab.com/tezos/tezos.git" }
 tezos-smart-rollup-panic-hook = { git = "https://gitlab.com/tezos/tezos.git" }
 tezos-smart-rollup-storage = { git = "https://gitlab.com/tezos/tezos.git" }
+boa_ast = { git = "https://github.com/trilitech/boa.git", branch = "ajob410@fix/remove-wasm-bindgen-from-time" }
+boa_engine = { git = "https://github.com/trilitech/boa.git", branch = "ajob410@fix/remove-wasm-bindgen-from-time" }
+boa_gc = { git = "https://github.com/trilitech/boa.git", branch = "ajob410@fix/remove-wasm-bindgen-from-time" }
+boa_interner = { git = "https://github.com/trilitech/boa.git", branch = "ajob410@fix/remove-wasm-bindgen-from-time" }
+boa_macros = { git = "https://github.com/trilitech/boa.git", branch = "ajob410@fix/remove-wasm-bindgen-from-time" }
+boa_parser = { git = "https://github.com/trilitech/boa.git", branch = "ajob410@fix/remove-wasm-bindgen-from-time" }
+boa_profiler = { git = "https://github.com/trilitech/boa.git", branch = "ajob410@fix/remove-wasm-bindgen-from-time" }


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

**Problem**: jstz sandbox is stuck
 
```sh
jstz sandbox start -d
tail -f ~/.jstz/sandbox-logs/kernel.log
```
Seeing no logs mean the kernel is stuck and cannot boot. 

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

How to find the issue. Firstly load the kernel using the `octez-smart-rollup-wasm-debugger` with empty inputs
```sh
make build-cli
echo '[[]]' > inputs.json
octez-smart-rollup-wasm-debugger --kernel crates/jstz_cli/jstz_kernel.wasm --inputs inputs.json
```

Erroneous outputs often look like:
```
Error
  Unknown exception: Error(_, "float instructions are forbidden")
```
or 
```
Error
  jstz_kernel:0x51a-0x550: link failure: unknown import "__wbindgen_placeholder__"."__wbindgen_object_drop_ref"
```

In this case, after #624, we need to fix the invalid import. To find the uses of the import, use `wasm2wat` to translate
`jstz_kernel.wasm` into readable wasm code and then grep for the bad import. 

In this case, the issue was introduced by #593 which uses the `time` crate with the `wasm-bindgen`. The fix is to disable the `wasm-bindgen` feature flag for the `time` crate, as shown in [this commit](https://github.com/trilitech/boa/commit/c10d6a2fd126eb5a6b9ce06161d201eb9059fad3)

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

```sh
jstz sandbox start -d
tail -f ~/.jstz/sandbox-logs/kernel.log
```
