### PR TITLE
feat: implement smart function hash

### DIFF
--- a/crates/jstz_cli/src/bridge/deposit.rs
+++ b/crates/jstz_cli/src/bridge/deposit.rs
@@ -1,3 +1,4 @@
+use jstz_crypto::hash::Hash;
 use log::{debug, info};
 
 use crate::{

--- a/crates/jstz_cli/src/bridge/withdraw.rs
+++ b/crates/jstz_cli/src/bridge/withdraw.rs
@@ -6,6 +6,7 @@ use crate::{
     term::styles,
     utils::AddressOrAlias,
 };
+use jstz_crypto::hash::Hash;
 use log::debug;
 
 pub async fn exec(

--- a/crates/jstz_cli/src/config.rs
+++ b/crates/jstz_cli/src/config.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use derive_more::{From, TryInto};
-use jstz_crypto::{public_key::PublicKey, secret_key::SecretKey};
+use jstz_crypto::{hash::Hash, public_key::PublicKey, secret_key::SecretKey};
 use jstz_proto::context::account::Address;
 use log::debug;
 use octez::{OctezClient, OctezNode, OctezRollupNode};

--- a/crates/jstz_cli/src/jstz.rs
+++ b/crates/jstz_cli/src/jstz.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use anyhow::{bail, Result};
 use jstz_api::KvValue;
+use jstz_crypto::hash::Hash;
 use jstz_proto::{
     context::account::{Address, Nonce},
     operation::{OperationHash, SignedOperation},

--- a/crates/jstz_cli/src/repl/debug_api/account.rs
+++ b/crates/jstz_cli/src/repl/debug_api/account.rs
@@ -5,7 +5,7 @@ use boa_engine::{
     JsResult, JsValue, NativeFunction,
 };
 use jstz_core::runtime;
-use jstz_crypto::public_key_hash::PublicKeyHash;
+use jstz_crypto::{hash::Hash, public_key_hash::PublicKeyHash};
 use jstz_proto::context::account::Account;
 
 fn get_public_key_hash(account: &str) -> JsResult<PublicKeyHash> {

--- a/crates/jstz_cli/src/run.rs
+++ b/crates/jstz_cli/src/run.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 
 use anyhow::bail;
 use http::{HeaderMap, Method, Uri};
+use jstz_crypto::hash::Hash;
 use jstz_proto::context::account::Address;
 use jstz_proto::executor::JSTZ_HOST;
 use jstz_proto::{

--- a/crates/jstz_core/src/kv/outbox.rs
+++ b/crates/jstz_core/src/kv/outbox.rs
@@ -333,7 +333,7 @@ pub enum OutboxError {
 
 #[cfg(test)]
 mod test {
-    use jstz_crypto::public_key_hash::PublicKeyHash;
+    use jstz_crypto::{hash::Hash, public_key_hash::PublicKeyHash};
     use tezos_data_encoding::nom::NomReader;
     use tezos_smart_rollup::{
         michelson::{

--- a/crates/jstz_core/src/kv/transaction.rs
+++ b/crates/jstz_core/src/kv/transaction.rs
@@ -609,7 +609,7 @@ impl JsTransaction {
 
 #[cfg(test)]
 mod test {
-    use jstz_crypto::public_key_hash::PublicKeyHash;
+    use jstz_crypto::{hash::Hash, public_key_hash::PublicKeyHash};
     use serde::{Deserialize, Serialize};
     use tezos_data_encoding::nom::NomReader;
     use tezos_smart_rollup::{

--- a/crates/jstz_crypto/src/error.rs
+++ b/crates/jstz_crypto/src/error.rs
@@ -1,15 +1,20 @@
 use derive_more::{Display, Error, From};
 
-use tezos_crypto_rs::{base58::FromBase58CheckError, hash::FromBytesError, CryptoError};
+use tezos_crypto_rs::{
+    base58::FromBase58CheckError, blake2b::Blake2bError, hash::FromBytesError,
+    CryptoError,
+};
 
 #[derive(Display, Debug, Error, From)]
 pub enum Error {
     TezosFromBase58Error { source: FromBase58CheckError },
     TezosFromBytesError { source: FromBytesError },
     TezosCryptoError { source: CryptoError },
+    TezosBlake2bError { source: Blake2bError },
     InvalidSignature,
     InvalidPublicKeyHash,
     InvalidPublicKey,
+    InvalidSmartFunctionHash,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/jstz_crypto/src/lib.rs
+++ b/crates/jstz_crypto/src/lib.rs
@@ -6,6 +6,7 @@ pub mod public_key;
 pub mod public_key_hash;
 pub mod secret_key;
 pub mod signature;
+pub mod smart_function_hash;
 
 use tezos_crypto_rs::hash::SeedEd25519;
 

--- a/crates/jstz_crypto/src/public_key_hash.rs
+++ b/crates/jstz_crypto/src/public_key_hash.rs
@@ -1,5 +1,6 @@
 use std::{fmt, str::FromStr};
 
+use crate::hash::Hash;
 use boa_gc::{empty_trace, Finalize, Trace};
 use serde::{Deserialize, Serialize};
 use tezos_crypto_rs::{
@@ -61,9 +62,8 @@ impl FromStr for PublicKeyHash {
         PublicKeyHash::from_base58(s)
     }
 }
-
-impl PublicKeyHash {
-    pub fn to_base58(&self) -> String {
+impl<'a> Hash<'a> for PublicKeyHash {
+    fn to_base58(&self) -> String {
         match self {
             PublicKeyHash::Tz1(inner) => inner.to_b58check(),
             PublicKeyHash::Tz2(inner) => inner.to_b58check(),
@@ -71,7 +71,7 @@ impl PublicKeyHash {
         }
     }
 
-    pub fn from_base58(data: &str) -> Result<Self> {
+    fn from_base58(data: &str) -> Result<Self> {
         match &data[..3] {
             "tz1" => Ok(PublicKeyHash::Tz1(ContractTz1Hash::from_base58_check(
                 data,
@@ -86,7 +86,7 @@ impl PublicKeyHash {
         }
     }
 
-    pub fn as_bytes(&self) -> &[u8] {
+    fn as_bytes(&self) -> &[u8] {
         match self {
             PublicKeyHash::Tz1(inner) => inner.as_ref(),
             PublicKeyHash::Tz2(inner) => inner.as_ref(),
@@ -99,9 +99,9 @@ impl PublicKeyHash {
     // Tz1 and the signature scheme. We currently depend on it to generate
     // new smart contract address but it should only be suitable in testing.
     // #[cfg(test)]
-    pub fn digest(data: &[u8]) -> Result<Self> {
+    fn digest(data: &[u8]) -> Result<Self> {
         let out_len = ContractTz1Hash::hash_size();
-        let bytes = blake2b::digest(data, out_len).expect("failed to create hash");
+        let bytes = blake2b::digest(data, out_len)?;
         Ok(PublicKeyHash::Tz1(ContractTz1Hash::try_from_bytes(&bytes)?))
     }
 }
@@ -124,6 +124,7 @@ impl From<&PublicKey> for PublicKeyHash {
 
 #[cfg(test)]
 mod test {
+    use crate::hash::Hash;
     use std::str::FromStr;
 
     use tezos_crypto_rs::hash::{

--- a/crates/jstz_crypto/src/smart_function_hash.rs
+++ b/crates/jstz_crypto/src/smart_function_hash.rs
@@ -1,0 +1,144 @@
+use boa_gc::{empty_trace, Finalize, Trace};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+use utoipa::ToSchema;
+
+use crate::{
+    error::{Error, Result},
+    hash::Hash,
+};
+use tezos_crypto_rs::{
+    blake2b,
+    hash::{ContractKt1Hash, HashTrait},
+};
+
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    Finalize,
+    ToSchema,
+)]
+pub enum SmartFunctionHash {
+    #[schema(
+        title = "KT1",
+        value_type = String,
+        example = json!("KT1RycYvM4EVs6BAXWEsGXaAaRqiMP53KT4w")
+    )]
+    Kt1(ContractKt1Hash),
+}
+
+unsafe impl Trace for SmartFunctionHash {
+    empty_trace!();
+}
+
+impl FromStr for SmartFunctionHash {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        SmartFunctionHash::from_base58(s)
+    }
+}
+
+impl<'a> Hash<'a> for SmartFunctionHash {
+    fn to_base58(&self) -> String {
+        match self {
+            SmartFunctionHash::Kt1(inner) => inner.to_b58check(),
+        }
+    }
+
+    fn from_base58(data: &str) -> Result<Self> {
+        match &data[..3] {
+            "KT1" => Ok(SmartFunctionHash::Kt1(ContractKt1Hash::from_base58_check(
+                data,
+            )?)),
+            _ => Err(Error::InvalidSmartFunctionHash),
+        }
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        match self {
+            SmartFunctionHash::Kt1(inner) => inner.as_ref(),
+        }
+    }
+
+    // Generate a new contract address by hashing the input data.
+    // This is the standard way to generate KT1 addresses for smart contracts.
+    fn digest(data: &[u8]) -> Result<Self> {
+        let out_len = ContractKt1Hash::hash_size();
+        let bytes = blake2b::digest(data, out_len)?;
+        Ok(SmartFunctionHash::Kt1(ContractKt1Hash::try_from_bytes(
+            &bytes,
+        )?))
+    }
+}
+
+impl fmt::Display for SmartFunctionHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_base58())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::str::FromStr;
+
+    const KT1_VALID: &str = "KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton";
+    const KT1_INVALID: &str = "KT1invalidaddress";
+    const UNKNOWN_PREFIX: &str = "KT2RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton";
+
+    #[test]
+    fn from_str_valid() {
+        let hash = SmartFunctionHash::from_str(KT1_VALID).unwrap();
+        match hash {
+            SmartFunctionHash::Kt1(inner) => {
+                assert_eq!(inner.to_b58check(), KT1_VALID);
+            }
+        }
+    }
+
+    #[test]
+    fn from_str_invalid() {
+        // Test with an invalid KT1 address
+        assert!(SmartFunctionHash::from_str(KT1_INVALID).is_err());
+
+        // Test with an unknown prefix
+        assert!(SmartFunctionHash::from_str(UNKNOWN_PREFIX).is_err());
+
+        // Test with completely invalid format
+        assert!(SmartFunctionHash::from_str("invalid").is_err());
+    }
+
+    #[test]
+    fn to_base58() {
+        let hash = SmartFunctionHash::from_str(KT1_VALID).unwrap();
+        assert_eq!(hash.to_base58(), KT1_VALID);
+    }
+
+    #[test]
+    fn as_bytes() {
+        let hash = SmartFunctionHash::from_str(KT1_VALID).unwrap();
+        // Assuming KT1 hashes are 20 bytes; adjust if different
+        assert_eq!(hash.as_bytes().len(), 20);
+    }
+
+    #[test]
+    fn display_trait() {
+        let hash = SmartFunctionHash::from_str(KT1_VALID).unwrap();
+        assert_eq!(hash.to_string(), KT1_VALID);
+    }
+
+    #[test]
+    fn digest() {
+        let hash = SmartFunctionHash::digest(b"hello").unwrap();
+        assert_eq!(hash.to_base58(), "KT1R7XS9SPbsf9ri9fUwjBLff8LB4oYCc4ao");
+    }
+}

--- a/crates/jstz_kernel/src/inbox.rs
+++ b/crates/jstz_kernel/src/inbox.rs
@@ -1,3 +1,4 @@
+use jstz_crypto::hash::Hash;
 use jstz_crypto::public_key_hash::PublicKeyHash;
 use jstz_proto::operation::{external::Deposit, ExternalOperation, SignedOperation};
 use num_traits::ToPrimitive;
@@ -190,6 +191,7 @@ pub fn read_message(
 
 #[cfg(test)]
 mod test {
+    use jstz_crypto::hash::Hash;
     use jstz_crypto::public_key_hash::PublicKeyHash;
     use jstz_mock::message::native_deposit::MockNativeDeposit;
     use jstz_mock::{host::JstzMockHost, message::fa_deposit::MockFaDeposit};

--- a/crates/jstz_kernel/src/lib.rs
+++ b/crates/jstz_kernel/src/lib.rs
@@ -59,6 +59,7 @@ pub fn entry(rt: &mut impl Runtime) {
 mod test {
 
     use jstz_core::kv::Transaction;
+    use jstz_crypto::hash::Hash;
     use jstz_mock::{
         host::{JstzMockHost, MOCK_SOURCE},
         message::{fa_deposit::MockFaDeposit, native_deposit::MockNativeDeposit},

--- a/crates/jstz_kernel/src/parsing.rs
+++ b/crates/jstz_kernel/src/parsing.rs
@@ -41,6 +41,7 @@ pub fn try_parse_fa_deposit(
 #[cfg(test)]
 mod test {
 
+    use jstz_crypto::hash::Hash;
     use jstz_proto::operation::external::FaDeposit;
     use tezos_smart_rollup::{
         michelson::{

--- a/crates/jstz_mock/src/lib.rs
+++ b/crates/jstz_mock/src/lib.rs
@@ -1,3 +1,4 @@
+use jstz_crypto::hash::Hash;
 use tezos_crypto_rs::hash::ContractKt1Hash;
 use tezos_smart_rollup::{
     michelson::{

--- a/crates/jstz_mock/src/message/fa_deposit.rs
+++ b/crates/jstz_mock/src/message/fa_deposit.rs
@@ -1,3 +1,4 @@
+use jstz_crypto::hash::Hash;
 use tezos_crypto_rs::hash::ContractKt1Hash;
 use tezos_smart_rollup::{
     michelson::{

--- a/crates/jstz_node/src/services/logs/mod.rs
+++ b/crates/jstz_node/src/services/logs/mod.rs
@@ -7,6 +7,7 @@ use axum::{
     Json,
 };
 use broadcaster::InfallibleSSeStream;
+use jstz_crypto::hash::Hash;
 #[cfg(feature = "persistent-logging")]
 use jstz_proto::request_logger::{
     RequestEvent, REQUEST_END_PREFIX, REQUEST_START_PREFIX,

--- a/crates/jstz_proto/src/api/ledger.rs
+++ b/crates/jstz_proto/src/api/ledger.rs
@@ -12,6 +12,7 @@ use jstz_core::{
     accessor, host::HostRuntime, kv::Transaction, native::Accessor, runtime,
     value::IntoJs,
 };
+use jstz_crypto::hash::Hash;
 
 use crate::{
     context::account::{Account, Address, Amount},

--- a/crates/jstz_proto/src/api/smart_function.rs
+++ b/crates/jstz_proto/src/api/smart_function.rs
@@ -12,6 +12,7 @@ use jstz_core::{
     host::HostRuntime, host_defined, kv::Transaction, native::JsNativeObject, runtime,
     value::IntoJs,
 };
+use jstz_crypto::hash::Hash;
 
 use crate::{
     context::account::{Account, Address, Amount, ParsedCode},
@@ -260,7 +261,7 @@ mod test {
         runtime::{self, with_js_hrt_and_tx},
         Runtime,
     };
-    use jstz_crypto::hash::Blake2b;
+    use jstz_crypto::hash::{Blake2b, Hash};
     use jstz_mock::host::JstzMockHost;
     use serde_json::json;
 

--- a/crates/jstz_proto/src/context/account.rs
+++ b/crates/jstz_proto/src/context/account.rs
@@ -243,6 +243,7 @@ impl Account {
 #[cfg(test)]
 mod test {
     use super::*;
+    use jstz_crypto::hash::Hash;
     use tezos_smart_rollup_mock::MockHost;
 
     #[test]

--- a/crates/jstz_proto/src/executor/fa_deposit.rs
+++ b/crates/jstz_proto/src/executor/fa_deposit.rs
@@ -2,7 +2,7 @@ use derive_more::{Display, Error, From};
 use http::{header::CONTENT_TYPE, HeaderMap, Method, Uri};
 use jstz_api::http::body::HttpBody;
 use jstz_core::{host::HostRuntime, kv::Transaction};
-use jstz_crypto::public_key_hash::PublicKeyHash;
+use jstz_crypto::{hash::Hash, public_key_hash::PublicKeyHash};
 use serde::{Deserialize, Serialize};
 use tezos_smart_rollup::{michelson::ticket::TicketHash, prelude::debug_msg};
 use utoipa::ToSchema;

--- a/crates/jstz_proto/src/executor/fa_withdraw.rs
+++ b/crates/jstz_proto/src/executor/fa_withdraw.rs
@@ -4,7 +4,7 @@ use jstz_core::{
     host::HostRuntime,
     kv::{outbox::OutboxMessage, Transaction},
 };
-use jstz_crypto::public_key_hash::PublicKeyHash;
+use jstz_crypto::{hash::Hash, public_key_hash::PublicKeyHash};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tezos_crypto_rs::hash::ContractKt1Hash;

--- a/crates/jstz_proto/src/executor/smart_function.rs
+++ b/crates/jstz_proto/src/executor/smart_function.rs
@@ -21,6 +21,7 @@ use jstz_core::{
     host::HostRuntime, host_defined, kv::Transaction, native::JsNativeObject, runtime,
     Module, Realm,
 };
+use jstz_crypto::hash::Hash;
 use tezos_smart_rollup::prelude::debug_msg;
 
 use crate::{
@@ -615,6 +616,7 @@ pub mod jstz_run {
     mod test {
         use http::{header, HeaderMap, Method, Uri};
         use jstz_core::kv::Transaction;
+        use jstz_crypto::hash::Hash;
         use jstz_mock::host::JstzMockHost;
         use serde_json::json;
         use tezos_crypto_rs::hash::ContractKt1Hash;

--- a/crates/jstz_proto/src/executor/withdraw.rs
+++ b/crates/jstz_proto/src/executor/withdraw.rs
@@ -2,6 +2,7 @@ use jstz_core::{
     host::HostRuntime,
     kv::{outbox::OutboxMessage, Transaction},
 };
+use jstz_crypto::hash::Hash;
 use serde::{Deserialize, Serialize};
 use tezos_smart_rollup::{
     michelson::{ticket::FA2_1Ticket, MichelsonOption, MichelsonPair},

--- a/crates/jstzd/tests/octez_client_test.rs
+++ b/crates/jstzd/tests/octez_client_test.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use jstz_crypto::public_key_hash::PublicKeyHash;
+use jstz_crypto::{hash::Hash, public_key_hash::PublicKeyHash};
 use jstzd::task::{utils::poll, Task};
 use octez::r#async::{
     client::{OctezClient, OctezClientConfigBuilder, Signature},

--- a/crates/octez/src/async/client.rs
+++ b/crates/octez/src/async/client.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, bail, Context, Result};
 use jstz_crypto::{
-    public_key::PublicKey, public_key_hash::PublicKeyHash, secret_key::SecretKey,
+    hash::Hash, public_key::PublicKey, public_key_hash::PublicKeyHash,
+    secret_key::SecretKey,
 };
 use regex::Regex;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
# Context

[Introduce smart function hash](https://linear.app/tezos/issue/JSTZ-251/introduce-smartfunctionhash)

In preparation for [254](https://linear.app/tezos/issue/JSTZ-254/migrate-to-newaddress-type)

# Description



1. Introduce a `Hash` trait that both the public key hash for user account and sf hash for sf account will use
```
pub trait Hash<'de>:
    Sized
    + ...
{
    fn to_base58(&self) -> String;

    fn from_base58(data: &str) -> Result<Self>;

    fn as_bytes(&self) -> &[u8];

    fn digest(data: &[u8]) -> Result<Self>;
}
```
2. make `PublicKeyHash` implement the JstzHash

3. Introduce `SmartFunctionHash` that implements the JstzHash. this hash will be used for sf address and starts with `TZ1...`


# Manually testing the PR

unit test
