### PR TITLE
feat(ci): integrates stainless client lib gen into ci

### DIFF
--- a/.github/workflows/generate-node-client.yml
+++ b/.github/workflows/generate-node-client.yml
@@ -1,0 +1,19 @@
+name: Upload OpenAPI spec to Stainless
+
+on:
+  pull_request: # testing only
+  push:
+    branches: [main]
+
+jobs:
+  stainless:
+    concurrency: upload-openapi-spec-action
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: stainless-api/upload-openapi-spec-action@main
+        with:
+          stainless_api_key: ${{ secrets.STAINLESS_API_KEY }}
+          input_path: "crates/jstz_node/openapi.json"
+          config_path: "crates/jstz_node/stainless.yml"
+          project_name: "jstz-client"

--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -872,7 +872,8 @@
           },
           "headers": {
             "type": "object",
-            "description": "Any valid HTTP headers"
+            "description": "Any valid HTTP headers",
+            "additionalProperties": true
           },
           "method": {
             "type": "string",
@@ -916,7 +917,8 @@
           },
           "headers": {
             "type": "object",
-            "description": "Any valid HTTP headers"
+            "description": "Any valid HTTP headers",
+            "additionalProperties": true
           },
           "status_code": {
             "type": "integer",

--- a/crates/jstz_node/stainless.yml
+++ b/crates/jstz_node/stainless.yml
@@ -1,0 +1,133 @@
+# yaml-language-server: $schema=https://app.stainlessapi.com/config.schema.json
+
+organization:
+  # Name of your organization or company, used to determine the name of the client
+  # and headings.
+  name: jstz client # Strangely, the organisation name is used as the name of the root class
+  docs: https://jstz-dev.github.io/jstz/
+  contact: contact@trili.tech
+
+# `targets` define the output targets and their customization options, such as
+# whether to emit the Node SDK and what it's package name should be.
+targets:
+  node:
+    readme_title: Jstz Client
+    package_name: "@jstz-dev/client"
+    production_repo: null
+    publish:
+      npm: false
+
+# `client_settings` define settings for the API client, such as extra constructor
+# arguments (used for authentication), retry behavior, idempotency, etc.
+client_settings:
+  opts: {}
+
+# `environments` are a map of the name of the environment (e.g. "sandbox",
+# "production") to the corresponding url to use.
+environments:
+  production: https://localhost:8933
+
+# `pagination` defines [pagination schemes] which provides a template to match
+# endpoints and generate next-page and auto-pagination helpers in the SDKs.
+pagination: []
+
+# `resources` define the structure and organziation for your API, such as how
+# methods and models are grouped together and accessed. See the [configuration
+# guide] for more information.
+#
+# [configuration guide]:
+#   https://app.stainlessapi.com/docs/guides/configure#resources
+resources:
+  accounts:
+    # Subresources define resources that are nested within another for more powerful
+    # logical groupings, e.g. `cards.payments`.
+    subresources:
+      balance:
+        # Configure the methods defined in this resource. Each key in the object is the
+        # name of the method and the value is either an endpoint (for example, `get /foo`)
+        # or an object with more detail.
+        #
+        # [reference]: https://app.stainlessapi.com/docs/reference/config#method
+        methods:
+          retrieve: get /accounts/{address}/balance
+      code:
+        # Configure the models--named types--defined in the resource. Each key in the
+        # object is the name of the model and the value is either the name of a schema in
+        # `#/components/schemas` or an object with more detail.
+        #
+        # [reference]: https://app.stainlessapi.com/docs/reference/config#model
+        models:
+          parsedCode: ParsedCode
+        methods:
+          retrieve: get /accounts/{address}/code
+      kv:
+        models:
+          kvValue: KvValue
+        methods:
+          retrieve: get /accounts/{address}/kv
+        subresources:
+          subkeys:
+            methods:
+              list:
+                type: http
+                endpoint: get /accounts/{address}/kv/subkeys
+                paginated: false
+      nonce:
+        models:
+          nonce: Nonce
+        methods:
+          retrieve: get /accounts/{address}/nonce
+
+  logs:
+    models:
+      logRecord: LogRecord
+    methods:
+      stream: get /logs/{address}/stream
+    subresources:
+      persistent_requests:
+        methods:
+          list:
+            type: http
+            endpoint: get /logs/{address}/persistent/requests
+            paginated: false
+          retrieve: get /logs/{address}/persistent/requests/{request_id}
+
+  operations:
+    methods:
+      inject: post /operations
+    subresources:
+      receipt:
+        models:
+          receipt: Receipt
+        methods:
+          retrieve: get /operations/{operation_hash}/receipt
+
+  crypto:
+    models:
+      publicKey: PublicKey
+      publicKeyHash: PublicKeyHash
+      signature: Signature
+
+settings:
+  license: Apache-2.0
+
+# `readme` is used to configure the code snippets that will be rendered in the
+# README.md of various SDKs. In particular, you can change the `headline`
+# snippet's endpoint and the arguments to call it with.
+readme:
+  example_requests:
+    default:
+      type: request
+      endpoint: get /accounts/{address}/code
+      params: &ref_0
+        address: REPLACE_ME
+    headline:
+      type: request
+      endpoint: get /accounts/{address}/code
+      params: *ref_0
+    pagination:
+      type: request
+      endpoint: get /accounts/{address}/kv/subkeys
+      params:
+        address: REPLACE_ME
+  include_stainless_attribution: false

--- a/crates/jstz_proto/src/operation.rs
+++ b/crates/jstz_proto/src/operation.rs
@@ -111,10 +111,7 @@ pub struct RunFunction {
     pub method: Method,
     /// Any valid HTTP headers
     #[serde(with = "http_serde::header_map")]
-    #[schema(
-            value_type = Object,
-            additional_properties,
-        )]
+    #[schema(schema_with= openapi::http_headers)]
     pub headers: HeaderMap,
     #[schema(schema_with = openapi::http_body_schema)]
     pub body: HttpBody,
