### PR TITLE
feat(node): add hash operation endpoint

### DIFF
--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -378,6 +378,43 @@
         }
       }
     },
+    "/operations/hash": {
+      "post": {
+        "tags": [
+          "Operations"
+        ],
+        "summary": "Returns the hash of an Operation",
+        "operationId": "hash_operation",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Operation"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Blake2b"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": ""
+          },
+          "500": {
+            "description": ""
+          }
+        }
+      }
+    },
     "/operations/{operation_hash}/receipt": {
       "get": {
         "tags": [

--- a/crates/jstz_node/src/services/operations.rs
+++ b/crates/jstz_node/src/services/operations.rs
@@ -5,7 +5,7 @@ use axum::{
     extract::{Path, State},
     Json,
 };
-use jstz_proto::operation::SignedOperation;
+use jstz_proto::operation::{Operation, OperationHash, SignedOperation};
 use jstz_proto::receipt::Receipt;
 use tezos_data_encoding::enc::BinWriter;
 use tezos_smart_rollup::inbox::ExternalMessageFrame;
@@ -78,11 +78,29 @@ async fn receipt(
     Ok(Json(receipt))
 }
 
+/// Returns the hash of an Operation
+#[utoipa::path(
+        post,
+        path = "/hash",
+        tag = OPERATIONS_TAG,
+        responses(
+            (status = 200, body = OperationHash),
+            (status = 400),
+            (status = 500)
+        )
+    )]
+async fn hash_operation(
+    Json(operation): Json<Operation>,
+) -> ServiceResult<Json<OperationHash>> {
+    Ok(Json(operation.hash()))
+}
+
 impl Service for OperationsService {
     fn router_with_openapi() -> OpenApiRouter<AppState> {
         let routes = OpenApiRouter::new()
             .routes(routes!(inject))
-            .routes(routes!(receipt));
+            .routes(routes!(receipt))
+            .routes(routes!(hash_operation));
 
         OpenApiRouter::new().nest("/operations", routes)
     }


### PR DESCRIPTION
# Context
Adds an endpoint to hash operations in Jstz so that user's can have consistent hashing without wasm dependency. A slightly nicer UX would be an indutry standard binary encoding that is consistent across rust, typescript and other languages but existing solutions are not effortless drop ins and will require additional effort at a later time.


<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
* Adds the hashing endpoint
*  Updates openapi
* 
<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
`cargo test -p jstz_node api_doc_regression`
<!-- Describe how reviewers and approvers can test this PR. -->
