### PR TITLE
fix(wpt): run subsetTest

### DIFF
--- a/crates/jstz_api/tests/wpt.rs
+++ b/crates/jstz_api/tests/wpt.rs
@@ -3,8 +3,8 @@ use std::future::IntoFuture;
 use anyhow::Result;
 use boa_engine::{
     js_string, object::FunctionObjectBuilder, property::PropertyDescriptor,
-    value::TryFromJs, Context, JsArgs, JsData, JsNativeError, JsResult, JsValue,
-    NativeFunction, Source,
+    value::TryFromJs, Context, JsArgs, JsData, JsNativeError, JsObject, JsResult,
+    JsValue, NativeFunction, Source,
 };
 use boa_gc::{Finalize, Trace};
 use derive_more::{From, Into};
@@ -246,6 +246,36 @@ pub fn register_apis(context: &mut Context) {
     jstz_api::file::FileApi.init(context);
 }
 
+fn insert_global_properties(rt: &mut Runtime) {
+    // Define self
+    rt.global_object().insert_property(
+        js_string!("self"),
+        PropertyDescriptor::builder()
+            .value(rt.global_object().clone())
+            .configurable(true)
+            .writable(true)
+            .enumerable(true)
+            .build(),
+    );
+
+    // Define a dummy `location` object so that subsetTest can run
+    let location = JsObject::with_null_proto();
+    location
+        // `location.search` is used by wpt to determine how many tests in a subset test can run.
+        // Setting this to 5 here because those subsets can contain thousands of tests
+        .create_data_property(js_string!("search"), js_string!("?0-5"), rt.context())
+        .unwrap();
+    rt.global_object().insert_property(
+        js_string!("location"),
+        PropertyDescriptor::builder()
+            .value(location)
+            .configurable(true)
+            .writable(true)
+            .enumerable(true)
+            .build(),
+    );
+}
+
 pub fn run_wpt_test_harness(bundle: &Bundle) -> JsResult<Box<TestHarnessReport>> {
     let mut rt: Runtime = Runtime::new(usize::MAX)?;
 
@@ -258,16 +288,7 @@ pub fn run_wpt_test_harness(bundle: &Bundle) -> JsResult<Box<TestHarnessReport>>
     // Register APIs
     register_apis(&mut rt);
 
-    // Define self
-    rt.global_object().insert_property(
-        js_string!("self"),
-        PropertyDescriptor::builder()
-            .value(rt.global_object().clone())
-            .configurable(true)
-            .writable(true)
-            .enumerable(true)
-            .build(),
-    );
+    insert_global_properties(&mut rt);
 
     // Run the bundle, evaluating each script in order
     // Instead of loading the TestHarnessReport script, we initialize it manually

--- a/crates/jstz_api/tests/wptreport.json
+++ b/crates/jstz_api/tests/wptreport.json
@@ -96,37 +96,141 @@
           "Test": {
             "variations": [
               {
-                "subtests": [],
-                "status": "Err",
+                "subtests": [
+                  {
+                    "name": "Invalid label \"invalid-invalidLabel\" should be rejected by TextDecoder.",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Invalid label \"\\0unicode-1-1-utf-8\" should be rejected by TextDecoder.",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Invalid label \"unicode-1-1-utf-8\\0\" should be rejected by TextDecoder.",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Invalid label \"\\0unicode-1-1-utf-8\\0\" should be rejected by TextDecoder.",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Invalid label \"\\vunicode-1-1-utf-8\" should be rejected by TextDecoder.",
+                    "status": "Pass",
+                    "message": null
+                  }
+                ],
+                "status": "Ok",
                 "metrics": {
-                  "passed": 0,
+                  "passed": 5,
                   "failed": 0,
                   "timed_out": 0
                 }
               },
               {
-                "subtests": [],
-                "status": "Err",
+                "subtests": [
+                  {
+                    "name": "Invalid label \"invalid-invalidLabel\" should be rejected by TextDecoder.",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Invalid label \"\\0unicode-1-1-utf-8\" should be rejected by TextDecoder.",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Invalid label \"unicode-1-1-utf-8\\0\" should be rejected by TextDecoder.",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Invalid label \"\\0unicode-1-1-utf-8\\0\" should be rejected by TextDecoder.",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Invalid label \"\\vunicode-1-1-utf-8\" should be rejected by TextDecoder.",
+                    "status": "Pass",
+                    "message": null
+                  }
+                ],
+                "status": "Ok",
                 "metrics": {
-                  "passed": 0,
+                  "passed": 5,
                   "failed": 0,
                   "timed_out": 0
                 }
               },
               {
-                "subtests": [],
-                "status": "Err",
+                "subtests": [
+                  {
+                    "name": "Invalid label \"invalid-invalidLabel\" should be rejected by TextDecoder.",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Invalid label \"\\0unicode-1-1-utf-8\" should be rejected by TextDecoder.",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Invalid label \"unicode-1-1-utf-8\\0\" should be rejected by TextDecoder.",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Invalid label \"\\0unicode-1-1-utf-8\\0\" should be rejected by TextDecoder.",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Invalid label \"\\vunicode-1-1-utf-8\" should be rejected by TextDecoder.",
+                    "status": "Pass",
+                    "message": null
+                  }
+                ],
+                "status": "Ok",
                 "metrics": {
-                  "passed": 0,
+                  "passed": 5,
                   "failed": 0,
                   "timed_out": 0
                 }
               },
               {
-                "subtests": [],
-                "status": "Err",
+                "subtests": [
+                  {
+                    "name": "Invalid label \"invalid-invalidLabel\" should be rejected by TextDecoder.",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Invalid label \"\\0unicode-1-1-utf-8\" should be rejected by TextDecoder.",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Invalid label \"unicode-1-1-utf-8\\0\" should be rejected by TextDecoder.",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Invalid label \"\\0unicode-1-1-utf-8\\0\" should be rejected by TextDecoder.",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Invalid label \"\\vunicode-1-1-utf-8\" should be rejected by TextDecoder.",
+                    "status": "Pass",
+                    "message": null
+                  }
+                ],
+                "status": "Ok",
                 "metrics": {
-                  "passed": 0,
+                  "passed": 5,
                   "failed": 0,
                   "timed_out": 0
                 }
@@ -642,73 +746,281 @@
           "Test": {
             "variations": [
               {
-                "subtests": [],
-                "status": "Err",
+                "subtests": [
+                  {
+                    "name": "Not throw: IBM866 has a pointer 0",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 1",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 2",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 3",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 4",
+                    "status": "Pass",
+                    "message": null
+                  }
+                ],
+                "status": "Ok",
                 "metrics": {
-                  "passed": 0,
+                  "passed": 5,
                   "failed": 0,
                   "timed_out": 0
                 }
               },
               {
-                "subtests": [],
-                "status": "Err",
+                "subtests": [
+                  {
+                    "name": "Not throw: IBM866 has a pointer 0",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 1",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 2",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 3",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 4",
+                    "status": "Pass",
+                    "message": null
+                  }
+                ],
+                "status": "Ok",
                 "metrics": {
-                  "passed": 0,
+                  "passed": 5,
                   "failed": 0,
                   "timed_out": 0
                 }
               },
               {
-                "subtests": [],
-                "status": "Err",
+                "subtests": [
+                  {
+                    "name": "Not throw: IBM866 has a pointer 0",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 1",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 2",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 3",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 4",
+                    "status": "Pass",
+                    "message": null
+                  }
+                ],
+                "status": "Ok",
                 "metrics": {
-                  "passed": 0,
+                  "passed": 5,
                   "failed": 0,
                   "timed_out": 0
                 }
               },
               {
-                "subtests": [],
-                "status": "Err",
+                "subtests": [
+                  {
+                    "name": "Not throw: IBM866 has a pointer 0",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 1",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 2",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 3",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 4",
+                    "status": "Pass",
+                    "message": null
+                  }
+                ],
+                "status": "Ok",
                 "metrics": {
-                  "passed": 0,
+                  "passed": 5,
                   "failed": 0,
                   "timed_out": 0
                 }
               },
               {
-                "subtests": [],
-                "status": "Err",
+                "subtests": [
+                  {
+                    "name": "Not throw: IBM866 has a pointer 0",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 1",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 2",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 3",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 4",
+                    "status": "Pass",
+                    "message": null
+                  }
+                ],
+                "status": "Ok",
                 "metrics": {
-                  "passed": 0,
+                  "passed": 5,
                   "failed": 0,
                   "timed_out": 0
                 }
               },
               {
-                "subtests": [],
-                "status": "Err",
+                "subtests": [
+                  {
+                    "name": "Not throw: IBM866 has a pointer 0",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 1",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 2",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 3",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 4",
+                    "status": "Pass",
+                    "message": null
+                  }
+                ],
+                "status": "Ok",
                 "metrics": {
-                  "passed": 0,
+                  "passed": 5,
                   "failed": 0,
                   "timed_out": 0
                 }
               },
               {
-                "subtests": [],
-                "status": "Err",
+                "subtests": [
+                  {
+                    "name": "Not throw: IBM866 has a pointer 0",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 1",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 2",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 3",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 4",
+                    "status": "Pass",
+                    "message": null
+                  }
+                ],
+                "status": "Ok",
                 "metrics": {
-                  "passed": 0,
+                  "passed": 5,
                   "failed": 0,
                   "timed_out": 0
                 }
               },
               {
-                "subtests": [],
-                "status": "Err",
+                "subtests": [
+                  {
+                    "name": "Not throw: IBM866 has a pointer 0",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 1",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 2",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 3",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Not throw: IBM866 has a pointer 4",
+                    "status": "Pass",
+                    "message": null
+                  }
+                ],
+                "status": "Ok",
                 "metrics": {
-                  "passed": 0,
+                  "passed": 5,
                   "failed": 0,
                   "timed_out": 0
                 }


### PR DESCRIPTION
# Context

Closes JSTZ-258.

[JSTZ-258](https://linear.app/tezos/issue/JSTZ-258/run-wpt-subsettest)

# Description

Some test suites, e.g. `api-invalid-label.any.js`, allow users to run a subset of tests defined in the test suites. This mechanism parses the number of tests to be run from the URL, i.e. `location.search`, assuming that the tests are executed in a browser, even if the tests themselves might not have anything to do with browser-specific features. These test suites fail in wpt for jstz because jstz runtime does not have this global `location` object (for now, if it will ever be implemented.)

To make these test suites work for jstz, a dummy `location` object needs to be inserted into the runtime so that the test scripts can find it and then ignore it. Note that `location.search` is now set to a dummy value such that only 5 tests in each subset are executed. Each subset might have thousands of test cases and this would make `wptreport.json` explode, so I have to limit the amount of tests executed.

Also, these subset tests seem to be significantly slow, so we will need to add additional nextest config for wpt test specifically to extend its timeout when it gets enabled in the future.

# Manually testing the PR

`env UPDATE_EXPECT=1 cargo test --test wpt`

and more tests pop up.
