### PR TITLE
 feat(jstzd): launch jstzd server with cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1758,6 +1758,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "globset"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
 name = "group"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4252,6 +4265,7 @@ version = "8.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e5347777e9aacb56039b0e1f28785929a8a3b709e87482e7442c72e7c12529d"
 dependencies = [
+ "globset",
  "sha2 0.10.8",
  "walkdir",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,9 +81,9 @@ pretty_assertions = "1.4.1"
 proptest = "1.1"
 rand = "0.8"
 regex = "1"
-reqwest = { version = "0.11.24", features = ["json"] }
+reqwest = { version = "0.11.24", features = ["json", "blocking"] }
 reqwest-eventsource = "0.5.0"
-rust-embed = { version = "8.5.0", features = ["interpolate-folder-path"] }
+rust-embed = { version = "8.5.0", features = ["interpolate-folder-path", "include-exclude"] }
 rustyline = "14.0.0"
 serde = { version = "1.0.196", features = ["derive", "rc"] }
 serde-wasm-bindgen = "0.6.5"

--- a/crates/jstzd/Cargo.toml
+++ b/crates/jstzd/Cargo.toml
@@ -47,7 +47,7 @@ rand.workspace = true
 tezos_crypto_rs.workspace = true
 
 [features]
-ignore-flaky-tests = []
+skip-rollup-tests = []
 
 [[bin]]
 name = "jstzd"

--- a/crates/jstzd/src/lib.rs
+++ b/crates/jstzd/src/lib.rs
@@ -2,6 +2,7 @@ mod config;
 pub mod docker;
 pub mod task;
 
+use crate::task::jstzd::{JstzdConfig, JstzdServer};
 pub use config::BOOTSTRAP_CONTRACT_NAMES;
 pub mod jstz_rollup_path {
     include!(concat!(env!("OUT_DIR"), "/jstz_rollup_path.rs"));
@@ -15,10 +16,7 @@ pub const JSTZ_NATIVE_BRIDGE_ADDRESS: &str = "KT1GFiPkkTjd14oHe6MrBPiRh5djzRkVWc
 /// The `main` function for running jstzd
 pub async fn main(config_path: &Option<String>) {
     match config::build_config(config_path).await {
-        Ok((_port, _config)) => {
-            // TODO: run JstzdServer here
-            println!("ready");
-        }
+        Ok((port, config)) => run(port, config).await,
         Err(e) => {
             match config_path {
                 Some(p) => eprintln!("failed to build config from {}: {:?}", p, e),
@@ -27,4 +25,18 @@ pub async fn main(config_path: &Option<String>) {
             exit(1);
         }
     }
+}
+
+async fn run(port: u16, config: JstzdConfig) {
+    let mut server = JstzdServer::new(config, port);
+    if let Err(e) = server.run().await {
+        eprintln!("failed to run jstzd server: {:?}", e);
+        let _ = server.stop().await;
+        exit(1);
+    }
+
+    server.wait().await;
+
+    println!("Shutting down");
+    server.stop().await.unwrap();
 }

--- a/crates/jstzd/tests/jstzd_test.rs
+++ b/crates/jstzd/tests/jstzd_test.rs
@@ -33,7 +33,7 @@ pub const JSTZ_ROLLUP_OPERATOR_PK: &str =
     "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav";
 pub const JSTZ_ROLLUP_OPERATOR_ALIAS: &str = "bootstrap1";
 
-#[cfg_attr(feature = "ignore-flaky-tests", ignore)]
+#[cfg_attr(feature = "skip-rollup-tests", ignore)]
 #[tokio::test(flavor = "multi_thread")]
 async fn jstzd_test() {
     let octez_node_rpc_endpoint = Endpoint::localhost(unused_port());

--- a/crates/jstzd/tests/octez_client_test.rs
+++ b/crates/jstzd/tests/octez_client_test.rs
@@ -366,6 +366,7 @@ struct OutputProof {
     pub proof: String,
 }
 
+#[cfg_attr(feature = "skip-rollup-tests", ignore)]
 #[tokio::test(flavor = "multi_thread")]
 async fn execute_rollup_outbox_message() {
     let rollup_address = "sr1Uuiucg1wk5aovEY2dj1ZBsqjwxndrSaao";

--- a/nix/crates.nix
+++ b/nix/crates.nix
@@ -151,14 +151,14 @@ in {
         # Note: --workspace is required for --exclude. Once --exclude is removed, remove --workspace
         # FIXME(https://linear.app/tezos/issue/JSTZ-237):
         # Fix tests that only fail in CI/Nix
-        cargoNextestExtraArgs = "--workspace --test \"*\" --exclude \"jstz_api\" --features \"ignore-flaky-tests\"";
+        cargoNextestExtraArgs = "--workspace --test \"*\" --exclude \"jstz_api\" --features \"skip-rollup-tests\"";
       });
 
     cargo-llvm-cov = craneLib.cargoLlvmCov (commonWorkspace
       // {
         buildInputs = commonWorkspace.buildInputs ++ [pkgs.iana-etc octez pkgs.cacert];
         # Generate coverage reports for codecov
-        cargoLlvmCovExtraArgs = "--workspace --exclude-from-test \"jstz_api\" --codecov --output-path $out";
+        cargoLlvmCovExtraArgs = "--workspace --exclude-from-test \"jstz_api\" --codecov --output-path $out --features \"skip-rollup-tests\"";
       });
 
     cargo-clippy = craneLib.cargoClippy (commonWorkspace


### PR DESCRIPTION
# Context

Completes JSTZ-168.

[JSTZ-168](https://linear.app/tezos/issue/JSTZ-168/jstzd-run-cli)

# Description

Spins up jstzd server on `jstzd run <config_path>`. It makes things easier if we wait a bit for jstzd before spinning up jstzd server, so I made some changes to that part.

Threading is necessary in the tests because `assert_cmd` unfortunately does not handle async yet.

# Manually testing the PR

* Integration test: updated existing test cases
