### PR TITLE
fix(jstzd): mitigate test flakiness

### DIFF
--- a/crates/jstzd/tests/jstzd_test.rs
+++ b/crates/jstzd/tests/jstzd_test.rs
@@ -28,7 +28,7 @@ async fn jstzd_test() {
         // fund the account so that it can be used by the baker
         .set_bootstrap_accounts([BootstrapAccount::new(
             "edpkuSLWfVU1Vq7Jg9FucPyKmma6otcMHac9zG4oU1KMHSTBpJuGQ2",
-            6_000_000_000,
+            7_000_000_000,
         )
         .unwrap()])
         .build()
@@ -60,21 +60,21 @@ async fn jstzd_test() {
 
     let jstz_health_check_endpoint = format!("http://localhost:{}", jstzd_port);
     let octez_node_health_check_endpoint = format!("{}/health/ready", rpc_endpoint);
-    let jstzd_running = retry(10, 1000, || async {
+    let jstzd_running = retry(30, 1000, || async {
         let res = reqwest::get(&jstz_health_check_endpoint).await;
         Ok(res.is_ok())
     })
     .await;
     assert!(jstzd_running);
 
-    let node_running = retry(10, 1000, || async {
+    let node_running = retry(30, 1000, || async {
         let res = reqwest::get(&octez_node_health_check_endpoint).await;
         Ok(res.is_ok())
     })
     .await;
     assert!(node_running);
 
-    let baker_running = retry(10, 1000, || async {
+    let baker_running = retry(30, 1000, || async {
         if run_ps().await.contains("octez-baker") {
             let last_level = get_block_level(&rpc_endpoint.to_string()).await;
             return Ok(last_level > 2);
@@ -87,7 +87,7 @@ async fn jstzd_test() {
 
     jstzd.stop().await.unwrap();
 
-    let jstzd_stopped = retry(10, 1000, || async {
+    let jstzd_stopped = retry(30, 1000, || async {
         let res = reqwest::get(&jstz_health_check_endpoint).await;
         if let Err(e) = res {
             return Ok(e.to_string().contains("Connection refused"));
@@ -97,7 +97,7 @@ async fn jstzd_test() {
     .await;
     assert!(jstzd_stopped);
 
-    let node_destroyed = retry(10, 1000, || async {
+    let node_destroyed = retry(30, 1000, || async {
         let res = reqwest::get(&octez_node_health_check_endpoint).await;
         // Should get an error since the node should have been terminated
         if let Err(e) = res {

--- a/crates/jstzd/tests/octez_client_test.rs
+++ b/crates/jstzd/tests/octez_client_test.rs
@@ -285,8 +285,8 @@ async fn originate_contract_and_wait_for() {
 
     // test --check-previous
     tokio::time::timeout(
-        tokio::time::Duration::from_secs(2),
-        octez_client.wait_for(&op, None, Some(5)),
+        tokio::time::Duration::from_secs(5),
+        octez_client.wait_for(&op, None, Some(20)),
     )
     .await
     .expect("wait_for should complete soon enough")
@@ -294,19 +294,19 @@ async fn originate_contract_and_wait_for() {
 
     // test --branch
     tokio::time::timeout(
-        tokio::time::Duration::from_secs(2),
+        tokio::time::Duration::from_secs(5),
         octez_client.wait_for(&op, Some(&head), None),
     )
     .await
     .expect("wait_for should complete soon enough")
     .expect("wait_for should be able to find the operation");
 
-    tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
 
     // calling wait_for with the current head (after the operation was performed) should timeout
     let head = get_head_block_hash(&octez_node.rpc_endpoint().to_string()).await;
     tokio::time::timeout(
-        tokio::time::Duration::from_secs(2),
+        tokio::time::Duration::from_secs(5),
         octez_client.wait_for(&op, Some(&head), None),
     )
     .await
@@ -315,7 +315,7 @@ async fn originate_contract_and_wait_for() {
     // calling wait_for with the immediate previous block (after the operation was performed)
     // should time out
     tokio::time::timeout(
-        tokio::time::Duration::from_secs(2),
+        tokio::time::Duration::from_secs(10),
         octez_client.wait_for(&op, None, Some(1)),
     )
     .await


### PR DESCRIPTION
# Context

[CI](https://github.com/jstz-dev/jstz/actions/runs/11781846583/job/32815571186) just randomly failed (in some PR checks as well.) This happens a bit too often. For some reason,
* the baker process was not removed, i.e. still listed in `ps` output, after 10 seconds
* calling `octez-client wait for` took longer than expected when it should have returned almost immediately when the operation was present
* etc

and tests failed because of these. This never happened to me when I ran tests locally though.

# Description

Tweaked some test settings so that the tests are less likely to be flakey:
* Wait a bit longer in integration tests so that tests don't fail due to possibly some delay in the runner machine. That octez-client test might be longer, but it's still better than tests randomly failing.
* Give the `activator` account a bit more tez in `jstzd_test` so that it does not run out of fund after baking a few blocks.

# Manually testing the PR

All tests should still pass.
