### PR TITLE
ci: do not cancel workflow runs for main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 jobs:
   commitlint:


### PR DESCRIPTION
# Context

Make sure that workflow runs for all main commits still get executed.

# Description

I merged PRs consecutively too soon and some workflow runs, e.g. https://github.com/jstz-dev/jstz/actions/runs/11627599091/job/32381228428, were cancelled by the succeeding merge. The workflow should be executed for all main commits, so I'm adding a condition to the workflow definition so that pushes to main are excluded from that rule.

According to [github docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context), `github.ref_name` refers to

> The short ref name of the branch or tag that triggered the workflow run. This value matches the branch or tag name shown on GitHub. For example, feature-branch-1.
> For pull requests, the format is <pr_number>/merge.

so checking `github.ref_name != 'main'` should work.

# Manually testing the PR

Cannot really test this with main.
