### PR TITLE
feat(octez): write rollup log to file

### DIFF
--- a/crates/jstzd/src/task/octez_rollup.rs
+++ b/crates/jstzd/src/task/octez_rollup.rs
@@ -58,6 +58,7 @@ impl Task for OctezRollup {
             &config.octez_client_base_dir,
             &config.octez_node_endpoint,
             &config.rpc_endpoint,
+            &config.log_file,
         );
         let inner = ChildWrapper::new_shared(rollup.run(
             &config.address,


### PR DESCRIPTION
# Context

Part of JSTZ-244.
[JSTZ-244](https://linear.app/tezos/issue/JSTZ-244/direct-all-octez-logs-to-files).

# Description

Write rollup logs to a log file instead of stdout/stderr.

# Manually testing the PR

Ran jstzd locally and did not see any rollup node logs.