### PR TITLE
fix(jstzd): revise baker check in jstzd test

### DIFF
--- a/crates/jstzd/src/task/jstzd.rs
+++ b/crates/jstzd/src/task/jstzd.rs
@@ -207,6 +207,14 @@ impl JstzdServer {
         self.state.write().await.server_handle.replace(handle);
         Ok(())
     }
+
+    pub async fn baker_healthy(&self) -> bool {
+        if let Some(v) = &self.state.read().await.jstzd {
+            v.baker.read().await.health_check().await.unwrap_or(false)
+        } else {
+            false
+        }
+    }
 }
 
 async fn health_check(state: &ServerState) -> bool {

--- a/nix/crates.nix
+++ b/nix/crates.nix
@@ -127,7 +127,7 @@ in {
 
     cargo-test-int = craneLib.cargoNextest (commonWorkspace
       // {
-        buildInputs = commonWorkspace.buildInputs ++ [pkgs.iana-etc octez pkgs.cacert pkgs.which pkgs.ps];
+        buildInputs = commonWorkspace.buildInputs ++ [pkgs.iana-etc octez pkgs.cacert];
         doCheck = true;
         # Run the integration tests
         #
@@ -140,7 +140,7 @@ in {
 
     cargo-llvm-cov = craneLib.cargoLlvmCov (commonWorkspace
       // {
-        buildInputs = commonWorkspace.buildInputs ++ [pkgs.iana-etc octez pkgs.cacert pkgs.which pkgs.ps];
+        buildInputs = commonWorkspace.buildInputs ++ [pkgs.iana-etc octez pkgs.cacert];
         # Generate coverage reports for codecov
         cargoLlvmCovExtraArgs = "--workspace --exclude-from-test \"jstz_api\" --codecov --output-path $out";
       });

--- a/nix/crates.nix
+++ b/nix/crates.nix
@@ -127,7 +127,7 @@ in {
 
     cargo-test-int = craneLib.cargoNextest (commonWorkspace
       // {
-        buildInputs = commonWorkspace.buildInputs ++ [pkgs.iana-etc octez pkgs.cacert pkgs.ps];
+        buildInputs = commonWorkspace.buildInputs ++ [pkgs.iana-etc octez pkgs.cacert pkgs.which pkgs.ps];
         doCheck = true;
         # Run the integration tests
         #
@@ -140,7 +140,7 @@ in {
 
     cargo-llvm-cov = craneLib.cargoLlvmCov (commonWorkspace
       // {
-        buildInputs = commonWorkspace.buildInputs ++ [pkgs.iana-etc octez pkgs.cacert pkgs.ps];
+        buildInputs = commonWorkspace.buildInputs ++ [pkgs.iana-etc octez pkgs.cacert pkgs.which pkgs.ps];
         # Generate coverage reports for codecov
         cargoLlvmCovExtraArgs = "--workspace --exclude-from-test \"jstz_api\" --codecov --output-path $out";
       });


### PR DESCRIPTION
# Context

Changes the way the test checks if baker has been destroyed because it does not always work.

# Description

The original idea of checking if a baker process is indeed destroyed is to check if there is any process with `octez-baker` in its name with `ps`. This works fine when there is only one such test running each time, but it becomes problematic when there are multiple tests and even multiple workers running in parallel -- the baker launched by each test might have been destroyed, but `ps` also shows baker processes launched by other tests.

This check is now performed with a different approach. ~The baker binary is copied to a temp file and then jstzd launches the baker with that clone. The test still looks for that name in `ps` and removes that clone at the end of the test. This approach should be fine for now since it's only used this jstzd_test~. One public method is implemented in jstzd server so that we can check if the baker is alive directly by asking the underlying baker task. This is not really ideal, but let's keep it for now so that we don't get blocked here.

# Manually testing the PR

`jstzd_test` should still pass.
