### PR TITLE
ci: terminate slow tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.default]
+slow-timeout = { period = "60s", terminate-after = 1 }

--- a/nix/crates.nix
+++ b/nix/crates.nix
@@ -15,7 +15,7 @@
   src = let
     # Include all Rust files / cargo related files
     # Include all files in the `contracts` and `crates` directories
-    regexes = [".*\.toml$" ".*\.rs$" "^\.cargo.*$" "^Cargo.lock$" "^crates.*$" "^contracts.*$"];
+    regexes = [".*\.toml$" ".*\.rs$" "^\.cargo.*$" "^Cargo.lock$" "^crates.*$" "^contracts.*$" "\.config.*$"];
   in
     lib.sourceByRegex (lib.cleanSource ../.) regexes;
 
@@ -151,7 +151,7 @@ in {
         # Note: --workspace is required for --exclude. Once --exclude is removed, remove --workspace
         # FIXME(https://linear.app/tezos/issue/JSTZ-237):
         # Fix tests that only fail in CI/Nix
-        cargoNextestExtraArgs = "--workspace --test \"*\" --exclude \"jstz_api\" --features \"skip-rollup-tests\"";
+        cargoNextestExtraArgs = "--workspace --test \"*\" --exclude \"jstz_api\" --features \"skip-rollup-tests\" --config-file ${src}/.config/nextest.toml";
       });
 
     cargo-llvm-cov = craneLib.cargoLlvmCov (commonWorkspace
@@ -160,7 +160,7 @@ in {
         # Use nextest for test harness (instead of `cargo test`)
         cargoLlvmCovCommand = "nextest";
         # Generate coverage reports for codecov
-        cargoLlvmCovExtraArgs = "--workspace --exclude-from-test \"jstz_api\" --codecov --output-path $out --features \"skip-rollup-tests\"";
+        cargoLlvmCovExtraArgs = "--workspace --exclude-from-test \"jstz_api\" --codecov --output-path $out --features \"skip-rollup-tests\" --config-file ${src}/.config/nextest.toml";
       });
 
     cargo-clippy = craneLib.cargoClippy (commonWorkspace


### PR DESCRIPTION
# Context

Closes JSTZ-208.

[JSTZ-208](https://linear.app/tezos/issue/JSTZ-208/ci-terminate-slow-tests)

# Description

Terminate tests that take too much time in CI to save resources and prevent unexpected long-running tests from blocking the CI runner.

# Manually testing the PR

A test branch contains changes in this PR and a dummy test that does nothing but sleeps for 2 minutes. Workflow run: https://github.com/jstz-dev/jstz/actions/runs/12035957074/job/33556133877

The test was terminated and the overall check failed as expected.