### PR TITLE
feat(jstz): use file wrapper for kernel debug log in config

### DIFF
--- a/crates/jstzd/src/task/octez_rollup.rs
+++ b/crates/jstzd/src/task/octez_rollup.rs
@@ -60,12 +60,18 @@ impl Task for OctezRollup {
             &config.rpc_endpoint,
             &config.log_file,
         );
-        let inner = ChildWrapper::new_shared(rollup.run(
-            &config.address,
-            &config.operator,
-            Some(&config.boot_sector_file),
-            config.kernel_debug_file.as_deref(),
-        )?);
+        let inner = ChildWrapper::new_shared(
+            rollup.run(
+                &config.address,
+                &config.operator,
+                Some(&config.boot_sector_file),
+                config
+                    .kernel_debug_file
+                    .as_ref()
+                    .map(|v| v.path())
+                    .as_deref(),
+            )?,
+        );
         Ok(Self {
             inner,
             config,


### PR DESCRIPTION
# Context

Part of JSTZ-250.
[JSTZ-250](https://linear.app/tezos/issue/JSTZ-250/use-tempfile-for-kernel-debug-log)

# Description

Use `FileWrapper` in jstz node config for kernel debug log.

`kernel_debug_file` does not get deserialised since we don't have any use case for that, so we don't need to implement `Deserialize` for `FileWrapper`. Overall, carrying a file like this in config is definitely not good because it complicates de/serialisation. There should be a refactor later on to get rid of all these whatever wrapper in config types and instead hold them somewhere else like in the jstzd state or so.

# Manually testing the PR

* Unit test: added one tests. All existing relevant tests should still work since fundamentally there is nothing changed.
