### PR TITLE
Fix: serde on enums

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,13 +60,14 @@ test: test-unit test-int
 test-unit:
 # --lib only runs unit tests in library crates
 # --bins only runs unit tests in binary crates
-	@cargo nextest run --lib --bins 
+	@cargo nextest run --lib --bins
 
 .PHONY: test-int
 test-int:
 # --test only runs a specified integration test (a test in /tests).
 #        the glob pattern is used to match all integration tests
-	@cargo nextest run --test "*"
+# --exclude excludes the jstz_api wpt test
+	@cargo nextest run --test "*" --workspace --exclude "jstz_api"
 
 .PHONY: cov 
 cov:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ endif
 CLI_KERNEL_PATH := crates/jstz_cli/jstz_kernel.wasm
 
 .PHONY: all
-all: test build check
+all: build test check
 
 .PHONY: build
 build: build-cli-kernel

--- a/crates/jstz_cli/src/deploy.rs
+++ b/crates/jstz_cli/src/deploy.rs
@@ -2,7 +2,7 @@ use boa_engine::JsError;
 use jstz_proto::{
     context::account::ParsedCode,
     operation::{Content, DeployFunction, Operation, SignedOperation},
-    receipt::ReceiptContent,
+    receipt::{ReceiptContent, ReceiptResult},
 };
 use log::{debug, info};
 
@@ -96,11 +96,11 @@ pub async fn exec(
     debug!("Receipt: {:?}", receipt);
 
     let address = match receipt.inner {
-        Ok(ReceiptContent::DeployFunction(deploy)) => deploy.address,
-        Ok(_) => {
+        ReceiptResult::Success(ReceiptContent::DeployFunction(deploy)) => deploy.address,
+        ReceiptResult::Success(_) => {
             bail!("Expected a `DeployFunction` receipt, but got something else.")
         }
-        Err(err) => {
+        ReceiptResult::Failed { source: err } => {
             bail_user_error!("Failed to deploy smart function with error {err:?}.")
         }
     };

--- a/crates/jstz_cli/src/deploy.rs
+++ b/crates/jstz_cli/src/deploy.rs
@@ -95,12 +95,12 @@ pub async fn exec(
 
     debug!("Receipt: {:?}", receipt);
 
-    let address = match receipt.inner {
+    let address = match receipt.result {
         ReceiptResult::Success(ReceiptContent::DeployFunction(deploy)) => deploy.address,
         ReceiptResult::Success(_) => {
             bail!("Expected a `DeployFunction` receipt, but got something else.")
         }
-        ReceiptResult::Failed { source: err } => {
+        ReceiptResult::Failed(err) => {
             bail_user_error!("Failed to deploy smart function with error {err:?}.")
         }
     };

--- a/crates/jstz_cli/src/run.rs
+++ b/crates/jstz_cli/src/run.rs
@@ -164,7 +164,7 @@ pub async fn exec(
     let receipt = jstz_client.wait_for_operation_receipt(&hash).await?;
 
     debug!("Receipt: {:?}", receipt);
-    let (status_code, headers, body) = match receipt.inner {
+    let (status_code, headers, body) = match receipt.result {
         ReceiptResult::Success(ReceiptContent::RunFunction(run_function)) => (
             run_function.status_code,
             run_function.headers,
@@ -174,7 +174,7 @@ pub async fn exec(
             bail!("Expected a `RunFunction` receipt, but got something else.")
         }
 
-        ReceiptResult::Failed { source: err } => bail_user_error!("{err}"),
+        ReceiptResult::Failed(err) => bail_user_error!("{err}"),
     };
 
     if let Some(spinner) = spinner.as_mut() {

--- a/crates/jstz_crypto/src/hash.rs
+++ b/crates/jstz_crypto/src/hash.rs
@@ -7,6 +7,7 @@ use boa_gc::{empty_trace, Finalize, Trace};
 use derive_more::{Display, Error};
 use hex::FromHexError;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 #[derive(
     Debug,
@@ -20,6 +21,7 @@ use serde::{Deserialize, Serialize};
     Deserialize,
     Default,
     Finalize,
+    ToSchema,
 )]
 pub struct Blake2b([u8; 32]);
 

--- a/crates/jstz_crypto/src/public_key.rs
+++ b/crates/jstz_crypto/src/public_key.rs
@@ -9,23 +9,24 @@ use utoipa::ToSchema;
 // Add BLS support
 /// Tezos public key
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, ToSchema)]
+#[serde(untagged)]
 pub enum PublicKey {
     #[schema(
         title = "Ed25519",
         value_type = String,
-        example = json!({ "Ed25519": "edpkukK9ecWxib28zi52nvbXTdsYt8rYcvmt5bdH8KjipWXm8sH3Qi" })
+        example = json!("edpkukK9ecWxib28zi52nvbXTdsYt8rYcvmt5bdH8KjipWXm8sH3Qi")
     )]
     Ed25519(PublicKeyEd25519),
     #[schema(
         title = "Secp256k1",
         value_type = String,
-        example = json!({ "Secp256k1": "sppk7aMwoVDiMGXkzwqPMrqHNE6QrZ1vAJ2CvTEeGZRLSSTM8jogmKY" })
+        example = json!("sppk7aMwoVDiMGXkzwqPMrqHNE6QrZ1vAJ2CvTEeGZRLSSTM8jogmKY")
     )]
     Secp256k1(PublicKeySecp256k1),
     #[schema(
         title = "P256",
         value_type = String,
-        example = json!({ "P256": "p2pk67ArUx3aDGyFgRco8N3pTnnnbodpP2FMZLAewV6ZAVvCxKjW3Q1" })
+        example = json!("p2pk67ArUx3aDGyFgRco8N3pTnnnbodpP2FMZLAewV6ZAVvCxKjW3Q1")
     )]
     P256(PublicKeyP256),
 }

--- a/crates/jstz_crypto/src/public_key_hash.rs
+++ b/crates/jstz_crypto/src/public_key_hash.rs
@@ -28,23 +28,24 @@ use crate::{
     Finalize,
     ToSchema,
 )]
+#[serde(untagged)]
 pub enum PublicKeyHash {
     #[schema(
         title = "Tz1",
         value_type = String,
-        example = json!({ "Tz1": "tz1cD5CuvAALcxgypqBXcBQEA8dkLJivoFjU" })
+        example = json!("tz1cD5CuvAALcxgypqBXcBQEA8dkLJivoFjU")
     )]
     Tz1(ContractTz1Hash),
     #[schema(
         title = "Tz2",
         value_type = String,
