### PR TITLE
feat(octez): make ProtocolParameterBuilder return protocol

### DIFF
--- a/crates/jstzd/tests/protocol_test.rs
+++ b/crates/jstzd/tests/protocol_test.rs
@@ -5,7 +5,7 @@ use octez::r#async::{
     endpoint::Endpoint,
     protocol::{
         BootstrapAccount, BootstrapContract, BootstrapSmartRollup,
-        ProtocolParameterBuilder, ReadWritable, SmartRollupPvmKind,
+        ProtocolParameterBuilder, SmartRollupPvmKind,
     },
 };
 use utils::{
@@ -55,7 +55,11 @@ async fn protocol_parameters() {
     let octez_client = create_client(octez_node.rpc_endpoint());
     import_bootstrap_keys(&octez_client).await;
     import_activator(&octez_client).await;
-    activate_alpha(&octez_client, Some(param_file.path())).await;
+    activate_alpha(
+        &octez_client,
+        Some(param_file.parameter_file().path().to_path_buf()),
+    )
+    .await;
 
     for (address, _, amount) in bootstrap_accounts {
         check_bootstrap_contract(octez_node.rpc_endpoint(), address, amount).await;


### PR DESCRIPTION
# Context

Part of JSTZ-163; in preparation for #634.

[JSTZ-163](https://linear.app/tezos/issue/JSTZ-163/spawn-octezbaker-in-jstzd)

# Description

Expose `Protocol` after a protocol file is built. This is required because calling `activate_protocol` after a parameter file is generated still needs the protocol hash and that cannot be extracted from the parameter file.

# Manually testing the PR

All existing test cases should still work.
