### PR TITLE
feat(jstzd): deserialise user config

### DIFF
--- a/crates/jstzd/src/config.rs
+++ b/crates/jstzd/src/config.rs
@@ -1,0 +1,207 @@
+#![allow(dead_code)]
+
+use anyhow::{Context, Result};
+use octez::r#async::{
+    baker::OctezBakerConfigBuilder, client::OctezClientConfigBuilder,
+    node_config::OctezNodeConfigBuilder, protocol::ProtocolParameterBuilder,
+};
+use serde::Deserialize;
+use tokio::io::AsyncReadExt;
+
+#[derive(Deserialize, Default)]
+struct Config {
+    server_port: Option<u16>,
+    #[serde(default)]
+    octez_node: OctezNodeConfigBuilder,
+    #[serde(default)]
+    octez_baker: OctezBakerConfigBuilder,
+    octez_client: Option<OctezClientConfigBuilder>,
+    #[serde(default)]
+    protocol: ProtocolParameterBuilder,
+}
+
+async fn parse_config(path: &str) -> Result<Config> {
+    let mut s = String::new();
+    tokio::fs::File::open(path)
+        .await
+        .context("failed to open config file")?
+        .read_to_string(&mut s)
+        .await
+        .context("failed to read config file")?;
+    Ok(serde_json::from_str::<Config>(&s)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{io::Write, path::PathBuf, str::FromStr};
+
+    use http::Uri;
+    use octez::r#async::{
+        baker::{BakerBinaryPath, OctezBakerConfigBuilder},
+        client::OctezClientConfigBuilder,
+        endpoint::Endpoint,
+        node_config::{
+            OctezNodeConfigBuilder, OctezNodeHistoryMode, OctezNodeRunOptionsBuilder,
+        },
+        protocol::{
+            BootstrapAccount, BootstrapContract, BootstrapSmartRollup, Protocol,
+            ProtocolConstants, ProtocolParameterBuilder, SmartRollupPvmKind,
+        },
+    };
+    use tempfile::NamedTempFile;
+
+    use super::Config;
+
+    #[tokio::test]
+    async fn parse_config() {
+        let mut tmp_file = NamedTempFile::new().unwrap();
+        let content = serde_json::to_string(
+            &serde_json::json!({"octez_client": {"octez_node_endpoint": "localhost:8888"}}),
+        )
+        .unwrap();
+        tmp_file.write_all(content.as_bytes()).unwrap();
+
+        let config = super::parse_config(&tmp_file.path().to_string_lossy())
+            .await
+            .unwrap();
+        assert_eq!(
+            config.octez_client,
+            Some(OctezClientConfigBuilder::new(Endpoint::localhost(8888)))
+        );
+    }
+
+    #[test]
+    fn deserialize_config_default() {
+        let config = serde_json::from_value::<Config>(serde_json::json!({})).unwrap();
+        assert_eq!(config.octez_baker, OctezBakerConfigBuilder::default());
+        assert!(config.octez_client.is_none());
+        assert_eq!(config.octez_node, OctezNodeConfigBuilder::default());
+        assert_eq!(config.protocol, ProtocolParameterBuilder::default());
+        assert!(config.server_port.is_none());
+    }
+
+    #[test]
+    fn deserialize_config_octez_node() {
+        let config = serde_json::from_value::<Config>(serde_json::json!({
+            "octez_node": {
+                "binary_path": "bin",
+                "data_dir": "data_dir",
+                "network": "test",
+                "rpc_endpoint": "rpc.test",
+                "p2p_address": "p2p.test",
+                "log_file": "log_file",
+                "run_options": {
+                    "synchronisation_threshold": 1,
+                    "network": "test",
+                    "history_mode": "archive"
+                }
+            }
+        }))
+        .unwrap();
+        let mut expected = OctezNodeConfigBuilder::new();
+        expected
+            .set_binary_path("bin")
+            .set_data_dir("data_dir")
+            .set_network("test")
+            .set_rpc_endpoint(&Endpoint::try_from(Uri::from_static("rpc.test")).unwrap())
+            .set_p2p_address(&Endpoint::try_from(Uri::from_static("p2p.test")).unwrap())
+            .set_log_file("log_file")
+            .set_run_options(
+                &OctezNodeRunOptionsBuilder::new()
+                    .set_history_mode(OctezNodeHistoryMode::Archive)
+                    .set_network("test")
+                    .set_synchronisation_threshold(1)
+                    .build(),
+            );
+        assert_eq!(config.octez_node, expected);
+    }
+
+    #[test]
+    fn deserialize_config_octez_client() {
+        let config = serde_json::from_value::<Config>(serde_json::json!({
+            "octez_client": {
+                "binary_path": "bin",
+                "base_dir": "base_dir",
+                "disable_unsafe_disclaimer": false,
+                "octez_node_endpoint": "rpc.test",
+            }
+        }))
+        .unwrap();
+        let expected = OctezClientConfigBuilder::new(
+            Endpoint::try_from(Uri::from_static("rpc.test")).unwrap(),
+        )
+        .set_binary_path(PathBuf::from_str("bin").unwrap())
+        .set_base_dir(PathBuf::from_str("base_dir").unwrap())
+        .set_disable_unsafe_disclaimer(false);
+        assert_eq!(config.octez_client, Some(expected));
+    }
+
+    #[test]
+    fn deserialize_config_baker() {
+        let config = serde_json::from_value::<Config>(serde_json::json!({
+            "octez_baker": {
+                "binary_path": "bin",
+                "octez_client_base_dir": "base_dir",
+                "octez_node_endpoint": "rpc.test",
+            }
+        }))
+        .unwrap();
+        let expected = OctezBakerConfigBuilder::new()
+            .set_binary_path(BakerBinaryPath::Custom(PathBuf::from_str("bin").unwrap()))
+            .set_octez_client_base_dir("base_dir")
+            .set_octez_node_endpoint(
+                &Endpoint::try_from(Uri::from_static("rpc.test")).unwrap(),
+            );
+        assert_eq!(config.octez_baker, expected);
+    }
+
+    #[test]
+    fn deserialize_config_protocol() {
+        let config = serde_json::from_value::<Config>(serde_json::json!({
+            "protocol": {
+                "protocol": "parisC",
+                "constants": "sandbox",
+                "bootstrap_accounts": [["edpktkhoky4f5kqm2EVwYrMBq5rY9sLYdpFgXixQDWifuBHjhuVuNN", "1"]],
+                "bootstrap_contracts": [{"amount":"1", "script": "dummy-script-no-hash"}],
+                "bootstrap_smart_rollups": [{
+                    "address": "sr1PuFMgaRUN12rKQ3J2ae5psNtwCxPNmGNK",
+                    "pvm_kind": "riscv",
+                    "kernel": "dummy-kernel",
+                    "parameters_ty": "dummy-params"
+                }]
+            }
+        }))
+        .unwrap();
+        let mut expected = ProtocolParameterBuilder::new();
+        expected
+            .set_protocol(Protocol::ParisC)
+            .set_constants(ProtocolConstants::Sandbox)
+            .set_bootstrap_accounts([BootstrapAccount::new(
+                "edpktkhoky4f5kqm2EVwYrMBq5rY9sLYdpFgXixQDWifuBHjhuVuNN",
+                1,
+            )
+            .unwrap()])
+            .set_bootstrap_contracts([BootstrapContract::new(
+                serde_json::json!("dummy-script-no-hash"),
+                1,
+                None,
+            )
+            .unwrap()])
+            .set_bootstrap_smart_rollups([BootstrapSmartRollup::new(
+                "sr1PuFMgaRUN12rKQ3J2ae5psNtwCxPNmGNK",
+                SmartRollupPvmKind::Riscv,
+                "dummy-kernel",
+                serde_json::json!("dummy-params"),
+            )
+            .unwrap()]);
+        assert_eq!(config.protocol, expected);
+    }
+
+    #[test]
+    fn deserialize_config_port() {
+        let config =
+            serde_json::from_value::<Config>(serde_json::json!({"server_port":5678}))
+                .unwrap();
+        assert_eq!(config.server_port, Some(5678));
+    }
+}