-        example =  json!({ "Tz2": "tz2KDvEL9fuvytRfe1cVVDo1QfDfaBktGNkh" })
+        example =  json!("tz2KDvEL9fuvytRfe1cVVDo1QfDfaBktGNkh")
     )]
     Tz2(ContractTz2Hash),
     #[schema(
         title = "Tz3",
         value_type = String,
-        example = json!({ "Tz3": "tz3QxNCB8HgxJyp5V9ZmCVGcTm6BzYc14k9C" })
+        example = json!("tz3QxNCB8HgxJyp5V9ZmCVGcTm6BzYc14k9C")
     )]
     Tz3(ContractTz3Hash),
 }

--- a/crates/jstz_crypto/src/secret_key.rs
+++ b/crates/jstz_crypto/src/secret_key.rs
@@ -6,6 +6,7 @@ use tezos_crypto_rs::hash::SecretKeyEd25519;
 use crate::{error::Result, signature::Signature};
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(untagged)]
 pub enum SecretKey {
     Ed25519(SecretKeyEd25519),
 }
@@ -59,8 +60,7 @@ mod test {
 
     #[test]
     fn json_round_trip() {
-        let json =
-            r#"{"Ed25519":"edsk3YuM4VFTRxq4LmWzf293iEdgramaDhgVnx3ij3CzgQTeDRcb1Q"}"#;
+        let json = "\"edsk3YuM4VFTRxq4LmWzf293iEdgramaDhgVnx3ij3CzgQTeDRcb1Q\"";
         let sk: SecretKey = serde_json::from_str(json).expect("Should not fail");
         assert_eq!(
             sk.to_string(),

--- a/crates/jstz_crypto/src/signature.rs
+++ b/crates/jstz_crypto/src/signature.rs
@@ -8,23 +8,24 @@ use utoipa::ToSchema;
 #[derive(
     Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, ToSchema,
 )]
+#[serde(untagged)]
 pub enum Signature {
     #[schema(
         title = "Ed25519 signature", 
         value_type = String,
-        example = json!({ "Ed25519": "edsigtpe2oRBMFdrrwf99ETNjmBaRzNDexDjhancfQdz5phrwyPPhRi9L7kzJD4cAW1fFcsyTJcTDPP8W4H168QPQdGPKe7jrZB" }
-    ))]
+        example = json!("edsigtpe2oRBMFdrrwf99ETNjmBaRzNDexDjhancfQdz5phrwyPPhRi9L7kzJD4cAW1fFcsyTJcTDPP8W4H168QPQdGPKe7jrZB")
+    )]
     Ed25519(tezos_crypto_rs::hash::Ed25519Signature),
     #[schema(
         title = "Secp256k1 signature", 
         value_type = String,
-        example = json!({ "Secp256k1": "spsig1NajZUT4nSiWU7UiV98fmmsjApFFYwPHtiDiJfGMgGL6oP3U9SPEccTfhAPdnAcvJ6AUSQ8EBPxYNX4UeNNDLBxVg9qv5H" })
+        example = json!("spsig1NajZUT4nSiWU7UiV98fmmsjApFFYwPHtiDiJfGMgGL6oP3U9SPEccTfhAPdnAcvJ6AUSQ8EBPxYNX4UeNNDLBxVg9qv5H")
     )]
     Secp256k1(tezos_crypto_rs::hash::Secp256k1Signature),
     #[schema(
         title = "P256 signature", 
         value_type = String,
-        example = json!({ "P256": "p2signEdtYeHXyWfCaGej9AFv7QraDsunRimyK47YGBQRNDEPXPQctwjPxbyFbTUtVLsACzG8QTrLAxddjjTRikF3nThwKL8nH" })
+        example = json!("p2signEdtYeHXyWfCaGej9AFv7QraDsunRimyK47YGBQRNDEPXPQctwjPxbyFbTUtVLsACzG8QTrLAxddjjTRikF3nThwKL8nH")
     )]
     P256(tezos_crypto_rs::hash::P256Signature),
 }

--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -465,7 +465,10 @@
             ],
             "title": "RunFunction"
           }
-        ]
+        ],
+        "discriminator": {
+          "propertyName": "_type"
+        }
       },
       "DeployFunction": {
         "type": "object",
@@ -662,13 +665,13 @@
         "type": "object",
         "required": [
           "hash",
-          "inner"
+          "result"
         ],
         "properties": {
           "hash": {
             "type": "string"
           },
-          "inner": {
+          "result": {
             "$ref": "#/components/schemas/ReceiptResult"
           }
         }
@@ -785,37 +788,37 @@
             ],
             "title": "FaWithdraw"
           }
-        ]
+        ],
+        "discriminator": {
+          "propertyName": "_type"
+        }
       },
       "ReceiptResult": {
         "oneOf": [
           {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ReceiptContent"
-              },
-              {
-                "type": "object",
-                "required": [
-                  "_type"
-                ],
-                "properties": {
-                  "_type": {
-                    "type": "string",
-                    "enum": [
-                      "Success"
-                    ]
-                  }
-                }
-              }
+            "type": "object",
+            "title": "Success",
+            "required": [
+              "inner",
+              "_type"
             ],
-            "title": "Success"
+            "properties": {
+              "_type": {
+                "type": "string",
+                "enum": [
+                  "Success"
+                ]
+              },
+              "inner": {
+                "$ref": "#/components/schemas/ReceiptContent"
+              }
+            }
           },
           {
             "type": "object",
             "title": "Failure",
             "required": [
-              "source",
+              "inner",
               "_type"
             ],
             "properties": {
@@ -825,7 +828,7 @@
                   "Failed"
                 ]
               },
-              "source": {
+              "inner": {
                 "type": "string"
               }
             }

--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -440,7 +440,8 @@
                   }
                 }
               }
-            ]
+            ],
+            "title": "DeployFunction"
           },
           {
             "allOf": [
@@ -461,7 +462,8 @@
                   }
                 }
               }
-            ]
+            ],
+            "title": "RunFunction"
           }
         ]
       },
@@ -667,122 +669,16 @@
             "type": "string"
           },
           "inner": {
-            "$ref": "#/components/schemas/ReceiptResult_ReceiptContent"
+            "$ref": "#/components/schemas/ReceiptResult"
           }
         }
       },
