### PR TITLE
fix(octez): remove octez_node_data_dir from baker

### DIFF
--- a/crates/jstzd/tests/utils.rs
+++ b/crates/jstzd/tests/utils.rs
@@ -80,7 +80,6 @@ pub async fn spawn_baker(
         .set_octez_client_base_dir(
             PathBuf::from(octez_client.base_dir()).to_str().unwrap(),
         )
-        .set_octez_node_data_dir(octez_node.data_dir().to_str().unwrap())
         .set_octez_node_endpoint(octez_node.rpc_endpoint())
         .build()
         .expect("Failed to build baker config");


### PR DESCRIPTION
# Context

Part of JSTZ-163; in preparation for #634.

[JSTZ-163](https://linear.app/tezos/issue/JSTZ-163/spawn-octezbaker-in-jstzd)

# Description

Remove `octez_node_data_dir` from baker because it's not in use and it's not part of the config for the `octez-baker` executable either.

# Manually testing the PR

All existing test cases should still work.
