### PR TITLE
feat(jstz_engine): add type definition for `JsValue` wrapper

### DIFF
--- a/crates/jstz_engine/src/context.rs
+++ b/crates/jstz_engine/src/context.rs
@@ -31,11 +31,11 @@ use mozjs::{
 use crate::{
     compartment::{self, Compartment},
     gc::{
+        ptr::AsRawPtr,
         root::{unsafe_ffi_trace_context_roots, Root, ShadowStack},
         Trace,
     },
     realm::Realm,
-    AsRawPtr,
 };
 
 /// The context of a JavaScript runtime with a state `S`.
@@ -188,7 +188,7 @@ mod test {
         rust::{JSEngine, Runtime},
     };
 
-    use crate::AsRawPtr;
+    use crate::gc::ptr::AsRawPtr;
 
     use super::Context;
 

--- a/crates/jstz_engine/src/gc/ptr.rs
+++ b/crates/jstz_engine/src/gc/ptr.rs
@@ -15,6 +15,13 @@ use mozjs::{
     jsval::{JSVal, UndefinedValue},
 };
 
+pub trait AsRawPtr {
+    type Ptr;
+
+    /// Get the raw pointer to the underlying object.
+    unsafe fn as_raw_ptr(&self) -> Self::Ptr;
+}
+
 /// A GC barrier is a mechanism used to ensure that the garbage collector maintains
 /// a valid set of reachable objects.
 ///

--- a/crates/jstz_engine/src/lib.rs
+++ b/crates/jstz_engine/src/lib.rs
@@ -3,6 +3,7 @@ mod context;
 mod gc;
 mod realm;
 mod script;
+mod value;
 
 #[cfg(test)]
 mod test {

--- a/crates/jstz_engine/src/lib.rs
+++ b/crates/jstz_engine/src/lib.rs
@@ -4,13 +4,6 @@ mod gc;
 mod realm;
 mod script;
 
-pub(crate) trait AsRawPtr {
-    type Ptr;
-
-    /// Get the raw pointer to the underlying object.
-    unsafe fn as_raw_ptr(&self) -> Self::Ptr;
-}
-
 #[cfg(test)]
 mod test {
 

--- a/crates/jstz_engine/src/realm.rs
+++ b/crates/jstz_engine/src/realm.rs
@@ -33,8 +33,10 @@ use crate::{
     compartment::{self, Compartment},
     context::{CanAccess, CanAlloc, Context, InCompartment},
     custom_trace,
-    gc::{ptr::GcPtr, Finalize, Prolong, Trace},
-    AsRawPtr,
+    gc::{
+        ptr::{AsRawPtr, GcPtr},
+        Finalize, Prolong, Trace,
+    },
 };
 
 /// A JavaScript realm with lifetime of at least `'a` allocated in compartment `C`.

--- a/crates/jstz_engine/src/script.rs
+++ b/crates/jstz_engine/src/script.rs
@@ -23,8 +23,11 @@ use crate::{
     compartment::Compartment,
     context::{CanAlloc, Context, InCompartment},
     custom_trace,
-    gc::{ptr::GcPtr, Finalize, Prolong, Trace},
-    letroot, AsRawPtr,
+    gc::{
+        ptr::{AsRawPtr, GcPtr},
+        Finalize, Prolong, Trace,
+    },
+    letroot,
 };
 
 #[derive(Debug)]

--- a/crates/jstz_engine/src/value/conversions.rs
+++ b/crates/jstz_engine/src/value/conversions.rs
@@ -1,0 +1,26 @@
+use crate::{compartment::Compartment, gc::ptr::AsRawPtr};
+
+use super::JsValue;
+
+impl<'a, C: Compartment> JsValue<'a, C> {
+    pub fn is_undefined(&self) -> bool {
+        unsafe { self.as_raw_ptr().is_undefined() }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use mozjs::rust::{JSEngine, Runtime};
+
+    use crate::{context::Context, value::JsValue};
+
+    #[test]
+    fn test_is_undefined() {
+        let engine = JSEngine::init().unwrap();
+        let rt = Runtime::new(engine.handle());
+        let rt_cx = &mut Context::from_runtime(&rt);
+        let mut cx = rt_cx.new_realm().unwrap();
+        let val = JsValue::undefined(&mut cx);
+        assert!(val.is_undefined());
+    }
+}

--- a/crates/jstz_engine/src/value/mod.rs
+++ b/crates/jstz_engine/src/value/mod.rs
@@ -1,0 +1,95 @@
+use std::{marker::PhantomData, pin::Pin, sync::Arc};
+
+use mozjs::jsval::{JSVal, UndefinedValue};
+mod conversions;
+
+use crate::{
+    compartment::Compartment,
+    context::{CanAlloc, Context, InCompartment},
+    custom_trace,
+    gc::{
+        ptr::{AsRawHandle, AsRawHandleMut, AsRawPtr, GcPtr, Handle, HandleMut},
+        Finalize, Prolong, Trace,
+    },
+};
+
+pub struct JsValue<'a, C: Compartment> {
+    inner_ptr: Pin<Arc<GcPtr<JSVal>>>,
+    marker: PhantomData<(&'a (), C)>,
+}
+
+impl<'a, C: Compartment> AsRawPtr for JsValue<'a, C> {
+    type Ptr = JSVal;
+
+    unsafe fn as_raw_ptr(&self) -> Self::Ptr {
+        self.inner_ptr.as_raw_ptr()
+    }
+}
+
+impl<'a, C: Compartment> AsRawHandle for JsValue<'a, C> {
+    unsafe fn as_raw_handle(&self) -> Handle<Self::Ptr> {
+        self.inner_ptr.as_raw_handle()
+    }
+}
+
+impl<'a, C: Compartment> AsRawHandleMut for JsValue<'a, C> {
+    unsafe fn as_raw_handle_mut(&self) -> HandleMut<Self::Ptr> {
+        self.inner_ptr.as_raw_handle_mut()
+    }
+}
+
+impl<'a, C: Compartment> JsValue<'a, C> {
+    pub fn undefined<S>(_: &'a mut Context<S>) -> Self
+    where
+        S: InCompartment<C> + CanAlloc,
+    {
+        Self {
+            inner_ptr: GcPtr::pinned(UndefinedValue()),
+            marker: PhantomData,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) unsafe fn from_raw(jsval: JSVal) -> Self {
+        Self {
+            inner_ptr: GcPtr::pinned(jsval),
+            marker: PhantomData,
+        }
+    }
+}
+
+unsafe impl<'a, 'b, C: Compartment> Prolong<'a> for JsValue<'b, C> {
+    type Aged = JsValue<'a, C>;
+}
+
+impl<'a, C: Compartment> Finalize for JsValue<'a, C> {
+    fn finalize(&self) {
+        self.inner_ptr.finalize()
+    }
+}
+
+unsafe impl<'a, C: Compartment> Trace for JsValue<'a, C> {
+    custom_trace!(this, mark, {
+        mark(&this.inner_ptr);
+    });
+}
+
+#[cfg(test)]
+mod test {
+    use mozjs::rust::{JSEngine, Runtime};
+
+    use crate::context::Context;
+
+    use super::JsValue;
+
+    #[test]
+    fn test_undefined() {
+        // Initialize the JS engine.
+        let engine = JSEngine::init().unwrap();
+        let rt = Runtime::new(engine.handle());
+        let rt_cx = &mut Context::from_runtime(&rt);
+        let mut cx = rt_cx.new_realm().unwrap();
+        let val = JsValue::undefined(&mut cx);
+        assert!(val.is_undefined())
+    }
+}


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
**Related Tasks**: [jstz-265](https://linear.app/tezos/issue/JSTZ-265/implement-jsvalue-skeleton)

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
**Dependencies**: #738 

This PR:
- Adds a `JsValue` wrapper type
- Adds some useful traits for obtaining (raw) handles (used by mozjs ffi functions as 'rooted pointers')
- Replaces uses of `JSVal` with `JsValue` 

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

PR either consists of tyoe definitions or refactors.
``` 
cargo nextest run -p jstz_engine
```