-      "ReceiptResult_ReceiptContent": {
+      "ReceiptContent": {
         "oneOf": [
           {
             "allOf": [
               {
-                "oneOf": [
-                  {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/DeployFunctionReceipt"
-                      },
-                      {
-                        "type": "object",
-                        "required": [
-                          "_type"
-                        ],
-                        "properties": {
-                          "_type": {
-                            "type": "string",
-                            "enum": [
-                              "DeployFunction"
-                            ]
-                          }
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/RunFunctionReceipt"
-                      },
-                      {
-                        "type": "object",
-                        "required": [
-                          "_type"
-                        ],
-                        "properties": {
-                          "_type": {
-                            "type": "string",
-                            "enum": [
-                              "RunFunction"
-                            ]
-                          }
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/DepositReceipt"
-                      },
-                      {
-                        "type": "object",
-                        "required": [
-                          "_type"
-                        ],
-                        "properties": {
-                          "_type": {
-                            "type": "string",
-                            "enum": [
-                              "Deposit"
-                            ]
-                          }
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/FaDepositReceipt"
-                      },
-                      {
-                        "type": "object",
-                        "required": [
-                          "_type"
-                        ],
-                        "properties": {
-                          "_type": {
-                            "type": "string",
-                            "enum": [
-                              "FaDeposit"
-                            ]
-                          }
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/FaWithdrawReceipt"
-                      },
-                      {
-                        "type": "object",
-                        "required": [
-                          "_type"
-                        ],
-                        "properties": {
-                          "_type": {
-                            "type": "string",
-                            "enum": [
-                              "FaWithdraw"
-                            ]
-                          }
-                        }
-                      }
-                    ]
-                  }
-                ]
+                "$ref": "#/components/schemas/DeployFunctionReceipt"
               },
               {
                 "type": "object",
@@ -793,24 +689,144 @@
                   "_type": {
                     "type": "string",
                     "enum": [
-                      "Ok"
+                      "DeployFunction"
                     ]
                   }
                 }
               }
-            ]
+            ],
+            "title": "DeployFunction"
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RunFunctionReceipt"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "_type"
+                ],
+                "properties": {
+                  "_type": {
+                    "type": "string",
+                    "enum": [
+                      "RunFunction"
+                    ]
+                  }
+                }
+              }
+            ],
+            "title": "RunFunction"
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DepositReceipt"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "_type"
+                ],
+                "properties": {
+                  "_type": {
+                    "type": "string",
+                    "enum": [
+                      "Deposit"
+                    ]
+                  }
+                }
+              }
+            ],
+            "title": "Deposit"
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FaDepositReceipt"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "_type"
+                ],
+                "properties": {
+                  "_type": {
+                    "type": "string",
+                    "enum": [
+                      "FaDeposit"
+                    ]
+                  }
+                }
+              }
+            ],
+            "title": "FaDeposit"
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FaWithdrawReceipt"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "_type"
+                ],
+                "properties": {
+                  "_type": {
+                    "type": "string",
+                    "enum": [
+                      "FaWithdraw"
+                    ]
+                  }
+                }
+              }
+            ],
+            "title": "FaWithdraw"
+          }
+        ]
+      },
+      "ReceiptResult": {
+        "oneOf": [
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ReceiptContent"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "_type"
+                ],
+                "properties": {
+                  "_type": {
+                    "type": "string",
+                    "enum": [
+                      "Success"
+                    ]
+                  }
+                }
+              }
+            ],
+            "title": "Success"
           },
           {
             "type": "object",
+            "title": "Failure",
             "required": [
+              "source",
               "_type"
             ],
             "properties": {
               "_type": {
                 "type": "string",
                 "enum": [
-                  "Err"
+                  "Failed"
                 ]
+              },
+              "source": {
+                "type": "string"
               }
             }
           }

