### PR TITLE
fix(jstzd): include bootstrap contracts in builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2988,6 +2988,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "reqwest",
+ "rust-embed",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/jstzd/Cargo.toml
+++ b/crates/jstzd/Cargo.toml
@@ -20,6 +20,7 @@ jstz_node = {path = "../jstz_node"}
 octez = { path = "../octez" }
 regex.workspace = true
 reqwest.workspace = true
+rust-embed.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true


### PR DESCRIPTION
# Context

There is a problem with simply loading files from `CARGO_MANIFEST_DIR`: the directory is no longer available after the binary is built and therefore the binary will complain that the files do not exist.

# Description

Pack bootstrap contracts into builds at compile time with `rust_embed` so that they remain accessible to the binary. This is already done for protocol parameters, so the only part with problems is the bootstrap contracts. This PR changes the way those files are loaded.

# Manually testing the PR

Manually built jstzd and ran the executable in an octez container and the sandbox launched as expected.

This cannot really be tested with any of the existing test now. As long as all existing tests still work, we should be good to go.
