### PR TITLE
feat(jstz_cli): make Config::load async

### DIFF
--- a/crates/jstz_cli/src/account.rs
+++ b/crates/jstz_cli/src/account.rs
@@ -32,8 +32,8 @@ impl User {
     }
 }
 
-fn add_smart_function(alias: String, address: Address) -> Result<()> {
-    let mut cfg = Config::load()?;
+async fn add_smart_function(alias: String, address: Address) -> Result<()> {
+    let mut cfg = Config::load().await?;
 
     if cfg.accounts.contains(&alias) {
         bail_user_error!(
@@ -50,8 +50,8 @@ fn add_smart_function(alias: String, address: Address) -> Result<()> {
     Ok(())
 }
 
-fn create_account(alias: String, passphrase: Option<String>) -> Result<()> {
-    let mut cfg = Config::load()?;
+async fn create_account(alias: String, passphrase: Option<String>) -> Result<()> {
+    let mut cfg = Config::load().await?;
 
     if cfg.accounts.contains(&alias) {
         bail_user_error!(
@@ -80,8 +80,8 @@ fn create_account(alias: String, passphrase: Option<String>) -> Result<()> {
     Ok(())
 }
 
-fn delete_account(alias: String) -> Result<()> {
-    let mut cfg = Config::load()?;
+async fn delete_account(alias: String) -> Result<()> {
+    let mut cfg = Config::load().await?;
 
     if !cfg.accounts.contains(&alias) {
         bail_user_error!("The account '{}' does not exist.", alias);
@@ -106,8 +106,8 @@ fn delete_account(alias: String) -> Result<()> {
     Ok(())
 }
 
-pub fn login(alias: String) -> Result<()> {
-    let mut cfg = Config::load()?;
+pub async fn login(alias: String) -> Result<()> {
+    let mut cfg = Config::load().await?;
 
     if cfg.accounts.current_alias().is_some()
         && !Confirm::new()
@@ -169,20 +169,20 @@ pub fn login(alias: String) -> Result<()> {
     }
 }
 
-pub fn login_quick(cfg: &mut Config) -> Result<()> {
+pub async fn login_quick(cfg: &mut Config) -> Result<()> {
     if cfg.accounts.current_user().is_none() {
         let account_alias: String = Input::new()
                 .with_prompt("You are not logged in. Please type the account name that you want to log into or create as new")
                 .interact()?;
 
-        login(account_alias)?;
+        login(account_alias).await?;
         info!("");
     }
     Ok(())
 }
 
-pub fn logout() -> Result<()> {
-    let mut cfg = Config::load()?;
+pub async fn logout() -> Result<()> {
+    let mut cfg = Config::load().await?;
 
     if cfg.accounts.current_alias().is_none() {
         bail_user_error!("You are not logged in. Please run `jstz login`.");
@@ -196,8 +196,8 @@ pub fn logout() -> Result<()> {
     Ok(())
 }
 
-pub fn whoami() -> Result<()> {
-    let cfg = Config::load()?;
+pub async fn whoami() -> Result<()> {
+    let cfg = Config::load().await?;
 
     let (alias, user) = cfg.accounts.current_user().ok_or(user_error!(
         "You are not logged in. Please run `jstz login`."
@@ -213,8 +213,8 @@ pub fn whoami() -> Result<()> {
     Ok(())
 }
 
-fn list_accounts(long: bool) -> Result<()> {
-    let cfg = Config::load()?;
+async fn list_accounts(long: bool) -> Result<()> {
+    let cfg = Config::load().await?;
 
     info!("Accounts:");
     for (alias, account) in cfg.accounts.iter() {
@@ -248,7 +248,7 @@ async fn get_code(
     account: Option<AddressOrAlias>,
     network: Option<NetworkName>,
 ) -> Result<()> {
-    let cfg = Config::load()?;
+    let cfg = Config::load().await?;
 
     debug!("Getting code.. {:?}.", network);
 
@@ -269,7 +269,7 @@ async fn get_balance(
     account: Option<AddressOrAlias>,
     network: Option<NetworkName>,
 ) -> Result<()> {
-    let cfg = Config::load()?;
+    let cfg = Config::load().await?;
 
     let address = AddressOrAlias::resolve_or_use_current_user(account, &cfg)?;
     debug!("resolved `account` -> {:?}", address);
@@ -339,10 +339,10 @@ pub enum Command {
 
 pub async fn exec(command: Command) -> Result<()> {
     match command {
-        Command::Alias { alias, address } => add_smart_function(alias, address),
-        Command::Create { alias, passphrase } => create_account(alias, passphrase),
-        Command::Delete { alias } => delete_account(alias),
-        Command::List { long } => list_accounts(long),
+        Command::Alias { alias, address } => add_smart_function(alias, address).await,
+        Command::Create { alias, passphrase } => create_account(alias, passphrase).await,
+        Command::Delete { alias } => delete_account(alias).await,
+        Command::List { long } => list_accounts(long).await,
         Command::Code { account, network } => get_code(account, network).await,
         Command::Balance { account, network } => get_balance(account, network).await,
     }

--- a/crates/jstz_cli/src/bridge/deposit.rs
+++ b/crates/jstz_cli/src/bridge/deposit.rs
@@ -9,13 +9,13 @@ use crate::{
     utils::AddressOrAlias,
 };
 
-pub fn exec(
+pub async fn exec(
     from: String,
     to: AddressOrAlias,
     amount: u64,
     network: Option<NetworkName>,
 ) -> Result<()> {
-    let cfg = Config::load()?;
+    let cfg = Config::load().await?;
 
     // Check network
     if cfg.network_name(&network)? == NetworkName::Dev && cfg.sandbox.is_none() {

--- a/crates/jstz_cli/src/bridge/mod.rs
+++ b/crates/jstz_cli/src/bridge/mod.rs
@@ -51,7 +51,7 @@ pub async fn exec(command: Command) -> Result<()> {
             to,
             amount,
             network,
-        } => deposit::exec(from, to, amount, network),
+        } => deposit::exec(from, to, amount, network).await,
         Command::Withdraw {
             to,
             amount,

--- a/crates/jstz_cli/src/bridge/withdraw.rs
+++ b/crates/jstz_cli/src/bridge/withdraw.rs
@@ -14,7 +14,7 @@ pub async fn exec(
     amount: f64,
     network: Option<NetworkName>,
 ) -> Result<()> {
-    let cfg = Config::load()?;
+    let cfg = Config::load().await?;
 
     // Check network
     if cfg.network_name(&network)? == NetworkName::Dev && cfg.sandbox.is_none() {

--- a/crates/jstz_cli/src/config.rs
+++ b/crates/jstz_cli/src/config.rs
@@ -288,13 +288,23 @@ impl Config {
         jstz_home_dir().join("config.json")
     }
 
-    pub fn reload(&mut self) -> Result<()> {
-        *self = Self::load()?;
+    pub async fn reload(&mut self) -> Result<()> {
+        *self = Self::load().await?;
+        Ok(())
+    }
+
+    pub fn reload_sync(&mut self) -> Result<()> {
+        *self = Self::load_sync()?;
         Ok(())
     }
 
     /// Load the configuration from the file
-    pub fn load() -> Result<Self> {
+    pub async fn load() -> Result<Self> {
+        Self::load_sync()
+    }
+
+    /// Load the configuration from the file
+    pub fn load_sync() -> Result<Self> {
         let path = Self::path();
 
         let config = if path.exists() {

--- a/crates/jstz_cli/src/deploy.rs
+++ b/crates/jstz_cli/src/deploy.rs
@@ -23,7 +23,7 @@ pub async fn exec(
     // maximum size of code until the DAL is implemented
     const MAX_CODE_LENGTH: usize = 3915;
 
-    let mut cfg = Config::load()?;
+    let mut cfg = Config::load().await?;
     // Load sandbox if the selected network is Dev and sandbox is not already loaded
     if cfg.network_name(&network)? == NetworkName::Dev && cfg.sandbox.is_none() {
         bail_user_error!(
@@ -33,8 +33,8 @@ pub async fn exec(
     }
 
     // Get the current user and check if we are logged in
-    account::login_quick(&mut cfg)?;
-    cfg.reload()?;
+    account::login_quick(&mut cfg).await?;
+    cfg.reload().await?;
     let (user_name, user) = cfg.accounts.current_user().ok_or(anyhow!(
         "Failed to setup the account. Please run `{}`.",
         styles::command("jstz login")

--- a/crates/jstz_cli/src/kv.rs
+++ b/crates/jstz_cli/src/kv.rs
@@ -12,7 +12,7 @@ async fn get(
     key: String,
     network: Option<NetworkName>,
 ) -> Result<()> {
-    let cfg = Config::load()?;
+    let cfg = Config::load().await?;
 
     let address = AddressOrAlias::resolve_or_use_current_user(account, &cfg)?;
     debug!("resolved `account` -> {:?}", address);
@@ -36,7 +36,7 @@ async fn list(
     key: Option<String>,
     network: Option<NetworkName>,
 ) -> Result<()> {
-    let cfg = Config::load()?;
+    let cfg = Config::load().await?;
 
     let address = AddressOrAlias::resolve_or_use_current_user(account, &cfg)?;
     debug!("resolved `account` -> {:?}", address);

--- a/crates/jstz_cli/src/logs/trace.rs
+++ b/crates/jstz_cli/src/logs/trace.rs
@@ -13,7 +13,7 @@ pub async fn exec(
     log_level: LogLevel,
     network: &Option<NetworkName>,
 ) -> Result<()> {
-    let cfg = Config::load()?;
+    let cfg = Config::load().await?;
 
     let address = address_or_alias.resolve(&cfg)?;
     debug!("resolved `address_or_alias` -> {:?}", address);

--- a/crates/jstz_cli/src/main.rs
+++ b/crates/jstz_cli/src/main.rs
@@ -131,11 +131,11 @@ async fn exec(command: Command) -> Result<()> {
             network,
             trace,
         } => run::exec(url, http_method, gas_limit, json_data, network, trace).await,
-        Command::Repl { account } => repl::exec(account),
+        Command::Repl { account } => repl::exec(account).await,
         Command::Logs(logs) => logs::exec(logs).await,
-        Command::Login { alias } => account::login(alias),
-        Command::Logout {} => account::logout(),
-        Command::WhoAmI {} => account::whoami(),
+        Command::Login { alias } => account::login(alias).await,
+        Command::Logout {} => account::logout().await,
+        Command::WhoAmI {} => account::whoami().await,
         Command::Kv(kv_command) => kv::exec(kv_command).await,
     }
 }

--- a/crates/jstz_cli/src/repl/mod.rs
+++ b/crates/jstz_cli/src/repl/mod.rs
@@ -104,8 +104,8 @@ const DEFAULT_SMART_FUNCTION_ADDRESS: &str = "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZ
 const DEFAULT_GAS_LIMIT: usize = usize::MAX;
 const DEFAULT_RANDOM_SEED: u64 = 42;
 
-pub fn exec(account: Option<AddressOrAlias>) -> Result<()> {
-    let cfg = Config::load()?;
+pub async fn exec(account: Option<AddressOrAlias>) -> Result<()> {
+    let cfg = Config::load().await?;
 
     let address = match account {
         Some(account) => account.resolve(&cfg)?.clone(),

--- a/crates/jstz_cli/src/run.rs
+++ b/crates/jstz_cli/src/run.rs
@@ -67,9 +67,9 @@ pub async fn exec(
     trace: bool,
 ) -> Result<()> {
     // 1. Get the current user (checking if we are logged in)
-    let mut cfg = Config::load()?;
-    account::login_quick(&mut cfg)?;
-    cfg.reload()?;
+    let mut cfg = Config::load().await?;
+    account::login_quick(&mut cfg).await?;
+    cfg.reload().await?;
 
     let (_, user) = cfg.accounts.current_user().ok_or(anyhow!(
         "Failed to setup the account. Please run `{}`.",

--- a/crates/jstz_cli/src/sandbox/daemon.rs
+++ b/crates/jstz_cli/src/sandbox/daemon.rs
@@ -225,7 +225,7 @@ impl Sandbox {
 
     fn remove_sandbox_from_config(&mut self) -> Result<()> {
         let mut config = self.config.borrow_mut();
-        config.reload()?;
+        config.reload_sync()?;
         config.sandbox = None;
         config.save()
     }
@@ -769,7 +769,7 @@ pub fn stop_sandbox(restart: bool) -> Result<()> {
         bail_user_error!("Stopping the sandbox is not supported in this environment. Please run CTRL+C to stop the sandbox.");
     }
 
-    let cfg = Config::load()?;
+    let cfg = Config::load_sync()?;
 
     match cfg.sandbox {
         Some(sandbox_cfg) => {
@@ -812,7 +812,7 @@ pub async fn main(detach: bool, background: bool, cfg: &mut Config) -> Result<()
         run_progress_bar(cfg, Some(child))?;
 
         // Reload the config to get the pid of the sandbox
-        cfg.reload()?;
+        cfg.reload_sync()?;
         info!(
             "Sandbox pid: {}.   Use `{}` to stop the sandbox background process.",
             cfg.sandbox()?.pid,

--- a/crates/jstz_cli/src/sandbox/mod.rs
+++ b/crates/jstz_cli/src/sandbox/mod.rs
@@ -31,7 +31,7 @@ pub enum Command {
 }
 
 pub async fn start(detach: bool, background: bool) -> Result<()> {
-    let mut cfg = Config::load()?;
+    let mut cfg = Config::load_sync()?;
 
     daemon::main(detach, background, &mut cfg).await?;
     Ok(())


### PR DESCRIPTION
# Context

Part of JSTZ-248.
[JSTZ-248](https://linear.app/tezos/issue/JSTZ-248/revise-jstz-cli-so-that-it-works-with-jstzd)

In preparation for #732.

# Description

We want to make jstz_cli make http requests to fetch jstzd config so that it can be used against jstzd. The `load` method is synchronous now, but we cannot use `reqwest::blocking` because this method is normally called inside async functions elsewhere. This means that we need to change this method itself and other functions where this is called to async.

Note that `load_sync` and `reload_sync` are created as a synchronous version of the `load` and `reload` methods just for the sandbox. Since the sandbox has nothing to do with jstzd, it will never make http calls to fetch jstzd config and thus it can keep using the synchronous version. This avoids unnecessary and tricky updates to the sandbox code.

# Manually testing the PR

Manually tested jstz_cli and it still worked.

I'm not fixing the low test coverage at this moment.
