### PR TITLE
feat(jstzd): print bootstrap account info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3003,6 +3003,7 @@ dependencies = [
  "jstz_node",
  "octez",
  "predicates",
+ "prettytable",
  "rand 0.8.5",
  "regex",
  "reqwest",

--- a/crates/jstzd/Cargo.toml
+++ b/crates/jstzd/Cargo.toml
@@ -21,6 +21,7 @@ indicatif.workspace = true
 jstz_crypto = { path = "../jstz_crypto" }
 jstz_node = {path = "../jstz_node"}
 octez = { path = "../octez" }
+prettytable.workspace = true
 regex.workspace = true
 reqwest.workspace = true
 rust-embed.workspace = true


### PR DESCRIPTION
# Context

Completes JSTZ-247.
[JSTZ-247](https://linear.app/tezos/issue/JSTZ-247/display-useful-information-for-users)

# Description

Print information about bootstrap accounts when all components are ready.

# Manually testing the PR

* Unit testing: added one test
* Manual testing: ran jstzd locally and observed the printed lines
```sh
$ ./jstzd run /tmp/config.json 

           __________
           \  jstz  /
            )______(
            |""""""|_.-._,.---------.,_.-._
            |      | | |               | | ''-.
            |      |_| |_             _| |_..-'
            |______| '-' `'---------'` '-'
            )""""""(
           /________\
           `'------'`
         .------------.
        /______________\

        0.1.0-alpha.0 https://github.com/jstz-dev/jstz

  +--------------------------------------+---------------------+
  | Address                              | XTZ Balance (mutez) |
  +======================================+=====================+
  | tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV | 40000000000         |
  +--------------------------------------+---------------------+
  | tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx | 60000000000         |
  +--------------------------------------+---------------------+
```
