### PR TITLE
refactor(jstz_kernel): mirgrate to new_address

### DIFF
--- a/crates/jstz_kernel/src/lib.rs
+++ b/crates/jstz_kernel/src/lib.rs
@@ -66,6 +66,7 @@ mod test {
     };
     use jstz_proto::context::{
         account::{Account, ParsedCode},
+        new_account::NewAddress,
         ticket_table::TicketTable,
     };
     use tezos_smart_rollup::types::{Contract, PublicKeyHash};
@@ -137,13 +138,15 @@ mod test {
                     TicketTable::get_balance(host.rt(), tx, &proxy, &ticket_hash)
                         .unwrap();
                 assert_eq!(300, proxy_balance);
-                let receiver_balance = TicketTable::get_balance(
-                    host.rt(),
-                    tx,
-                    &try_parse_contract(&deposit.receiver).unwrap(),
-                    &ticket_hash,
-                )
-                .unwrap();
+                // TODO: use new address after jstz-proto is updated
+                // https://linear.app/tezos/issue/JSTZ-261/use-newaddress-for-jstz-proto
+                let owner = match try_parse_contract(&deposit.receiver).unwrap() {
+                    NewAddress::User(pkh) => pkh,
+                    NewAddress::SmartFunction(_) => panic!("Unexpected owner"),
+                };
+                let receiver_balance =
+                    TicketTable::get_balance(host.rt(), tx, &owner, &ticket_hash)
+                        .unwrap();
                 assert_eq!(0, receiver_balance);
             }
             _ => panic!("Unexpected receiver"),
@@ -167,13 +170,15 @@ mod test {
                     TicketTable::get_balance(host.rt(), &mut tx, &proxy, &ticket_hash)
                         .unwrap();
                 assert_eq!(0, proxy_balance);
-                let receiver_balance = TicketTable::get_balance(
-                    host.rt(),
-                    &mut tx,
-                    &try_parse_contract(&deposit.receiver).unwrap(),
-                    &ticket_hash,
-                )
-                .unwrap();
+                // TODO: use new address after jstz-proto is updated
+                // https://linear.app/tezos/issue/JSTZ-261/use-newaddress-for-jstz-proto
+                let owner = match try_parse_contract(&deposit.receiver).unwrap() {
+                    NewAddress::User(pkh) => pkh,
+                    NewAddress::SmartFunction(_) => panic!("Unexpected owner"),
+                };
+                let receiver_balance =
+                    TicketTable::get_balance(host.rt(), &mut tx, &owner, &ticket_hash)
+                        .unwrap();
                 assert_eq!(300, receiver_balance);
             }
             _ => panic!("Unexpected receiver"),

--- a/crates/jstz_mock/src/lib.rs
+++ b/crates/jstz_mock/src/lib.rs
@@ -1,4 +1,4 @@
-use jstz_crypto::hash::Hash;
+use jstz_crypto::{hash::Hash, smart_function_hash::SmartFunctionHash};
 use tezos_crypto_rs::hash::ContractKt1Hash;
 use tezos_smart_rollup::{
     michelson::{
@@ -40,6 +40,10 @@ pub fn account2() -> jstz_crypto::public_key_hash::PublicKeyHash {
 
 pub fn kt1_account1() -> ContractKt1Hash {
     ContractKt1Hash::try_from("KT1QgfSE4C1dX9UqrPAXjUaFQ36F9eB4nNkV").unwrap()
+}
+
+pub fn sf_account1() -> SmartFunctionHash {
+    SmartFunctionHash::from_base58("KT1QgfSE4C1dX9UqrPAXjUaFQ36F9eB4nNkV").unwrap()
 }
 
 pub fn ticket_hash1() -> TicketHash {


### PR DESCRIPTION
# Context

[task link](https://linear.app/tezos/issue/JSTZ-262/use-newaddress-for-jstz-kernel)
Prep for [254](https://linear.app/tezos/issue/JSTZ-254/migrate-to-newaddress-type)
# Description

use new address type for jstz kernel


# Manually testing the PR

add unit tests 
