### PR TITLE
feat(octez): add OctezClientConfig

### DIFF
--- a/crates/jstzd/tests/octez_client_test.rs
+++ b/crates/jstzd/tests/octez_client_test.rs
@@ -1,7 +1,7 @@
 use jstz_crypto::public_key_hash::PublicKeyHash;
 use jstzd::task::Task;
 use octez::r#async::{
-    client::{OctezClientBuilder, Signature},
+    client::{OctezClient, OctezClientConfigBuilder, Signature},
     endpoint::Endpoint,
 };
 use serde_json::Value;
@@ -34,10 +34,11 @@ async fn config_init() {
     let expected_endpoint = Endpoint::localhost(3000);
     let config_file = NamedTempFile::new().unwrap();
     let _ = remove_file(config_file.path());
-    let octez_client = OctezClientBuilder::new(expected_endpoint.clone())
+    let octez_client_config = OctezClientConfigBuilder::new(expected_endpoint.clone())
         .set_base_dir(expected_base_dir.clone())
         .build()
         .unwrap();
+    let octez_client = OctezClient::new(octez_client_config);
     let res = octez_client.config_init(config_file.path()).await;
     assert!(res.is_ok());
     let actual: Value =

--- a/crates/jstzd/tests/utils.rs
+++ b/crates/jstzd/tests/utils.rs
@@ -2,7 +2,7 @@
 use jstzd::task::{octez_baker, octez_node::OctezNode, octez_rollup, Task};
 use octez::r#async::{
     baker::{BakerBinaryPath, OctezBakerConfigBuilder},
-    client::{OctezClient, OctezClientBuilder},
+    client::{OctezClient, OctezClientConfigBuilder},
     endpoint::Endpoint,
     node_config::{OctezNodeConfigBuilder, OctezNodeRunOptionsBuilder},
     protocol::Protocol,
@@ -115,9 +115,10 @@ pub async fn spawn_octez_node() -> OctezNode {
 }
 
 pub fn create_client(node_endpoint: &Endpoint) -> OctezClient {
-    OctezClientBuilder::new(node_endpoint.clone())
+    let config = OctezClientConfigBuilder::new(node_endpoint.clone())
         .build()
-        .unwrap()
+        .unwrap();
+    OctezClient::new(config)
 }
 
 pub async fn get_block_level(rpc_endpoint: &str) -> i32 {


### PR DESCRIPTION
# Context

Part of JSTZ-163; in preparation for #634.

[JSTZ-163](https://linear.app/tezos/issue/JSTZ-163/spawn-octezbaker-in-jstzd)

# Description

Make `OctezClientBuilder` build `OctezClientConfig` instead of `OctezClient` directly. `OctezClient` then can be instantiated by calling `new(config)`. `OctezClientConfig` is needed because configs for octez client will be added to `JstzdConfig` and I don't think the client itself should be part of the config.

# Manually testing the PR

Updated relevant test cases.
