### PR TITLE
Jstzd: use real jstz node config

### DIFF
--- a/crates/jstzd/src/task/jstzd.rs
+++ b/crates/jstzd/src/task/jstzd.rs
@@ -106,6 +106,10 @@ impl JstzdConfig {
         &self.octez_rollup_config
     }
 
+    pub fn jstz_node_config(&self) -> &JstzNodeConfig {
+        &self.jstz_node_config
+    }
+
     pub fn protocol_params(&self) -> &ProtocolParameter {
         &self.protocol_params
     }


### PR DESCRIPTION
# Context

[jstz node config](https://linear.app/tezos/issue/JSTZ-240/use-real-jstz-node-in-config)

# Description

replace the dummy jstz node with actual one in the config

# Manually testing the PR

extened the config unit test