--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -582,49 +582,19 @@
       "PublicKey": {
         "oneOf": [
           {
-            "type": "object",
+            "type": "string",
             "title": "Ed25519",
-            "required": [
-              "Ed25519"
-            ],
-            "properties": {
-              "Ed25519": {
-                "type": "string"
-              }
-            },
-            "example": {
-              "Ed25519": "edpkukK9ecWxib28zi52nvbXTdsYt8rYcvmt5bdH8KjipWXm8sH3Qi"
-            }
+            "example": "edpkukK9ecWxib28zi52nvbXTdsYt8rYcvmt5bdH8KjipWXm8sH3Qi"
           },
           {
-            "type": "object",
+            "type": "string",
             "title": "Secp256k1",
-            "required": [
-              "Secp256k1"
-            ],
-            "properties": {
-              "Secp256k1": {
-                "type": "string"
-              }
-            },
-            "example": {
-              "Secp256k1": "sppk7aMwoVDiMGXkzwqPMrqHNE6QrZ1vAJ2CvTEeGZRLSSTM8jogmKY"
-            }
+            "example": "sppk7aMwoVDiMGXkzwqPMrqHNE6QrZ1vAJ2CvTEeGZRLSSTM8jogmKY"
           },
           {
-            "type": "object",
+            "type": "string",
             "title": "P256",
-            "required": [
-              "P256"
-            ],
-            "properties": {
-              "P256": {
-                "type": "string"
-              }
-            },
-            "example": {
-              "P256": "p2pk67ArUx3aDGyFgRco8N3pTnnnbodpP2FMZLAewV6ZAVvCxKjW3Q1"
-            }
+            "example": "p2pk67ArUx3aDGyFgRco8N3pTnnnbodpP2FMZLAewV6ZAVvCxKjW3Q1"
           }
         ],
         "description": "Tezos public key"
@@ -632,49 +602,19 @@
       "PublicKeyHash": {
         "oneOf": [
           {
-            "type": "object",
+            "type": "string",
             "title": "Tz1",
-            "required": [
-              "Tz1"
-            ],
-            "properties": {
-              "Tz1": {
-                "type": "string"
-              }
-            },
-            "example": {
-              "Tz1": "tz1cD5CuvAALcxgypqBXcBQEA8dkLJivoFjU"
-            }
+            "example": "tz1cD5CuvAALcxgypqBXcBQEA8dkLJivoFjU"
           },
           {
-            "type": "object",
+            "type": "string",
             "title": "Tz2",
-            "required": [
-              "Tz2"
-            ],
-            "properties": {
-              "Tz2": {
-                "type": "string"
-              }
-            },
-            "example": {
-              "Tz2": "tz2KDvEL9fuvytRfe1cVVDo1QfDfaBktGNkh"
-            }
+            "example": "tz2KDvEL9fuvytRfe1cVVDo1QfDfaBktGNkh"
           },
           {
-            "type": "object",
+            "type": "string",
             "title": "Tz3",
-            "required": [
-              "Tz3"
-            ],
-            "properties": {
-              "Tz3": {
-                "type": "string"
-              }
-            },
-            "example": {
-              "Tz3": "tz3QxNCB8HgxJyp5V9ZmCVGcTm6BzYc14k9C"
-            }
+            "example": "tz3QxNCB8HgxJyp5V9ZmCVGcTm6BzYc14k9C"
           }
         ],
         "description": "Tezos Address"
@@ -856,49 +796,19 @@
       "Signature": {
         "oneOf": [
           {
-            "type": "object",
+            "type": "string",
             "title": "Ed25519 signature",
-            "required": [
-              "Ed25519"
-            ],
-            "properties": {
-              "Ed25519": {
-                "type": "string"
-              }
-            },
-            "example": {
-              "Ed25519": "edsigtpe2oRBMFdrrwf99ETNjmBaRzNDexDjhancfQdz5phrwyPPhRi9L7kzJD4cAW1fFcsyTJcTDPP8W4H168QPQdGPKe7jrZB"
-            }
+            "example": "edsigtpe2oRBMFdrrwf99ETNjmBaRzNDexDjhancfQdz5phrwyPPhRi9L7kzJD4cAW1fFcsyTJcTDPP8W4H168QPQdGPKe7jrZB"
           },
           {
-            "type": "object",
+            "type": "string",
             "title": "Secp256k1 signature",
-            "required": [
-              "Secp256k1"
-            ],
-            "properties": {
-              "Secp256k1": {
-                "type": "string"
-              }
-            },
-            "example": {
-              "Secp256k1": "spsig1NajZUT4nSiWU7UiV98fmmsjApFFYwPHtiDiJfGMgGL6oP3U9SPEccTfhAPdnAcvJ6AUSQ8EBPxYNX4UeNNDLBxVg9qv5H"
-            }
+            "example": "spsig1NajZUT4nSiWU7UiV98fmmsjApFFYwPHtiDiJfGMgGL6oP3U9SPEccTfhAPdnAcvJ6AUSQ8EBPxYNX4UeNNDLBxVg9qv5H"
           },
           {
-            "type": "object",
+            "type": "string",
             "title": "P256 signature",
-            "required": [
-              "P256"
-            ],
-            "properties": {
-              "P256": {
-                "type": "string"
-              }
-            },
-            "example": {
-              "P256": "p2signEdtYeHXyWfCaGej9AFv7QraDsunRimyK47YGBQRNDEPXPQctwjPxbyFbTUtVLsACzG8QTrLAxddjjTRikF3nThwKL8nH"
-            }
+            "example": "p2signEdtYeHXyWfCaGej9AFv7QraDsunRimyK47YGBQRNDEPXPQctwjPxbyFbTUtVLsACzG8QTrLAxddjjTRikF3nThwKL8nH"
           }
         ]
       },

--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -422,26 +422,46 @@
       "Content": {
         "oneOf": [
           {
-            "type": "object",
-            "required": [
-              "DeployFunction"
-            ],
-            "properties": {
-              "DeployFunction": {
+            "allOf": [
+              {
                 "$ref": "#/components/schemas/DeployFunction"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "_type"
+                ],
+                "properties": {
+                  "_type": {
+                    "type": "string",
+                    "enum": [
+                      "DeployFunction"
+                    ]
+                  }
+                }
               }
-            }
+            ]
           },
           {
-            "type": "object",
-            "required": [
-              "RunFunction"
-            ],
-            "properties": {
-              "RunFunction": {
+            "allOf": [
+              {
                 "$ref": "#/components/schemas/RunFunction"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "_type"
+                ],
+                "properties": {
+                  "_type": {
+                    "type": "string",
+                    "enum": [
+                      "RunFunction"
+                    ]
+                  }
+                }
               }
-            }
+            ]
           }
         ]
       },
@@ -470,6 +490,23 @@
         "properties": {
           "address": {
             "$ref": "#/components/schemas/PublicKeyHash"
+          }
+        }
+      },
+      "DepositReceipt": {
+        "type": "object",
+        "required": [
+          "account",
+          "updated_balance"
+        ],
+        "properties": {
+          "account": {
+            "$ref": "#/components/schemas/PublicKeyHash"
+          },
+          "updated_balance": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
           }
         }
       },
