### PR TITLE
feat(octez): serialise octez client config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ reqwest = { version = "0.11.24", features = ["json"] }
 reqwest-eventsource = "0.5.0"
 rust-embed = { version = "8.5.0", features = ["interpolate-folder-path"] }
 rustyline = "14.0.0"
-serde = { version = "1.0.196", features = ["derive"] }
+serde = { version = "1.0.196", features = ["derive", "rc"] }
 serde-wasm-bindgen = "0.6.5"
 serde_json = "1.0.107"
 serde_with = { version = "3.6.1", features = ["macros"] }


### PR DESCRIPTION
# Context

Part of JSTZ-121; in preparation for #655.

[JSTZ-121](https://linear.app/tezos/issue/JSTZ-121/endpoints-for-jstzd-server)

# Description

Serialise octez client config. Note that the `base_dir` field is omitted if it's a temp path because it's generated and managed by the program and users should not see it when they fetch the serialised config from the jstzd server.

# Manually testing the PR

* Unit test: added new test cases
