### PR TITLE
feat(jstz_node): implement openapi for logs service

### DIFF
--- a/crates/jstz_api/src/js_log.rs
+++ b/crates/jstz_api/src/js_log.rs
@@ -5,8 +5,11 @@ use std::{
     cell::Cell,
     fmt::{self, Display},
 };
+use utoipa::ToSchema;
 
-#[derive(Serialize, Deserialize, PartialEq, PartialOrd, Clone, Debug, ValueEnum)]
+#[derive(
+    Serialize, Deserialize, PartialEq, PartialOrd, Clone, Debug, ValueEnum, ToSchema,
+)]
 pub enum LogLevel {
     ERROR = 1,
     WARN = 2,
@@ -35,6 +38,21 @@ impl LogLevel {
         }
     }
 }
+
+impl TryFrom<&str> for LogLevel {
+    type Error = String;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "ERROR" => Ok(LogLevel::ERROR),
+            "WARN" => Ok(LogLevel::WARN),
+            "INFO" => Ok(LogLevel::INFO),
+            "LOG" => Ok(LogLevel::LOG),
+            _ => Err(format!("Invalid LogLevel: {}", value)),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct LogData {
     pub level: LogLevel,

--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -209,6 +209,145 @@
         }
       }
     },
+    "/logs/{address}/persistent/requests": {
+      "get": {
+        "tags": [
+          "Logs"
+        ],
+        "summary": "Fetch console logs by address",
+        "description": "Fetch console logs by address from the log store only if persistent\nlogging is enabled on this Jstz node instance",
+        "operationId": "persistent_logs",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LogRecord"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": ""
+          },
+          "404": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/logs/{address}/persistent/requests/{request_id}": {
+      "get": {
+        "tags": [
+          "Logs"
+        ],
+        "summary": "Fetch console logs by address and request id",
+        "description": "Fetch console logs by address and request id from the log store only if persistent\nlogging is enabled on this Jstz node instance",
+        "operationId": "persistent_logs_by_request_id",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "request_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LogRecord"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": ""
+          },
+          "404": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/logs/{address}/stream": {
+      "get": {
+        "tags": [
+          "Logs"
+        ],
+        "summary": "Stream console logs",
+        "description": "Returns a stream of console logs from the given Smart Function as Server-Sent Events.",
+        "operationId": "stream_log",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully connected to log stream as Server-Sent Events"
+          },
+          "400": {
+            "description": ""
+          },
+          "404": {
+            "description": ""
+          }
+        }
+      }
+    },
     "/operations": {
       "post": {
         "tags": [
@@ -378,6 +517,38 @@
         "type": "string",
         "format": "json",
         "description": "A value stored in the Key-Value store. Always valid JSON."
+      },
+      "LogLevel": {
+        "type": "string",
+        "enum": [
+          "ERROR",
+          "WARN",
+          "INFO",
+          "LOG"
+        ]
+      },
+      "LogRecord": {
+        "type": "object",
+        "required": [
+          "address",
+          "request_id",
+          "level",
+          "text"
+        ],
+        "properties": {
+          "address": {
+            "$ref": "#/components/schemas/PublicKeyHash"
+          },
+          "level": {
+            "$ref": "#/components/schemas/LogLevel"
+          },
+          "request_id": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          }
+        }
       },
       "Nonce": {
         "type": "integer",

--- a/crates/jstz_node/src/services/error.rs
+++ b/crates/jstz_node/src/services/error.rs
@@ -11,6 +11,7 @@ pub enum ServiceError {
     FromAnyhow(anyhow::Error),
     NotFound,
     BadRequest(String),
+    PersistentLogsDisabled,
 }
 
 pub type ServiceResult<T> = anyhow::Result<T, ServiceError>;
@@ -24,6 +25,10 @@ impl IntoResponse for ServiceError {
             ServiceError::NotFound => StatusCode::NOT_FOUND.into_response(),
             ServiceError::BadRequest(error) => {
                 (StatusCode::BAD_REQUEST, error_body(error)).into_response()
+            }
+            ServiceError::PersistentLogsDisabled => {
+                ServiceError::BadRequest("Persistent logs disabled".to_string())
+                    .into_response()
             }
         }
     }

--- a/crates/jstz_node/src/services/logs/db.rs
+++ b/crates/jstz_node/src/services/logs/db.rs
@@ -1,8 +1,10 @@
 #![cfg(feature = "persistent-logging")]
 use std::fs;
 
-use super::{Line, QueryResponse};
+use super::Line;
 use anyhow::{anyhow, Result};
+use jstz_api::js_log::LogLevel;
+use jstz_crypto::public_key_hash::PublicKeyHash;
 use jstz_proto::{
     context::account::Address, js_logger::LogRecord, request_logger::RequestEvent,
 };
@@ -13,7 +15,7 @@ use tokio::task::spawn_blocking;
 
 pub type SqliteConnectionPool = Pool<SqliteConnectionManager>;
 pub type SqliteConnection = PooledConnection<r2d2_sqlite::SqliteConnectionManager>;
-type QueryResponseResult = Result<Vec<QueryResponse>>;
+type QueryResponseResult = Result<Vec<LogRecord>>;
 
 const DB_PATH: &str = ".jstz/log.db";
 
@@ -130,17 +132,30 @@ impl Db {
         mut stmt: Statement<'_>,
         params: P,
     ) -> QueryResponseResult {
-        let logs = stmt
+        let query_result = stmt
             .query_map(params, |row| {
-                Ok(QueryResponse::Log {
-                    level: row.get(1)?,
-                    content: row.get(2)?,
-                    function_address: row.get(3)?,
-                    request_id: row.get(4)?,
-                })
+                Ok((
+                    row.get::<usize, String>(1)?,
+                    row.get(2)?,
+                    row.get::<usize, String>(3)?,
+                    row.get(4)?,
+                ))
             })?
-            .filter_map(Result::ok)
-            .collect();
+            .filter_map(Result::ok);
+
+        // Process logs outside of `query_map` so that anyhow error
+        // can be returned on failure.
+        let mut logs: Vec<LogRecord> = Vec::new();
+        for (level, text, address, request_id) in query_result {
+            let log_record = LogRecord {
+                level: LogLevel::try_from(level.as_str())
+                    .map_err(|e| anyhow!(e.to_string()))?,
+                text,
+                address: PublicKeyHash::from_base58(address.as_str())?,
+                request_id,
+            };
+            logs.push(log_record)
+        }
 
         Ok(logs)
     }

--- a/crates/jstz_proto/src/js_logger.rs
+++ b/crates/jstz_proto/src/js_logger.rs
@@ -4,6 +4,7 @@ use boa_engine::prelude::Context;
 use jstz_core::{host::HostRuntime, host_defined, runtime};
 use serde::Deserialize;
 use serde::Serialize;
+use utoipa::ToSchema;
 
 use crate::{api::TraceData, context::account::Address};
 
@@ -11,7 +12,7 @@ pub use jstz_api::js_log::{JsLog, LogData, LogLevel};
 
 pub const LOG_PREFIX: &str = "[JSTZ:SMART_FUNCTION:LOG] ";
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, ToSchema)]
 pub struct LogRecord {
     pub address: Address,
     pub request_id: String,


### PR DESCRIPTION
# Context
Implements OpenAPI for LogsService
<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
 We probably want a single client gen binding that supports all node endpoints. With that in mind, the persistent log endpoints have been removed from conditional compilation and instead return a Bad Request if it is called on a node that was not compiled with persistent logging.

(Note: We should change enabling/disabling persistent logging enable from conditional compilation to runtime configuration)

Removed the `QueryResponse` which is a wrapper over LogRecord.

Removed `QueryParams` which acts as a function dispatch over the db api. Instead, just called the db api directly because they are 1 to 1 with their handlers.

# Manually testing the PR

```
cargo test -p jstz_node api_doc_regression
cargo test --features persisitent-logging -p jstz_node api_doc_regression
```

<!-- Describe how reviewers and approvers can test this PR. -->