@@ -637,75 +674,143 @@
       "ReceiptResult_ReceiptContent": {
         "oneOf": [
           {
-            "type": "object",
-            "required": [
-              "Ok"
-            ],
-            "properties": {
-              "Ok": {
+            "allOf": [
+              {
                 "oneOf": [
                   {
-                    "type": "object",
-                    "required": [
-                      "DeployFunction"
-                    ],
-                    "properties": {
-                      "DeployFunction": {
+                    "allOf": [
+                      {
                         "$ref": "#/components/schemas/DeployFunctionReceipt"
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "_type"
+                        ],
+                        "properties": {
+                          "_type": {
+                            "type": "string",
+                            "enum": [
+                              "DeployFunction"
+                            ]
+                          }
+                        }
                       }
-                    }
-                  },
-                  {
-                    "type": "object",
-                    "required": [
-                      "RunFunction"
-                    ],
-                    "properties": {
-                      "RunFunction": {
-                        "$ref": "#/components/schemas/RunFunctionReceipt"
-                      }
-                    }
-                  },
-                  {
-                    "type": "string",
-                    "enum": [
-                      "Deposit"
                     ]
                   },
                   {
-                    "type": "object",
-                    "required": [
-                      "FaDeposit"
-                    ],
-                    "properties": {
-                      "FaDeposit": {
-                        "$ref": "#/components/schemas/FaDepositReceipt"
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/RunFunctionReceipt"
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "_type"
+                        ],
+                        "properties": {
+                          "_type": {
+                            "type": "string",
+                            "enum": [
+                              "RunFunction"
+                            ]
+                          }
+                        }
                       }
-                    }
+                    ]
                   },
                   {
-                    "type": "object",
-                    "required": [
-                      "FaWithdraw"
-                    ],
-                    "properties": {
-                      "FaWithdraw": {
-                        "$ref": "#/components/schemas/FaWithdrawReceipt"
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/DepositReceipt"
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "_type"
+                        ],
+                        "properties": {
+                          "_type": {
+                            "type": "string",
+                            "enum": [
+                              "Deposit"
+                            ]
+                          }
+                        }
                       }
-                    }
+                    ]
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/FaDepositReceipt"
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "_type"
+                        ],
+                        "properties": {
+                          "_type": {
+                            "type": "string",
+                            "enum": [
+                              "FaDeposit"
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/FaWithdrawReceipt"
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "_type"
+                        ],
+                        "properties": {
+                          "_type": {
+                            "type": "string",
+                            "enum": [
+                              "FaWithdraw"
+                            ]
+                          }
+                        }
+                      }
+                    ]
                   }
                 ]
+              },
+              {
+                "type": "object",
+                "required": [
+                  "_type"
+                ],
+                "properties": {
+                  "_type": {
+                    "type": "string",
+                    "enum": [
+                      "Ok"
+                    ]
+                  }
+                }
               }
-            }
+            ]
           },
           {
             "type": "object",
             "required": [
-              "Err"
+              "_type"
             ],
             "properties": {
-              "Err": {
-                "type": "string"
+              "_type": {
+                "type": "string",
+                "enum": [
+                  "Err"
+                ]
               }
             }
           }

--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -419,6 +419,14 @@
   },
   "components": {
     "schemas": {
+      "Blake2b": {
+        "type": "array",
+        "items": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 0
+        }
+      },
       "Content": {
         "oneOf": [
           {
@@ -669,7 +677,7 @@
         ],
         "properties": {
           "hash": {
-            "type": "string"
+            "$ref": "#/components/schemas/Blake2b"
           },
           "result": {
             "$ref": "#/components/schemas/ReceiptResult"

--- a/crates/jstz_node/src/api_doc.rs
+++ b/crates/jstz_node/src/api_doc.rs
@@ -1,4 +1,7 @@
-use utoipa::OpenApi;
+use utoipa::{
+    openapi::{schema::ArrayItems, Discriminator, OneOf, RefOr, Schema},
+    OpenApi,
+};
 
 #[derive(OpenApi)]
 #[openapi(info(
@@ -11,3 +14,229 @@ use utoipa::OpenApi;
     contact(name = "Trilitech", email = "contact@trili.tech"),
 ))]
 pub struct ApiDoc;
+
+/// Modify OpenAPI doc after its been generated
+pub fn modify(openapi: &mut utoipa::openapi::OpenApi) {
+    if let Some(components) = &mut openapi.components {
+        let schemas = &mut components.schemas;
+        for (_, schema) in schemas.iter_mut() {
+            modify_with_discrminator(schema);
+        }
+    }
+}
+
+/// Adds discriminator property to `oneOf` Schemas by checking if all of its variants
+/// contain the `_type` discriminator property that was generate by serde + utoipa.
+/// Recursively applies the modification to all nodes in the Schema tree
+fn modify_with_discrminator(schema: &mut RefOr<Schema>) {
+    match schema {
+        RefOr::T(Schema::AllOf(all_of)) => {
+            for all_of_schema in all_of.items.iter_mut() {
+                modify_with_discrminator(all_of_schema)
+            }
+        }
+        RefOr::T(Schema::AnyOf(any_of)) => {
+            for item in any_of.items.iter_mut() {
+                modify_with_discrminator(item)
+            }
+        }
+        RefOr::T(Schema::OneOf(one_of)) => {
+            if is_sum_type(one_of) {
+                add_discriminator(one_of)
+            }
+        }
+        RefOr::T(Schema::Array(array)) => match &mut array.items {
+            ArrayItems::RefOrSchema(ref_or_schema) => {
+                modify_with_discrminator(ref_or_schema)
+            }
+            ArrayItems::False => (),
+        },
+        RefOr::T(Schema::Object(obj)) => {
+            for (_, property_schema) in obj.properties.iter_mut() {
+                modify_with_discrminator(property_schema)
+            }
+        }
+        RefOr::T(_) => (),
+        RefOr::Ref(_) => (),
+    }
+}
+
+/// Checks that all items in `one_of` are allOfs where at least
+/// one member of the allOf set is an object with a single property
+/// named "_type"
+fn is_sum_type(one_of: &OneOf) -> bool {
+    one_of.items.iter().all(|item| match item {
+        RefOr::T(Schema::AllOf(all_of)) => {
+            all_of.items.iter().any(|all_of_item| match all_of_item {
+                RefOr::T(Schema::Object(obj)) => {
+                    if obj.properties.len() != 1 {
+                        return false;
+                    }
+                    obj.properties.contains_key("_type")
+                }
+                _ => false,
+            })
+        }
+        _ => false,
+    })
+}
+
+fn add_discriminator(one_of: &mut OneOf) {
+    if one_of.discriminator.is_none() {
+        let discrimator = Discriminator::new("_type");
+        one_of.discriminator = Some(discrimator)
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use jstz_crypto::public_key_hash::PublicKeyHash;
+    use jstz_proto::{operation::Content, receipt::ReceiptContent};
+    use utoipa::{
+        openapi::{
+            schema::{ArrayItems, SchemaType},
+            AllOfBuilder, ArrayBuilder, ComponentsBuilder, ObjectBuilder, OpenApi,
+            OpenApiBuilder, RefOr, Schema, Type,
+        },
+        schema, PartialSchema,
+    };
+
+    use super::modify;
+
+    fn unsafe_get_schema(
+        open_api: &OpenApi,
+        schema_name: impl Into<String>,
+    ) -> RefOr<Schema> {
+        open_api
+            .components
+            .clone()
+            .unwrap()
+            .schemas
+            .get(schema_name.into().as_str())
+            .unwrap()
+            .clone()
+    }
+
+    fn check_contains_discriminator(schema: RefOr<Schema>) {
+        assert!(matches!(schema, RefOr::T(Schema::OneOf(one_of))
+             if one_of.discriminator.clone().unwrap().property_name == "_type"))
+    }
+
+    fn check_discriminator(
+        open_api: &OpenApi,
+        schema_name: impl Into<String>,
+        discriminator_should_exist: bool,
+    ) {
+        let schema = unsafe_get_schema(open_api, schema_name);
+        if discriminator_should_exist {
+            check_contains_discriminator(schema)
+        } else if let RefOr::T(Schema::OneOf(one_of)) = schema {
+            assert!(one_of.discriminator.is_none())
+        }
+    }
+
+    #[test]
+    fn modify_discriminator_one_of() {
+        let mut open_api = OpenApiBuilder::new()
+            .components(Some(
+                ComponentsBuilder::new()
+                    .schema_from::<ReceiptContent>()
+                    .schema_from::<Content>()
+                    .build(),
+            ))
+            .build();
+
+        modify(&mut open_api);
+        check_discriminator(&open_api, "ReceiptContent", true);
+        check_discriminator(&open_api, "Content", true);
+    }
+
+    #[test]
+    fn modify_discriminator_one_of_non_discriminant_type() {
+        let mut open_api = OpenApiBuilder::new()
+            .components(Some(
+                ComponentsBuilder::new()
+                    .schema_from::<PublicKeyHash>()
+                    .build(),
+            ))
+            .build();
+        modify(&mut open_api);
+        check_discriminator(&open_api, "PublicKeyHash", false);
+    }
+
+    #[test]
+    fn modify_discriminator_on_all_of() {
+        let mut open_api = OpenApiBuilder::new()
+            .components(Some(
+                ComponentsBuilder::new()
+                    .schema(
+                        "Test",
+                        AllOfBuilder::new().item(
+                            ObjectBuilder::new()
+                                .schema_type(SchemaType::Type(Type::String)),
+                        ),
+                    )
+                    .build(),
+            ))
+            .build();
+        modify(&mut open_api);
+        check_discriminator(&open_api, "Test", false);
+    }
+
+    #[test]
+    fn modify_discriminator_on_array() {
+        let mut open_api = OpenApiBuilder::new()
+            .components(Some(
+                ComponentsBuilder::new()
+                    .schema("Test", ArrayBuilder::new().items(ReceiptContent::schema()))
+                    .build(),
+            ))
+            .build();
+        modify(&mut open_api);
+
+        check_discriminator(&open_api, "Test", false);
+
+        let array = unsafe_get_schema(&open_api, "Test");
+        match array {
+            RefOr::T(Schema::Array(arr)) => {
+                if let ArrayItems::RefOrSchema(schema) = arr.items {
+                    // Checks that inner inline schema definitions
+                    // are modified
+                    check_contains_discriminator(*schema)
+                } else {
+                    panic!("Expected schema")
+                }
+            }
+            _ => panic!("Expected array"),
+        }
+    }
+
+    #[test]
+    fn modify_discrminator_on_object() {
+        let mut open_api = OpenApiBuilder::new()
+            .components(Some(
+                ComponentsBuilder::new()
+                    .schema(
+                        "Test",
+                        ObjectBuilder::new()
+                            .property("test", schema!(Vec<String>))
+                            .property("content", Content::schema())
+                            .build(),
+                    )
+                    .build(),
+            ))
+            .build();
+        modify(&mut open_api);
+        check_discriminator(&open_api, "Test", false);
+
+        let object = unsafe_get_schema(&open_api, "Test");
+        match object {
+            RefOr::T(Schema::Object(obj)) => {
+                let content = obj.properties.get("content").unwrap();
+                check_contains_discriminator(content.clone())
+            }
+            _ => panic!("Expected object"),
+        }
+    }
+}

--- a/crates/jstz_proto/src/api/smart_function.rs
+++ b/crates/jstz_proto/src/api/smart_function.rs
@@ -340,7 +340,7 @@ mod test {
                     "Content-type": "application/json",
                 },
                 body: JSON.stringify({
-                    receiver: { Tz1: "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx" },
+                    receiver: "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx",
                     amount: 5,
                 }),
             });
@@ -435,7 +435,7 @@ mod test {
                             body: JSON.stringify({{
                                 amount: {withdraw_amount},
                                 routing_info: {{
-                                    receiver: {{ Tz1: "{receiver}" }},
+                                    receiver: "{receiver}",
                                     proxy_l1_contract: "{l1_proxy_contract}"
                                 }},
                                 ticket_info: {{

--- a/crates/jstz_proto/src/context/account.rs
+++ b/crates/jstz_proto/src/context/account.rs
@@ -159,7 +159,7 @@ impl Account {
         tx: &mut Transaction,
         addr: &Address,
         amount: Amount,
-    ) -> Result<()> {
+    ) -> Result<u64> {
         let account = Self::get_mut(hrt, tx, addr)?;
         let checked_balance = account
             .amount
@@ -167,7 +167,7 @@ impl Account {
             .ok_or(crate::error::Error::BalanceOverflow)?;
 
         account.amount = checked_balance;
-        Ok(())
+        Ok(account.amount)
     }
 
     pub fn sub_balance(
@@ -175,13 +175,13 @@ impl Account {
         tx: &mut Transaction,
         addr: &Address,
         amount: Amount,
-    ) -> Result<()> {
+    ) -> Result<u64> {
         let account = Self::get_mut(hrt, tx, addr)?;
         if account.amount < amount {
             return Err(Error::InsufficientFunds)?;
         }
         account.amount -= amount;
-        Ok(())
+        Ok(account.amount)
     }
 
     pub fn set_balance(

--- a/crates/jstz_proto/src/executor/deposit.rs
+++ b/crates/jstz_proto/src/executor/deposit.rs
@@ -54,13 +54,13 @@ mod test {
         tx.begin();
         let receipt = execute(&mut host, &mut tx, deposit);
         assert!(matches!(
-            receipt.clone().inner,
+            receipt.clone().result,
             ReceiptResult::Success(ReceiptContent::Deposit(DepositReceipt {
                 account,
                 updated_balance,
             })) if account == receiver && updated_balance == 20
         ));
-        let raw_json_payload = r#"{"hash":[39,12,7,148,87,7,176,168,111,219,214,147,14,123,179,202,232,151,138,59,207,182,101,158,128,98,239,57,236,88,195,42],"inner":{"_type":"Success","inner":{"_type":"DepositReceipt","account":"tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx","updated_balance":20}}}"#;
+        let raw_json_payload = r#"{"hash":[39,12,7,148,87,7,176,168,111,219,214,147,14,123,179,202,232,151,138,59,207,182,101,158,128,98,239,57,236,88,195,42],"result":{"_type":"Success","inner":{"_type":"Deposit","account":"tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx","updated_balance":20}}}"#;
         assert_eq!(raw_json_payload, serde_json::to_string(&receipt).unwrap());
     }
 }

--- a/crates/jstz_proto/src/executor/deposit.rs
+++ b/crates/jstz_proto/src/executor/deposit.rs
@@ -36,7 +36,7 @@ mod test {
 
     use crate::{
         operation::external::Deposit,
-        receipt::{DepositReceipt, ReceiptContent},
+        receipt::{DepositReceipt, ReceiptContent, ReceiptResult},
     };
 
     use super::execute;
@@ -54,11 +54,13 @@ mod test {
         tx.begin();
         let receipt = execute(&mut host, &mut tx, deposit);
         assert!(matches!(
-            receipt.inner,
-            Ok(ReceiptContent::Deposit(DepositReceipt {
+            receipt.clone().inner,
+            ReceiptResult::Success(ReceiptContent::Deposit(DepositReceipt {
                 account,
                 updated_balance,
             })) if account == receiver && updated_balance == 20
-        ))
+        ));
+        let raw_json_payload = r#"{"hash":[39,12,7,148,87,7,176,168,111,219,214,147,14,123,179,202,232,151,138,59,207,182,101,158,128,98,239,57,236,88,195,42],"inner":{"_type":"Success","inner":{"_type":"DepositReceipt","account":"tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx","updated_balance":20}}}"#;
+        assert_eq!(raw_json_payload, serde_json::to_string(&receipt).unwrap());
     }
 }

--- a/crates/jstz_proto/src/executor/deposit.rs
+++ b/crates/jstz_proto/src/executor/deposit.rs
@@ -1,7 +1,11 @@
 use jstz_core::{host::HostRuntime, kv::Transaction};
 use jstz_crypto::hash::Blake2b;
 
-use crate::{context::account::Account, operation::external::Deposit, receipt::Receipt};
+use crate::{
+    context::account::Account,
+    operation::external::Deposit,
+    receipt::{DepositReceipt, Receipt},
+};
 
 pub fn execute(
     hrt: &mut impl HostRuntime,
@@ -16,6 +20,45 @@ pub fn execute(
     let hash = Blake2b::from(deposit.inbox_id.to_be_bytes().as_slice());
     Receipt::new(
         hash,
-        result.map(|_| crate::receipt::ReceiptContent::Deposit),
+        result.map(|updated_balance| {
+            crate::receipt::ReceiptContent::Deposit(DepositReceipt {
+                account: receiver,
+                updated_balance,
+            })
+        }),
     )
+}
+
+#[cfg(test)]
+mod test {
+    use jstz_core::kv::Transaction;
+    use tezos_smart_rollup_mock::MockHost;
+
+    use crate::{
+        operation::external::Deposit,
+        receipt::{DepositReceipt, ReceiptContent},
+    };
+
+    use super::execute;
+
+    #[test]
+    fn test_execute_receipt() {
+        let mut host = MockHost::default();
+        let mut tx = Transaction::default();
+        let receiver = jstz_mock::account1();
+        let deposit = Deposit {
+            inbox_id: 1,
+            amount: 20,
+            receiver: receiver.clone(),
+        };
+        tx.begin();
+        let receipt = execute(&mut host, &mut tx, deposit);
+        assert!(matches!(
+            receipt.inner,
+            Ok(ReceiptContent::Deposit(DepositReceipt {
+                account,
+                updated_balance,
+            })) if account == receiver && updated_balance == 20
+        ))
+    }
 }

--- a/crates/jstz_proto/src/executor/fa_deposit.rs
+++ b/crates/jstz_proto/src/executor/fa_deposit.rs
@@ -23,6 +23,7 @@ const NULL_ADDRESS: &str = "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx";
 const DEPOSIT_URI: &str = "/-/deposit";
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(tag = "_type")]
 pub struct FaDepositReceipt {
     pub receiver: PublicKeyHash,
     pub ticket_balance: Amount,
@@ -173,7 +174,7 @@ mod test {
     use crate::{
         context::{account::ParsedCode, ticket_table::TicketTable},
         executor::fa_deposit::{FaDeposit, FaDepositReceipt},
-        receipt::{Receipt, ReceiptContent},
+        receipt::{Receipt, ReceiptContent, ReceiptResult},
     };
 
     fn mock_fa_deposit(proxy: Option<PublicKeyHash>) -> FaDeposit {
@@ -201,7 +202,7 @@ mod test {
         assert_eq!(expected_hash, *receipt.hash());
 
         match receipt.inner {
-            Ok(ReceiptContent::FaDeposit(FaDepositReceipt {
+            ReceiptResult::Success(ReceiptContent::FaDeposit(FaDepositReceipt {
                 receiver,
                 ticket_balance,
                 run_function,
@@ -240,7 +241,7 @@ mod test {
         assert_eq!(expected_hash, *receipt.hash());
 
         match receipt.inner {
-            Ok(ReceiptContent::FaDeposit(FaDepositReceipt {
+            ReceiptResult::Success(ReceiptContent::FaDeposit(FaDepositReceipt {
                 receiver,
                 ticket_balance,
                 run_function,
@@ -292,7 +293,7 @@ mod test {
         let Receipt { inner, .. } = super::execute(&mut host, &mut tx, fa_deposit);
 
         match inner {
-            Ok(ReceiptContent::FaDeposit(FaDepositReceipt {
+            ReceiptResult::Success(ReceiptContent::FaDeposit(FaDepositReceipt {
                 receiver,
                 ticket_balance,
                 run_function,
@@ -344,7 +345,7 @@ mod test {
         let Receipt { inner, .. } = super::execute(&mut host, &mut tx, fa_deposit2);
 
         match inner {
-            Ok(ReceiptContent::FaDeposit(FaDepositReceipt {
+            ReceiptResult::Success(ReceiptContent::FaDeposit(FaDepositReceipt {
                 receiver,
                 ticket_balance,
                 run_function,
@@ -391,7 +392,7 @@ mod test {
         let Receipt { inner, .. } = super::execute(&mut host, &mut tx, fa_deposit);
 
         match inner {
-            Ok(ReceiptContent::FaDeposit(FaDepositReceipt {
+            ReceiptResult::Success(ReceiptContent::FaDeposit(FaDepositReceipt {
                 receiver,
                 ticket_balance,
                 run_function,

--- a/crates/jstz_proto/src/executor/fa_deposit.rs
+++ b/crates/jstz_proto/src/executor/fa_deposit.rs
@@ -201,7 +201,7 @@ mod test {
 
         assert_eq!(expected_hash, *receipt.hash());
 
-        match receipt.inner {
+        match receipt.result {
             ReceiptResult::Success(ReceiptContent::FaDeposit(FaDepositReceipt {
                 receiver,
                 ticket_balance,
@@ -240,7 +240,7 @@ mod test {
 
         assert_eq!(expected_hash, *receipt.hash());
 
-        match receipt.inner {
+        match receipt.result {
             ReceiptResult::Success(ReceiptContent::FaDeposit(FaDepositReceipt {
                 receiver,
                 ticket_balance,
@@ -290,7 +290,8 @@ mod test {
         let fa_deposit = mock_fa_deposit(Some(proxy.clone()));
         let ticket_hash = fa_deposit.ticket_hash.clone();
 
-        let Receipt { inner, .. } = super::execute(&mut host, &mut tx, fa_deposit);
+        let Receipt { result: inner, .. } =
+            super::execute(&mut host, &mut tx, fa_deposit);
 
         match inner {
             ReceiptResult::Success(ReceiptContent::FaDeposit(FaDepositReceipt {
@@ -342,7 +343,8 @@ mod test {
 
         let fa_deposit2 = mock_fa_deposit(Some(proxy.clone()));
 
-        let Receipt { inner, .. } = super::execute(&mut host, &mut tx, fa_deposit2);
+        let Receipt { result: inner, .. } =
+            super::execute(&mut host, &mut tx, fa_deposit2);
 
         match inner {
             ReceiptResult::Success(ReceiptContent::FaDeposit(FaDepositReceipt {
@@ -389,7 +391,8 @@ mod test {
         let expected_receiver = fa_deposit.receiver.clone();
         let ticket_hash = fa_deposit.ticket_hash.clone();
 
-        let Receipt { inner, .. } = super::execute(&mut host, &mut tx, fa_deposit);
+        let Receipt { result: inner, .. } =
+            super::execute(&mut host, &mut tx, fa_deposit);
 
         match inner {
             ReceiptResult::Success(ReceiptContent::FaDeposit(FaDepositReceipt {

--- a/crates/jstz_proto/src/executor/fa_withdraw.rs
+++ b/crates/jstz_proto/src/executor/fa_withdraw.rs
@@ -83,6 +83,7 @@ impl TryFrom<FA2_1Ticket> for Ticket {
 type OutboxMessageId = String;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
+#[serde(tag = "_type")]
 pub struct FaWithdrawReceipt {
     pub source: PublicKeyHash,
     pub outbox_message_id: OutboxMessageId,

--- a/crates/jstz_proto/src/executor/smart_function.rs
+++ b/crates/jstz_proto/src/executor/smart_function.rs
@@ -643,9 +643,7 @@ pub mod jstz_run {
                 body: Some(
                     json!({
                         "amount": 10,
-                        "receiver": {
-                            "Tz1": jstz_mock::account2().to_base58().to_string()
-                        },
+                        "receiver": jstz_mock::account2().to_base58().to_string(),
                     })
                     .to_string()
                     .as_bytes()

--- a/crates/jstz_proto/src/operation.rs
+++ b/crates/jstz_proto/src/operation.rs
@@ -80,6 +80,7 @@ impl Operation {
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, ToSchema)]
+#[serde(tag = "_type")]
 pub struct DeployFunction {
     /// Smart function code
     pub function_code: ParsedCode,
@@ -91,6 +92,7 @@ pub struct DeployFunction {
 #[schema(description = "Request used to run a smart function. \
     The target smart function is given by the host part of the uri. \
     The rest of the attributes will be handled by the smart function itself.")]
+#[serde(tag = "_type")]
 pub struct RunFunction {
     /// Smart function URI in the form tezos://{smart_function_address}/rest/of/path
     #[serde(with = "http_serde::uri")]
@@ -123,7 +125,9 @@ pub struct RunFunction {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, ToSchema)]
 #[serde(tag = "_type")]
 pub enum Content {
+    #[schema(title = "DeployFunction")]
     DeployFunction(DeployFunction),
+    #[schema(title = "RunFunction")]
     RunFunction(RunFunction),
 }
 

--- a/crates/jstz_proto/src/operation.rs
+++ b/crates/jstz_proto/src/operation.rs
@@ -121,6 +121,7 @@ pub struct RunFunction {
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, ToSchema)]
+#[serde(tag = "_type")]
 pub enum Content {
     DeployFunction(DeployFunction),
     RunFunction(RunFunction),

--- a/crates/jstz_proto/src/receipt.rs
+++ b/crates/jstz_proto/src/receipt.rs
@@ -51,19 +51,28 @@ pub struct RunFunctionReceipt {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct DepositReceipt {
+    pub account: Address,
+    pub updated_balance: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(tag = "_type")]
 pub enum ReceiptContent {
     DeployFunction(DeployFunctionReceipt),
     RunFunction(RunFunctionReceipt),
-    Deposit,
+    Deposit(DepositReceipt),
     FaDeposit(FaDepositReceipt),
     FaWithdraw(FaWithdrawReceipt),
 }
 
 mod openapi {
+    use serde::{Deserialize, Serialize};
     use utoipa::ToSchema;
 
     #[allow(dead_code)]
-    #[derive(ToSchema)]
+    #[derive(ToSchema, Serialize, Deserialize)]
+    #[serde(tag = "_type")]
     pub enum ReceiptResult<T: ToSchema> {
         Ok(T),
         Err(String),

--- a/crates/jstz_proto/src/receipt.rs
+++ b/crates/jstz_proto/src/receipt.rs
@@ -11,21 +11,19 @@ use utoipa::ToSchema;
 
 // pub type ReceiptResult<T> = std::result::Result<T, ReceiptError>;
 #[derive(Debug, Clone, ToSchema, Serialize, Deserialize)]
-#[serde(tag = "_type")]
+#[serde(tag = "_type", content = "inner")]
 pub enum ReceiptResult {
     #[schema(title = "Success")]
     Success(ReceiptContent),
     #[schema(title = "Failure")]
-    Failed { source: String },
+    Failed(String),
 }
 
 impl From<Result<ReceiptContent>> for ReceiptResult {
     fn from(value: Result<ReceiptContent>) -> Self {
         match value {
             Ok(ok) => ReceiptResult::Success(ok),
-            Err(err) => ReceiptResult::Failed {
-                source: err.to_string(),
-            },
+            Err(err) => ReceiptResult::Failed(err.to_string()),
         }
     }
 }
@@ -34,14 +32,14 @@ impl From<Result<ReceiptContent>> for ReceiptResult {
 pub struct Receipt {
     #[schema(value_type = String)]
     hash: OperationHash,
-    pub inner: ReceiptResult,
+    pub result: ReceiptResult,
 }
 
 impl Receipt {
     pub fn new(hash: OperationHash, inner: Result<ReceiptContent>) -> Self {
         Self {
             hash,
-            inner: inner.into(),
+            result: inner.into(),
         }
     }
 

--- a/crates/jstz_proto/src/receipt.rs
+++ b/crates/jstz_proto/src/receipt.rs
@@ -30,7 +30,6 @@ impl From<Result<ReceiptContent>> for ReceiptResult {
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct Receipt {
-    #[schema(value_type = String)]
     hash: OperationHash,
     pub result: ReceiptResult,
 }


### PR DESCRIPTION
# Context
This PR fixes the awkward external tagging that serde uses for Json serialisation with the following changes:
1. Cryptos enums are marked  with `#[serde(untagged)]`
2. Non-cryptos enums are marked as  `#[serde(tag = "_type")]`

These changes ensures that we get generated code that makes sense in Typescript from https://github.com/jstz-dev/jstz/pull/644
<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->
# Manually testing the PR
Code should build, tests should pass
`make`

<!-- Describe how reviewers and approvers can test this PR. -->
