### PR TITLE
feat(jstz_cli): make jstz_cli compatible with jstzd

### DIFF
--- a/crates/jstz_cli/src/sandbox/mod.rs
+++ b/crates/jstz_cli/src/sandbox/mod.rs
@@ -1,4 +1,4 @@
-use anyhow::{Ok, Result};
+use anyhow::{bail, Ok, Result};
 use clap::Subcommand;
 
 pub mod daemon;
@@ -7,7 +7,7 @@ mod consts;
 
 pub use consts::*;
 
-use crate::config::Config;
+use crate::{config::Config, utils::using_jstzd};
 
 #[derive(Debug, Subcommand)]
 pub enum Command {
@@ -48,6 +48,11 @@ pub async fn restart(detach: bool) -> Result<()> {
 }
 
 pub async fn exec(command: Command) -> Result<()> {
+    if using_jstzd() {
+        bail!(
+            "Jstz sandbox is not available when environment variable `USE_JSTZD` is truthy."
+        );
+    }
     match command {
         Command::Start { detach, background } => start(detach, background).await,
         Command::Stop => stop(),

--- a/crates/jstz_cli/src/utils.rs
+++ b/crates/jstz_cli/src/utils.rs
@@ -1,4 +1,5 @@
 use std::{
+    env,
     fmt::{self, Display},
     fs,
     io::{self, IsTerminal},
@@ -69,4 +70,11 @@ pub fn read_file_or_input_or_piped(
             read_piped_input()
         }
     }
+}
+
+pub fn using_jstzd() -> bool {
+    matches!(
+        env::var("USE_JSTZD").as_ref().map(String::as_str),
+        Ok("true") | Ok("1")
+    )
 }


### PR DESCRIPTION
# Context

Completes JSTZ-248.
[JSTZ-248](https://linear.app/tezos/issue/JSTZ-248/revise-jstz-cli-so-that-it-works-with-jstzd)

# Description

Make `jstz_cli` compatible with `jstzd`. This is more like a temporary patch before `jstz sandbox` is taken down.

To use `jstz_cli` with a running `jstzd` instance, an environment variable `USE_JSTZD` needs to be set to `true` or `1`. `jstz_cli` will then load config from jstzd server at 127.0.0.1:55555 (default jstzd server endpoint) and find the nodes and client directory.

Note that if a user uses `jstz_cli` with `jstz sandbox` first and then switch to `jstzd`, the next usage against `jstz sandbox` will fail because the data directory path stored in the config will still point to `jstzd`. I think this is fine for now since we don't plan to keep `jstz sandbox` alive in the long run.

# Manually testing the PR

* Unit test: added some test cases for the testable logic
* Manual run:
  ```sh
  # with jstzd running
  $ USE_JSTZD=1 cargo run -- account create test
  $ USE_JSTZD=1 cargo run -- bridge deposit --from tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV --to <test_address> --amount 1 --network dev
  ```
  and it worked as expected.