### PR TITLE
feat(octez): get path from file wrapper

### DIFF
--- a/crates/octez/src/async/file.rs
+++ b/crates/octez/src/async/file.rs
@@ -63,11 +63,19 @@ impl FileWrapper {
             FileWrapper::TempFile(v) => v.as_file(),
         }
     }
+
+    pub fn path(&self) -> PathBuf {
+        match self {
+            FileWrapper::File((_, p)) => p.to_owned(),
+            FileWrapper::TempFile(v) => v.path().to_path_buf(),
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use std::{
+        fs::File,
         io::{Read, Write},
         path::PathBuf,
     };
@@ -181,5 +189,20 @@ mod tests {
         assert_eq!(file1, file2);
         assert_eq!(file3, file4);
         assert_ne!(file2, file3);
+    }
+
+    #[test]
+    fn path() {
+        let path = NamedTempFile::new().unwrap().into_temp_path();
+        let file = FileWrapper::File((File::create(&path).unwrap(), path.to_path_buf()));
+        assert_eq!(file.path(), path.to_path_buf());
+    }
+
+    #[test]
+    fn path_tempfile() {
+        let tmp_file = NamedTempFile::new().unwrap();
+        let path = tmp_file.path().to_path_buf();
+        let file = FileWrapper::TempFile(tmp_file);
+        assert_eq!(file.path(), path);
     }
 }


### PR DESCRIPTION
# Context

Part of JSTZ-250.
[JSTZ-250](https://linear.app/tezos/issue/JSTZ-250/use-tempfile-for-kernel-debug-log)

# Description

Expose the path to the file inside `FileWrapper`.

# Manually testing the PR

* Unit test: added two tests
```sh
$ cargo test async::file::tests::path

running 2 tests
test r#async::file::tests::path_tempfile ... ok
test r#async::file::tests::path ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 108 filtered out; finished in 0.00s
```