### PR TITLE
feat(octez): store bootstrap accounts in protocol parameters

### DIFF
--- a/crates/octez/src/async/bootstrap.rs
+++ b/crates/octez/src/async/bootstrap.rs
@@ -108,7 +108,7 @@ impl BootstrapAccount {
     }
 }
 
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Clone)]
 pub struct BootstrapAccounts {
     accounts: HashMap<String, BootstrapAccount>,
 }


### PR DESCRIPTION
# Context

Part of JSTZ-247.
[JSTZ-247](https://linear.app/tezos/issue/JSTZ-247/display-useful-information-for-users)

In preparation for #721.

# Description

Store bootstrap accounts in protocol parameters so that they can be retrieved later.

# Manually testing the PR

* Unit testing: added one test