@@ -219,9 +216,19 @@ pub enum ExternalOperation {
 }
 
 pub mod openapi {
-    use utoipa::{openapi::Array, schema};
+    use utoipa::{
+        openapi::{schema::AdditionalProperties, Array, Object, ObjectBuilder},
+        schema,
+    };
 
     pub fn http_body_schema() -> Array {
         schema!(Option<Vec<u8>>).build()
+    }
+
+    pub fn http_headers() -> Object {
+        ObjectBuilder::new()
+            .additional_properties(Some(AdditionalProperties::FreeForm(true)))
+            .description(Some("Any valid HTTP headers"))
+            .build()
     }
 }

--- a/crates/jstz_proto/src/receipt.rs
+++ b/crates/jstz_proto/src/receipt.rs
@@ -62,7 +62,7 @@ pub struct RunFunctionReceipt {
     pub status_code: StatusCode,
     /// Any valid HTTP headers
     #[serde(with = "http_serde::header_map")]
-    #[schema(value_type = Object, additional_properties)]
+    #[schema(schema_with = crate::operation::openapi::http_headers)]
     pub headers: HeaderMap,
 }
 


### PR DESCRIPTION
# Context
This PR sets up [Stainless](https://app.stainlessapi.com/trilitech/projects) Github Action to automatically generate the client library and push changes to `jstz-client` repo.  The auto generated bindings will be useful as we continue to evolve the Jstz node endpoints and communication bindings. 

Generated code: https://github.com/jstz-dev/jstz-client


<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
* Adds generate client job
* Adds stainless.yaml config
* Represents operation hash as byte array

## Evaluation
Evaluation doc:  https://docs.google.com/document/d/1kU_xjPYoHaqgmewAZlJDpkJ25FTNnccq8Wb88YQhcFk/edit?usp=sharing

| | Description | Stainless
|-- | -- | --
| Code quality | Coherent generated code: (M1) Separation by resource, (M2) Sensible calling conventions and method names, (M3) Able to return the body type and Response, async, (M4) Idiomatic use of Typescript (M5) Package size(M6) Fetch configurability | (M1) + Types /Classes are separated by resource(M1) - Sub-resources are child types of resource ie. Type for subkey list is Jstz.Accounts.Kv.SubkeyListResponse(M2) + Calling convention are resource based ie. client.accounts.kv.subkeys.list(address)(M3) + Response are returned as Core.APIPromise<T>, an awaitable promises that returns T or can be converted into Response with asResponse() or withResponse()(M4) + OO Typescript(M4) + Namespaces to void conflicts(M6) + Client customisation eg. timeout, retries, custom fetch, agent for managing connections (M6) ~ Streamable response support via fetch API - cannot mark endpoint as returning a stream (could be an OAS definition problem)
Runtime compatibility |   | Node.js, Deno, Bun, browsers, and variousedge runtimes, as well as both CommonJS (CJS) and EcmaScript Modules (ESM).
Mock and testing |   | `Fetch` can be mocked
Customisability | Degree and ease of customising the code generation | + Method names, model references, and organisation can be controlled via stainless.yml config+ Patching with custom code by replaying patches for each generation
Language support |   | + Typescript- No Rust, not in roadmap~ SDK docs in roadmap
Developer experience |   | - No offline generation- No LSP to aid writing stainless configs~ Basic documentation
CI Integration | Degree and ease of integrating into CI | + GHA support- Dependent on Stainless platform to perform the code generation
Compatibility with OpenAPI 3.1 | Utopia generates OAS v3.1 | Yes





<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->
