### PR TITLE
feat(octez): write node log to file

### DIFF
--- a/crates/octez/src/async/node.rs
+++ b/crates/octez/src/async/node.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, path::PathBuf, process::Stdio};
+use std::{path::PathBuf, process::Stdio, sync::Arc};
 
 use tokio::process::{Child, Command};
 
@@ -6,7 +6,7 @@ use crate::path_or_default;
 
 use anyhow::Result;
 
-use super::{endpoint::Endpoint, node_config::OctezNodeRunOptions};
+use super::{endpoint::Endpoint, file::FileWrapper, node_config::OctezNodeRunOptions};
 
 pub struct OctezNode {
     /// Path to the octez-node binary
@@ -14,11 +14,17 @@ pub struct OctezNode {
     pub octez_node_bin: Option<PathBuf>,
     /// Path to the octez-node directory
     pub octez_node_dir: PathBuf,
+    /// Path to the log file.
+    pub log_file: Arc<FileWrapper>,
 }
 
 impl OctezNode {
-    fn command(&self) -> Command {
-        Command::new(path_or_default(self.octez_node_bin.as_ref(), "octez-node"))
+    fn command(&self) -> Result<Command> {
+        let mut cmd =
+            Command::new(path_or_default(self.octez_node_bin.as_ref(), "octez-node"));
+        cmd.stdout(Stdio::from(self.log_file.as_file().try_clone()?))
+            .stderr(Stdio::from(self.log_file.as_file().try_clone()?));
+        Ok(cmd)
     }
 
     pub async fn config_init(
@@ -29,7 +35,7 @@ impl OctezNode {
         num_connections: u32,
     ) -> Result<Child> {
         Ok(self
-            .command()
+            .command()?
             .args([
                 "config",
                 "init",
@@ -50,7 +56,7 @@ impl OctezNode {
 
     pub async fn generate_identity(&self) -> Result<Child> {
         Ok(self
-            .command()
+            .command()?
             .args([
                 "identity",
                 "generate",
@@ -61,8 +67,8 @@ impl OctezNode {
             .spawn()?)
     }
 
-    pub fn run(&self, log_file: &File, options: &OctezNodeRunOptions) -> Result<Child> {
-        let mut command = self.command();
+    pub fn run(&self, options: &OctezNodeRunOptions) -> Result<Child> {
+        let mut command = self.command()?;
 
         command
             .args([
@@ -71,9 +77,7 @@ impl OctezNode {
                 self.octez_node_dir.to_str().expect("Invalid path"),
                 "--singleprocess",
             ])
-            .args(options.to_string().split(' '))
-            .stdout(Stdio::from(log_file.try_clone()?))
-            .stderr(Stdio::from(log_file.try_clone()?));
+            .args(options.to_string().split(' '));
 
         Ok(command.spawn()?)
     }


### PR DESCRIPTION
# Context

Part of JSTZ-244.
[JSTZ-244](https://linear.app/tezos/issue/JSTZ-244/direct-all-octez-logs-to-files).

# Description

Write octez-node logs to a log file instead of stdout/stderr.

# Manually testing the PR

Ran jstzd locally and did not see any octez-node logs.