--- a/crates/jstzd/src/lib.rs
+++ b/crates/jstzd/src/lib.rs
@@ -1,3 +1,4 @@
+mod config;
 pub mod docker;
 pub mod task;
 

--- a/crates/octez/src/async/baker.rs
+++ b/crates/octez/src/async/baker.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Result};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_with::{DeserializeFromStr, SerializeDisplay};
 use std::{fmt::Display, path::PathBuf, str::FromStr};
 use tokio::process::{Child, Command};
@@ -47,7 +47,7 @@ pub struct OctezBakerConfig {
     octez_node_endpoint: Endpoint,
 }
 
-#[derive(Default)]
+#[derive(Default, Deserialize, Debug, PartialEq)]
 pub struct OctezBakerConfigBuilder {
     binary_path: Option<BakerBinaryPath>,
     octez_client_base_dir: Option<PathBuf>,

--- a/crates/octez/src/async/client.rs
+++ b/crates/octez/src/async/client.rs
@@ -3,7 +3,7 @@ use jstz_crypto::{
     public_key::PublicKey, public_key_hash::PublicKeyHash, secret_key::SecretKey,
 };
 use regex::Regex;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::{
     ffi::OsStr,
     fmt,
@@ -34,12 +34,14 @@ impl OctezClientConfig {
     }
 }
 
+#[derive(Deserialize, Debug, PartialEq)]
 pub struct OctezClientConfigBuilder {
     // if None, use the binary in $PATH
     binary_path: Option<PathBuf>,
     // if None, use temp directory
     base_dir: Option<PathBuf>,
     octez_node_endpoint: Endpoint,
+    #[serde(default)]
     disable_unsafe_disclaimer: bool,
 }
 

--- a/crates/octez/src/async/node_config.rs
+++ b/crates/octez/src/async/node_config.rs
@@ -1,6 +1,6 @@
 use crate::unused_port;
 use anyhow::Result;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_with::DeserializeFromStr;
 use std::{
     fmt::{self, Display, Formatter},
@@ -73,7 +73,7 @@ impl Serialize for OctezNodeHistoryMode {
     }
 }
 
-#[derive(Clone, PartialEq, Debug, Serialize)]
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub struct OctezNodeRunOptions {
     synchronisation_threshold: u8,
     network: String,
@@ -168,7 +168,7 @@ pub struct OctezNodeConfig {
     pub run_options: OctezNodeRunOptions,
 }
 
-#[derive(Default)]
+#[derive(Default, Deserialize, Debug, PartialEq)]
 pub struct OctezNodeConfigBuilder {
     binary_path: Option<PathBuf>,
     data_dir: Option<PathBuf>,

--- a/crates/octez/src/async/protocol.rs
+++ b/crates/octez/src/async/protocol.rs
@@ -4,6 +4,7 @@ pub use super::bootstrap::{
 use super::bootstrap::{BootstrapAccounts, BootstrapContracts, BootstrapSmartRollups};
 
 use rust_embed::Embed;
+use serde::Deserialize;
 use serde_json::Value;
 use serde_with::{DeserializeFromStr, SerializeDisplay};
 use std::fmt::Display;
@@ -120,17 +121,20 @@ impl ProtocolParameter {
     }
 }
 
-#[derive(Default)]
+#[derive(Deserialize, Default, PartialEq, Debug)]
 pub struct ProtocolParameterBuilder {
     /// Target protocol version.
     protocol: Option<Protocol>,
     /// Protocol constants.
     constants: Option<ProtocolConstants>,
     /// Bootstrap accounts.
+    #[serde(default)]
     bootstrap_accounts: BootstrapAccounts,
     /// Bootstrap contracts.
+    #[serde(default)]
     bootstrap_contracts: BootstrapContracts,
     /// Bootstrap smart rollups.
+    #[serde(default)]
     bootstrap_smart_rollups: BootstrapSmartRollups,
     /// Path to an existing parameter file whose content will be used as the base
     /// parameter set. If `source_path` is not given, a predefined parameter


### PR DESCRIPTION
# Context

Part of JSTZ-168.

[JSTZ-168](https://linear.app/tezos/issue/JSTZ-168/jstzd-run-cli)

# Description

Deserialise jstzd config provided by users. The config looks like
```json
{
  "octez_node": {...},
  "octez_client": {...},
  "octez_baker": {...},
  "protocol": {...},
  "server_port": 1234
}
```

where each object entry matches the corresponding config builder.

# Manually testing the PR

* Unit test: added test cases
