### PR TITLE
feat(octez): write baker log to file

### DIFF
--- a/crates/jstzd/src/config.rs
+++ b/crates/jstzd/src/config.rs
@@ -412,6 +412,7 @@ mod tests {
 
     #[test]
     fn populate_baker_config() {
+        let log_file = NamedTempFile::new().unwrap().into_temp_path();
         let tmp_dir = tempdir().unwrap();
         let node_config = OctezNodeConfigBuilder::new()
             .set_rpc_endpoint(&Endpoint::localhost(5678))
@@ -421,7 +422,7 @@ mod tests {
             .set_base_dir(tmp_dir.path().to_path_buf())
             .build()
             .unwrap();
-        let baker_builder = OctezBakerConfigBuilder::new();
+        let baker_builder = OctezBakerConfigBuilder::new().set_log_file(&log_file);
         let protocol_params = ProtocolParameterBuilder::new()
             .set_protocol(Protocol::ParisC)
             .set_bootstrap_accounts([
@@ -445,14 +446,17 @@ mod tests {
                 .set_binary_path(BakerBinaryPath::Env(Protocol::ParisC))
                 .set_octez_client_base_dir(tmp_dir.path().to_str().unwrap())
                 .set_octez_node_endpoint(&Endpoint::localhost(5678))
+                .set_log_file(&log_file)
                 .build()
                 .unwrap()
         );
 
         // baker path is provided in the config, so the builder takes that path and ignores protocol_params
-        let baker_builder = OctezBakerConfigBuilder::new().set_binary_path(
-            BakerBinaryPath::Custom(PathBuf::from_str("/foo/bar").unwrap()),
-        );
+        let baker_builder = OctezBakerConfigBuilder::new()
+            .set_binary_path(BakerBinaryPath::Custom(
+                PathBuf::from_str("/foo/bar").unwrap(),
+            ))
+            .set_log_file(&log_file);
         let baker_config = super::populate_baker_config(
             baker_builder,
             &node_config,
@@ -468,6 +472,7 @@ mod tests {
                 ))
                 .set_octez_client_base_dir(tmp_dir.path().to_str().unwrap())
                 .set_octez_node_endpoint(&Endpoint::localhost(5678))
+                .set_log_file(&log_file)
                 .build()
                 .unwrap()
         );

--- a/crates/jstzd/tests/main_test.rs
+++ b/crates/jstzd/tests/main_test.rs
@@ -48,11 +48,7 @@ fn valid_config_file() {
             .unwrap()
             .args(["run", &tmp_file.path().to_string_lossy()])
             .assert()
-            .success()
-            // baker log writes to stderr
-            .stderr(predicate::str::contains(
-                "block ready for delegate: activator",
-            ));
+            .success();
     });
 
     let client = reqwest::blocking::Client::new();


### PR DESCRIPTION
# Context

Part of JSTZ-244.
[JSTZ-244](https://linear.app/tezos/issue/JSTZ-244/direct-all-octez-logs-to-files).

# Description

Write baker logs to a log file instead of stdout/stderr.

# Manually testing the PR

Ran jstzd locally and did not see any baker logs.