### PR TITLE
feat(octez): implement send_rollup_inbox_message

### DIFF
--- a/crates/jstzd/tests/utils.rs
+++ b/crates/jstzd/tests/utils.rs
@@ -10,7 +10,7 @@ use octez::r#async::{
 };
 use regex::Regex;
 use std::path::{Path, PathBuf};
-use tezos_crypto_rs::hash::{BlockHash, SmartRollupHash};
+use tezos_crypto_rs::hash::{BlockHash, OperationHash, SmartRollupHash};
 
 pub const ACTIVATOR_SECRET_KEY: &str =
     "unencrypted:edsk31vznjHSSpGExDMHYASz45VZqXN4DPxvsa4hAyY8dHM28cZzp6";
@@ -199,4 +199,35 @@ pub async fn activate_alpha(octez_client: &OctezClient, params: Option<PathBuf>)
 
 pub async fn get_request(endpoint: &str) -> String {
     reqwest::get(endpoint).await.unwrap().text().await.unwrap()
+}
+
+pub async fn get_operation_kind(
+    rpc_endpoint: &str,
+    block_hash: &BlockHash,
+    operation_hash: &OperationHash,
+) -> Option<String> {
+    let op_str = operation_hash.to_string();
+    let blocks_head_endpoint = format!(
+        "{}/chains/main/blocks/{}/operations",
+        rpc_endpoint.to_owned(),
+        block_hash
+    );
+    let response: serde_json::Value =
+        serde_json::from_str(&get_request(&blocks_head_endpoint).await).unwrap();
+    for group in response.as_array()? {
+        for op in group.as_array()? {
+            let obj = op.as_object()?;
+            if obj.get("hash")? == &op_str {
+                return Some(
+                    obj.get("contents")?
+                        .as_array()?
+                        .first()?
+                        .get("kind")?
+                        .as_str()?
+                        .to_owned(),
+                );
+            }
+        }
+    }
+    None
 }

--- a/crates/octez/src/async/client.rs
+++ b/crates/octez/src/async/client.rs
@@ -510,6 +510,30 @@ impl OctezClient {
         self.spawn_and_wait_command(args).await?;
         Ok(())
     }
+
+    pub async fn send_rollup_inbox_message(
+        &self,
+        src: &str,
+        message_hex: &str,
+        burn_cap: Option<f64>,
+    ) -> Result<(BlockHash, OperationHash)> {
+        let burn_cap_str = burn_cap.map(|v| v.to_string());
+        let inbox_message = format!("hex: [\"{}\"]", message_hex);
+        let mut args = vec![
+            "send",
+            "smart",
+            "rollup",
+            "message",
+            &inbox_message,
+            "from",
+            src,
+        ];
+        if let Some(v) = &burn_cap_str {
+            args.append(&mut vec!["--burn-cap", v]);
+        }
+        let output = self.spawn_and_wait_command(args).await?;
+        Ok((parse_block_hash(&output)?, parse_operation_hash(&output)?))
+    }
 }
 
 fn parse_regex(pattern_str: &str, output: &str) -> Result<String> {
@@ -535,6 +559,14 @@ fn parse_contract_address(output: &str) -> Result<ContractKt1Hash> {
         output,
     )?;
     Ok(ContractKt1Hash::from_base58_check(&raw_contract_hash)?)
+}
+
+fn parse_block_hash(output: &str) -> Result<BlockHash> {
+    let raw_block_hash = parse_regex(
+        "Operation found in block: (B[1-9A-HJ-NP-Za-km-z]{50})",
+        output,
+    )?;
+    Ok(BlockHash::from_base58_check(&raw_block_hash)?)
 }
 
 #[cfg(test)]
@@ -853,5 +885,35 @@ mod test {
             .set_from("tz1".to_string())
             .build();
         assert!(options.is_err_and(|e| e.to_string().contains("Missing to")));
+    }
+
+    #[test]
+    fn test_parse_block_hash() {
+        let block_hash = "BMTQKTFpvnW4rm1g4U5YndrRmca6Msz8pNqZZZ9HwcHmGLeWYV1";
+        assert_eq!(
+            parse_block_hash(&format!("Operation found in block: {block_hash} ()"))
+                .unwrap(),
+            BlockHash::from_base58_check(block_hash).unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_block_hash_pattern_mismatch() {
+        assert_eq!(
+            parse_block_hash("Operation found in block: foobar")
+                .unwrap_err()
+                .to_string(),
+            "input string does not match the pattern"
+        );
+    }
+
+    #[test]
+    fn parse_block_hash_bad_hash() {
+        assert_eq!(
+            parse_block_hash(&format!("Operation found in block: B{}", "1".repeat(50)))
+                .unwrap_err()
+                .to_string(),
+            "invalid checksum"
+        );
     }
 }


### PR DESCRIPTION
# Context

Completes JSTZ-144.
[JSTZ-144](https://linear.app/tezos/issue/JSTZ-144/implement-octezclientsend-rollup-inbox-message)

# Description

Implement `send_rollup_inbox_message` which performs `octez-client send smart rollup message <messages> from <src>`.

# Manually testing the PR

* Unit test: added tests for parsing block hashes from execution output
```sh
$ cargo test --lib async::client::test::test_parse_block_hash
running 1 test
test r#async::client::test::test_parse_block_hash ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 77 filtered out; finished in 0.00s
$ cargo test --lib async::client::test::parse_block_hash
running 2 tests
test r#async::client::test::parse_block_hash_pattern_mismatch ... ok
test r#async::client::test::parse_block_hash_bad_hash ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 76 filtered out; finished in 0.13s
```
* Integration test: added one test for `send_rollup_inbox_message` that looks for the corresponding `smart_rollup_add_messages` operation after calling octez-client.
```sh
$ cargo test --test octez_client_test send_rollup_inbox_message
< ... baker logs >
test send_rollup_inbox_message ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 14 filtered out; finished in 7.88s
```