### PR TITLE
feat(jstzd): use AsyncDropper in JstzdServer

### DIFF
--- a/crates/jstzd/tests/jstzd_test.rs
+++ b/crates/jstzd/tests/jstzd_test.rs
@@ -39,6 +39,12 @@ async fn jstzd_test() {
         .unwrap();
 
     ensure_jstzd_components_are_down(&jstzd, &rpc_endpoint, jstzd_port).await;
+
+    // calling `run` after calling `stop` should fail because all states should have been cleared
+    assert_eq!(
+        jstzd.run().await.unwrap_err().to_string(),
+        "cannot run jstzd server without jstzd config"
+    );
 }
 
 async fn create_jstzd_server(


### PR DESCRIPTION
# Context

Closes JSTZ-121.

[JSTZ-121](https://linear.app/tezos/issue/JSTZ-121/endpoints-for-jstzd-server)

# Description

Wrap the test in a future so that we can still call `stop` at the end of the test to clean up everything before the program exits should the test fail and panic. Otherwise, the test program does not actually close after the panic and the baker and octez-node  processes remain running even after the test program terminates.

In a tokio task, `panic` is captured and returned as `Err`, so handling failed assertions like this is much simpler than trying to do something like `catch_unwind`.

# Manually testing the PR

The test should still work as is.
