### PR TITLE
feat(jstzd): implement health check endpoint in jstzd server

### DIFF
--- a/crates/jstzd/tests/jstzd_test.rs
+++ b/crates/jstzd/tests/jstzd_test.rs
@@ -58,7 +58,7 @@ async fn jstzd_test() {
     let mut jstzd = jstzd::task::jstzd::JstzdServer::new(config, jstzd_port);
     jstzd.run().await.unwrap();
 
-    let jstz_health_check_endpoint = format!("http://localhost:{}", jstzd_port);
+    let jstz_health_check_endpoint = format!("http://localhost:{}/health", jstzd_port);
     let octez_node_health_check_endpoint = format!("{}/health/ready", rpc_endpoint);
     let jstzd_running = retry(10, 1000, || async {
         let res = reqwest::get(&jstz_health_check_endpoint).await;


### PR DESCRIPTION
# Context

Part of JSTZ-121.

[JSTZ-121](https://linear.app/tezos/issue/JSTZ-121/endpoints-for-jstzd-server)

# Description

Added route `/health` to `JstzdServer`. Note that in this PR the octez node and baker instances in Jstzd are wrapped with `Arc<RwLock<_>>` because they need to be passed to the server as the state. I know we can just make baker derive `Clone` and then clone `JstzdServer.jstzd` and things under the hood are also wrapped with `Arc`, but I think it's clearer like this with explicit `Arc` and `RwLock` in this module and we know for sure that these instances are not duplicated but shared when they are cloned.

# Manually testing the PR

* Integration test: updated `crates/jstzd/tests/jstzd_test.rs` to use the health check endpoint
