### PR TITLE
feat(jstzd): spawn baker in jstzd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2928,6 +2928,7 @@ dependencies = [
  "async-trait",
  "axum",
  "bollard",
+ "futures",
  "futures-util",
  "http 1.1.0",
  "jstz_crypto",

--- a/crates/jstzd/Cargo.toml
+++ b/crates/jstzd/Cargo.toml
@@ -11,6 +11,7 @@ async-dropper-simple.workspace = true
 async-trait.workspace = true
 axum.workspace = true
 bollard.workspace = true
+futures.workspace = true
 futures-util.workspace = true
 http.workspace = true
 jstz_crypto = { path = "../jstz_crypto" }

--- a/crates/jstzd/src/task/mod.rs
+++ b/crates/jstzd/src/task/mod.rs
@@ -4,6 +4,7 @@ pub mod jstzd;
 pub mod octez_baker;
 pub mod octez_node;
 pub mod octez_rollup;
+pub mod utils;
 
 use anyhow::Result;
 use async_trait::async_trait;

--- a/crates/jstzd/src/task/utils.rs
+++ b/crates/jstzd/src/task/utils.rs
@@ -1,0 +1,15 @@
+pub async fn retry<'a, F>(retries: u16, interval_ms: u64, f: impl Fn() -> F) -> bool
+where
+    F: std::future::Future<Output = anyhow::Result<bool>> + Send + 'a,
+{
+    let duration = tokio::time::Duration::from_millis(interval_ms);
+    for _ in 0..retries {
+        tokio::time::sleep(duration).await;
+        if let Ok(v) = f().await {
+            if v {
+                return true;
+            }
+        }
+    }
+    false
+}

--- a/crates/jstzd/tests/jstzd_test.rs
+++ b/crates/jstzd/tests/jstzd_test.rs
@@ -1,17 +1,58 @@
 mod utils;
+use std::path::PathBuf;
+
+use jstzd::task::utils::retry;
+use octez::r#async::baker::{BakerBinaryPath, OctezBakerConfigBuilder};
+use octez::r#async::client::OctezClientConfigBuilder;
 use octez::r#async::endpoint::Endpoint;
-use octez::r#async::node_config::OctezNodeConfigBuilder;
+use octez::r#async::node_config::{OctezNodeConfigBuilder, OctezNodeRunOptionsBuilder};
+use octez::r#async::protocol::{BootstrapAccount, ProtocolParameterBuilder};
 use octez::unused_port;
-use utils::retry;
+use utils::get_block_level;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn jstzd_test() {
     let rpc_endpoint = Endpoint::localhost(unused_port());
-    let config = jstzd::task::jstzd::JstzdConfig::new(
-        OctezNodeConfigBuilder::new()
-            .set_rpc_endpoint(&rpc_endpoint)
+    let run_options = OctezNodeRunOptionsBuilder::new()
+        .set_synchronisation_threshold(0)
+        .set_network("sandbox")
+        .build();
+    let octez_node_config = OctezNodeConfigBuilder::new()
+        .set_network("sandbox")
+        .set_rpc_endpoint(&rpc_endpoint)
+        .set_run_options(&run_options)
+        .build()
+        .unwrap();
+    let protocol_params = ProtocolParameterBuilder::new()
+        // this is the activator account
+        // fund the account so that it can be used by the baker
+        .set_bootstrap_accounts([BootstrapAccount::new(
+            "edpkuSLWfVU1Vq7Jg9FucPyKmma6otcMHac9zG4oU1KMHSTBpJuGQ2",
+            6_000_000_000,
+        )
+        .unwrap()])
+        .build()
+        .unwrap();
+    let octez_client_config =
+        OctezClientConfigBuilder::new(octez_node_config.rpc_endpoint.clone())
             .build()
-            .unwrap(),
+            .unwrap();
+    let baker_config = OctezBakerConfigBuilder::new()
+        .set_binary_path(BakerBinaryPath::Env(protocol_params.protocol().clone()))
+        .set_octez_client_base_dir(
+            PathBuf::from(octez_client_config.base_dir())
+                .to_str()
+                .unwrap(),
+        )
+        .set_octez_node_endpoint(&octez_node_config.rpc_endpoint)
+        .build()
+        .expect("Failed to build baker config");
+
+    let config = jstzd::task::jstzd::JstzdConfig::new(
+        octez_node_config,
+        baker_config,
+        octez_client_config,
+        protocol_params,
     );
     let jstzd_port = unused_port();
     let mut jstzd = jstzd::task::jstzd::JstzdServer::new(config, jstzd_port);
@@ -21,23 +62,27 @@ async fn jstzd_test() {
     let octez_node_health_check_endpoint = format!("{}/health/ready", rpc_endpoint);
     let jstzd_running = retry(10, 1000, || async {
         let res = reqwest::get(&jstz_health_check_endpoint).await;
-        if res.is_ok() {
-            return Ok(true);
-        }
-        Err(anyhow::anyhow!(""))
+        Ok(res.is_ok())
     })
     .await;
     assert!(jstzd_running);
 
     let node_running = retry(10, 1000, || async {
         let res = reqwest::get(&octez_node_health_check_endpoint).await;
-        if res.is_ok() {
-            return Ok(true);
-        }
-        Err(anyhow::anyhow!(""))
+        Ok(res.is_ok())
     })
     .await;
     assert!(node_running);
+
+    let baker_running = retry(10, 1000, || async {
+        if run_ps().await.contains("octez-baker") {
+            let last_level = get_block_level(&rpc_endpoint.to_string()).await;
+            return Ok(last_level > 2);
+        }
+        Ok(false)
+    })
+    .await;
+    assert!(baker_running);
     assert!(jstzd.health_check().await);
 
     jstzd.stop().await.unwrap();
@@ -47,7 +92,7 @@ async fn jstzd_test() {
         if let Err(e) = res {
             return Ok(e.to_string().contains("Connection refused"));
         }
-        Err(anyhow::anyhow!(""))
+        Ok(false)
     })
     .await;
     assert!(jstzd_stopped);
@@ -58,10 +103,28 @@ async fn jstzd_test() {
         if let Err(e) = res {
             return Ok(e.to_string().contains("Connection refused"));
         }
-        Err(anyhow::anyhow!(""))
+        Ok(false)
     })
     .await;
     assert!(node_destroyed);
 
+    let baker_destroyed = retry(30, 1000, || async {
+        Ok(!run_ps().await.contains("octez-baker"))
+    })
+    .await;
+    assert!(baker_destroyed);
+
     assert!(!jstzd.health_check().await);
+}
+
+async fn run_ps() -> String {
+    let output = tokio::process::Command::new("ps")
+        // print with extra columns so that commands don't get truncated too much
+        .args(["-o", "comm"])
+        .env("COLUMNS", "1000")
+        .output()
+        .await
+        .unwrap();
+    assert_eq!(String::from_utf8(output.stderr).unwrap(), "");
+    String::from_utf8(output.stdout).unwrap()
 }

--- a/crates/jstzd/tests/octez_node_test.rs
+++ b/crates/jstzd/tests/octez_node_test.rs
@@ -1,4 +1,4 @@
-use jstzd::task::{octez_node, Task};
+use jstzd::task::{octez_node, utils::retry, Task};
 mod utils;
 use octez::{
     r#async::{
@@ -7,7 +7,6 @@ use octez::{
     },
     unused_port,
 };
-use utils::retry;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn octez_node_test() {

--- a/crates/jstzd/tests/utils.rs
+++ b/crates/jstzd/tests/utils.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-use jstzd::task::{octez_baker, octez_node::OctezNode, octez_rollup, Task};
+use jstzd::task::{octez_baker, octez_node::OctezNode, octez_rollup, utils::retry, Task};
 use octez::r#async::{
     baker::{BakerBinaryPath, OctezBakerConfigBuilder},
     client::{OctezClient, OctezClientConfigBuilder},
@@ -14,24 +14,7 @@ use tezos_crypto_rs::hash::{BlockHash, SmartRollupHash};
 
 pub const ACTIVATOR_SECRET_KEY: &str =
     "unencrypted:edsk31vznjHSSpGExDMHYASz45VZqXN4DPxvsa4hAyY8dHM28cZzp6";
-
 pub const ROLLUP_ADDRESS: &str = "sr1PuFMgaRUN12rKQ3J2ae5psNtwCxPNmGNK";
-
-pub async fn retry<'a, F>(retries: u16, interval_ms: u64, f: impl Fn() -> F) -> bool
-where
-    F: std::future::Future<Output = anyhow::Result<bool>> + Send + 'a,
-{
-    let duration = tokio::time::Duration::from_millis(interval_ms);
-    for _ in 0..retries {
-        tokio::time::sleep(duration).await;
-        if let Ok(v) = f().await {
-            if v {
-                return true;
-            }
-        }
-    }
-    false
-}
 
 pub async fn setup() -> (OctezNode, OctezClient, octez_baker::OctezBaker) {
     let octez_node = spawn_octez_node().await;

--- a/nix/crates.nix
+++ b/nix/crates.nix
@@ -127,7 +127,7 @@ in {
 
     cargo-test-int = craneLib.cargoNextest (commonWorkspace
       // {
-        buildInputs = commonWorkspace.buildInputs ++ [pkgs.iana-etc octez pkgs.cacert];
+        buildInputs = commonWorkspace.buildInputs ++ [pkgs.iana-etc octez pkgs.cacert pkgs.ps];
         doCheck = true;
         # Run the integration tests
         #
@@ -140,7 +140,7 @@ in {
 
     cargo-llvm-cov = craneLib.cargoLlvmCov (commonWorkspace
       // {
-        buildInputs = commonWorkspace.buildInputs ++ [pkgs.iana-etc octez pkgs.cacert];
+        buildInputs = commonWorkspace.buildInputs ++ [pkgs.iana-etc octez pkgs.cacert pkgs.ps];
         # Generate coverage reports for codecov
         cargoLlvmCovExtraArgs = "--workspace --exclude-from-test \"jstz_api\" --codecov --output-path $out";
       });


### PR DESCRIPTION
# Context

Completes JSTZ-163.

[JSTZ-163](https://linear.app/tezos/issue/JSTZ-163/spawn-octezbaker-in-jstzd)

# Description

Spawn baker in jstzd.

Note that there is a small usability issue regarding bootstrap accounts: these accounts cannot be used by the baker except for the hard-coded activator account. This is because bakers only use accounts with secret keys imported and bootstrap accounts in parameter files only have public keys. This is especially a problem when users use their own template parameter files with bootstrap accounts attached. There is no solution for now. I don't think hardcoding a "base baker" account inside `ProtocolParameterBuilder` is a good idea since it adds irrelevant logic to that module.

# Manually testing the PR

Updated `crates/jstzd/tests/jstzd_test.rs`.

```sh
$ cargo test --test jstzd_test
running 1 test
< ... baker logs >
test jstzd_test ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 8.52s
```
