### PR TITLE
feat(jstz_engine): implement `JsString` and `JsStr` wrappers

### DIFF
--- a/crates/jstz_engine/src/gc/ptr.rs
+++ b/crates/jstz_engine/src/gc/ptr.rs
@@ -28,6 +28,14 @@ pub trait AsRawPtr {
     unsafe fn as_raw_ptr(&self) -> Self::Ptr;
 }
 
+impl<T: AsRawPtr> AsRawPtr for &T {
+    type Ptr = T::Ptr;
+
+    unsafe fn as_raw_ptr(&self) -> Self::Ptr {
+        (*self).as_raw_ptr()
+    }
+}
+
 pub trait AsRawHandle: AsRawPtr {
     /// Retrieves a SpiderMonkey Rooted Handle to the underlying value.
     ///
@@ -38,6 +46,12 @@ pub trait AsRawHandle: AsRawPtr {
     unsafe fn as_raw_handle(&self) -> Handle<Self::Ptr>;
 }
 
+impl<T: AsRawHandle> AsRawHandle for &T {
+    unsafe fn as_raw_handle(&self) -> Handle<Self::Ptr> {
+        (*self).as_raw_handle()
+    }
+}
+
 pub trait AsRawHandleMut: AsRawHandle {
     /// Retrieves a SpiderMonkey Rooted Handle to the underlying value.
     ///
@@ -46,6 +60,12 @@ pub trait AsRawHandleMut: AsRawHandle {
     /// This is only safe to do on a rooted object (which [`GcPtr`] is not,
     /// it needs to be additionally rooted).
     unsafe fn as_raw_handle_mut(&self) -> HandleMut<Self::Ptr>;
+}
+
+impl<T: AsRawHandleMut> AsRawHandleMut for &T {
+    unsafe fn as_raw_handle_mut(&self) -> HandleMut<Self::Ptr> {
+        (*self).as_raw_handle_mut()
+    }
 }
 
 /// A GC barrier is a mechanism used to ensure that the garbage collector maintains

--- a/crates/jstz_engine/src/lib.rs
+++ b/crates/jstz_engine/src/lib.rs
@@ -10,6 +10,7 @@ mod context;
 pub mod gc;
 mod realm;
 mod script;
+mod string;
 mod value;
 
 pub fn compile_and_evaluate_script(handle: JSEngineHandle, source: &str) -> JSVal {
@@ -44,6 +45,17 @@ mod test {
     use mozjs::rooted;
     use mozjs::rust::SIMPLE_GLOBAL_CLASS;
     use mozjs::rust::{JSEngine, RealmOptions, Runtime};
+
+    #[macro_export]
+    macro_rules! setup_cx {
+        ($name: ident) => {
+            let engine = mozjs::rust::JSEngine::init().unwrap();
+            let rt = mozjs::rust::Runtime::new(engine.handle());
+            let rt_cx = &mut $crate::context::Context::from_runtime(&rt);
+            $crate::alloc_compartment!(c);
+            let mut $name = rt_cx.new_realm(c).unwrap();
+        };
+    }
 
     #[test]
     fn test_eval() {

--- a/crates/jstz_engine/src/string/mod.rs
+++ b/crates/jstz_engine/src/string/mod.rs
@@ -1,0 +1,491 @@
+#![allow(unused)]
+
+use std::{
+    env::consts,
+    ffi::{c_char, CStr, CString},
+    marker::PhantomData,
+    pin::Pin,
+    ptr,
+    sync::Arc,
+};
+
+use indoc::indoc;
+use mozjs::{
+    conversions::ToJSValConvertible,
+    jsapi::{
+        JSString, JS_CompareStrings, JS_ConcatStrings, JS_DeprecatedStringHasLatin1Chars,
+        JS_GetEmptyString, JS_GetLatin1StringCharsAndLength, JS_GetStringCharAt,
+        JS_GetStringLength, JS_GetTwoByteStringCharsAndLength, JS_NewStringCopyN,
+        JS_NewUCStringCopyN, JS_StringEqualsAscii,
+    },
+    rust::jsapi_wrapped,
+};
+
+use crate::{
+    context::{CanAccess, CanAlloc, Context, InCompartment},
+    custom_trace,
+    gc::{
+        compartment::Compartment,
+        ptr::{AsRawHandle, AsRawHandleMut, AsRawPtr, GcPtr, Handle, HandleMut},
+        Finalize, Prolong, Trace,
+    },
+    gcptr_wrapper, letroot,
+    value::JsValue,
+};
+
+mod str;
+
+use str::{JsStr, JsStrVariant};
+
+gcptr_wrapper!(
+    indoc! {"
+        [`JsString`] represents a Javascript string. Javascript strings are encoded as
+        UTF-16.
+
+        Latin-1 was initially supported by SpiderMonkey for backward compatibility. However,
+        it is now used to represent more compact strings ie. If the string only contains
+        codepoints that are <= 255, then it can be represented as latin1  which uses [u8] 
+        rather than [u16].
+
+        The encoding scheme is abstracted from the users once a valid *mut JSString is
+        constructed.
+
+         More information:
+         - [EMCAScript reference][spec]
+
+        [spec]: https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type
+"},
+    JsString,
+    *mut JSString
+);
+
+/// Returns true if `s` is latin1 encodable ie. All codepoints
+/// in the string are less than or equal to 255
+fn latin1_encodable(s: &str) -> bool {
+    s.chars().all(|c| c as u32 <= 0xFF)
+}
+
+impl<'a, C: Compartment> JsString<'a, C> {
+    /// Creates a new empty [`JsString`]
+    pub fn empty<S>(cx: &mut Context<S>) -> Self
+    where
+        S: InCompartment<C> + CanAlloc,
+    {
+        unsafe { Self::from_raw(JS_GetEmptyString(cx.as_raw_ptr())) }
+    }
+
+    /// Creates a new [`JsString`] from `std_str`
+    pub fn new<S>(std_str: &'_ str, cx: &'a mut Context<S>) -> Self
+    where
+        S: InCompartment<C> + CanAlloc,
+    {
+        if std_str.is_empty() {
+            unsafe { Self::from_raw(JS_GetEmptyString(cx.as_raw_ptr())) }
+        } else if latin1_encodable(std_str) {
+            Self::from_slice(JsStr::latin1(std_str.as_bytes()), cx)
+        } else {
+            let mut buf = Vec::with_capacity(std_str.len());
+            buf.extend(std_str.encode_utf16());
+            Self::from_slice(JsStr::utf16(buf.as_slice()), cx)
+        }
+    }
+
+    /// Creates a new [`JsString`] from `slice`.
+    pub fn from_slice<S>(slice: JsStr<'_>, cx: &mut Context<S>) -> Self
+    where
+        S: InCompartment<C> + CanAlloc,
+    {
+        unsafe {
+            /* https://github.com/servo/mozjs/blob/main/mozjs-sys/mozjs/js/public/String.h#L52
+             *
+             * String creation.
+             *
+             * NB: JS_NewUCString takes ownership of bytes on success, avoiding a copy;
+             * but on error (signified by null return), it leaves chars owned by the
+             * caller. So the caller must free bytes in the error case, if it has no use
+             * for them. In contrast, all the JS_New*StringCopy* functions do not take
+             * ownership of the character memory passed to them -- they copy it.
+             */
+            match slice.variant() {
+                JsStrVariant::Latin1(slice) => JsString::from_raw(JS_NewStringCopyN(
+                    cx.as_raw_ptr(),
+                    slice.as_ptr() as *const c_char,
+                    slice.len(),
+                )),
+                JsStrVariant::Utf16(slice) => JsString::from_raw(JS_NewUCStringCopyN(
+                    cx.as_raw_ptr(),
+                    slice.as_ptr(),
+                    slice.len(),
+                )),
+            }
+        }
+    }
+
+    /// Converts a [`JsString`] to an owned Rust string [`String`].
+    pub fn to_std_string<'cx, S>(&self, cx: &'cx mut Context<S>) -> anyhow::Result<String>
+    where
+        S: InCompartment<C> + CanAccess,
+        'cx: 'a,
+    {
+        match self.as_str(cx).variant() {
+            JsStrVariant::Latin1(slice) => Ok(String::from_utf8(slice.to_vec())?),
+            JsStrVariant::Utf16(slice) => Ok(String::from_utf16(slice)?),
+        }
+    }
+
+    /// Checks if the string consists of only Latin-1 characters.
+    pub fn is_latin1(&self) -> bool {
+        unsafe { JS_DeprecatedStringHasLatin1Chars(self.as_raw_ptr()) }
+    }
+
+    /// Checks if the string consists of UTF-16 characters.
+    pub fn is_utf16(&self) -> bool {
+        !self.is_latin1()
+    }
+
+    /// Obtains a slice of a [`JsString`] as a [`JsStr`].
+    pub fn as_str<'cx, S>(&self, cx: &'cx mut Context<S>) -> JsStr<'cx>
+    where
+        S: InCompartment<C> + CanAccess,
+        'cx: 'a,
+    {
+        let mut len = 0;
+
+        // # SAFETY
+        //
+        // The caller is required to ensure we do not GC as long as
+        // the return type is used. We do this by having `JsStr` have
+        // the lifetime `'cx`.
+        let nogc = ptr::null();
+
+        if self.is_latin1() {
+            let raw = unsafe {
+                JS_GetLatin1StringCharsAndLength(
+                    cx.as_raw_ptr(),
+                    nogc,
+                    self.as_raw_ptr(),
+                    &mut len,
+                )
+            };
+            JsStr::latin1(unsafe { std::slice::from_raw_parts(raw, len) })
+        } else {
+            let raw = unsafe {
+                JS_GetTwoByteStringCharsAndLength(
+                    cx.as_raw_ptr(),
+                    nogc,
+                    self.as_raw_ptr(),
+                    &mut len,
+                )
+            };
+
+            JsStr::utf16(unsafe { std::slice::from_raw_parts(raw, len) })
+        }
+    }
+
+    /// Get the length of the [`JsString`].
+    pub fn len(&self) -> usize {
+        unsafe { JS_GetStringLength(self.as_raw_ptr()) }
+    }
+
+    /// Return true if the [`JsString`] is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Concatenates two [`JsString`]s into a new [`JsString`].
+    pub fn concat<'cx, 'b, S>(
+        &self,
+        other: &JsString<'b, C>,
+        cx: &'cx mut Context<S>,
+    ) -> JsString<'cx, C>
+    where
+        S: InCompartment<C> + CanAlloc,
+        'cx: 'a,
+        'cx: 'b,
+    {
+        // SAFETY: Root both self and other to obtain handles
+        //        (since `JS_ConcatStrings` will allocate and maybe GC)
+        letroot!(rooted_self = self.clone(); [cx]);
+        letroot!(rooted_other = other.clone(); [cx]);
+
+        unsafe {
+            JsString::from_raw(JS_ConcatStrings(
+                cx.as_raw_ptr(),
+                rooted_self.handle(),
+                rooted_other.handle(),
+            ))
+        }
+    }
+
+    /// Returns the UTF-16 codepoint at the given character.
+    pub fn code_point_at<'cx, S>(&self, index: usize, cx: &'cx mut Context<S>) -> u16
+    where
+        S: InCompartment<C> + CanAccess,
+        'cx: 'a,
+    {
+        unsafe {
+            let mut char = 0;
+            JS_GetStringCharAt(cx.as_raw_ptr(), self.as_raw_ptr(), index, &mut char);
+            char
+        }
+    }
+
+    /// Returns `Some(true)` if the string equals `std_str`.
+    ///
+    /// # Notes
+    ///
+    /// Returns `None` if the string failed to compare
+    pub fn equals_std<'cx, 'b, S>(
+        &'a self,
+        value: &'b str,
+        cx: &'cx mut Context<S>,
+    ) -> Option<bool>
+    where
+        S: InCompartment<C> + CanAccess + CanAlloc,
+        'cx: 'a,
+    {
+        // # Safety
+        //
+        // `self` must be rooted since Self::new may allocate and GC
+        letroot!(rooted_self = self.clone(); [cx]);
+        letroot!(v = JsString::<C>::new(value, cx); [cx]);
+
+        rooted_self.equals(&v, cx)
+    }
+
+    pub fn equals<'cx, 'b, S>(
+        &self,
+        s2: &JsString<'b, C>,
+        cx: &'cx mut Context<S>,
+    ) -> Option<bool>
+    where
+        S: InCompartment<C> + CanAccess,
+        'cx: 'a,
+        'cx: 'b,
+    {
+        let mut match_success: i32 = -1;
+        let result = unsafe {
+            JS_CompareStrings(
+                cx.as_raw_ptr(),
+                self.as_raw_ptr(),
+                s2.as_raw_ptr(),
+                &mut match_success,
+            )
+        };
+
+        if result {
+            Some(match_success == 0)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use mozjs::{
+        jsval::StringValue,
+        rust::{JSEngine, Runtime},
+    };
+
+    use crate::{
+        alloc_compartment,
+        context::Context,
+        setup_cx,
+        string::{str::JsStr, JsString},
+    };
+
+    use super::*;
+
+    const VALUE: &str = "hello world🚀";
+
+    fn utf16_value() -> Vec<u16> {
+        VALUE.encode_utf16().collect()
+    }
+
+    #[test]
+    fn from_raw() {
+        setup_cx!(cx);
+
+        let js_string = unsafe { JsString::from_raw(JS_GetEmptyString(cx.as_raw_ptr())) };
+        assert!(js_string.equals_std("", &mut cx).unwrap())
+    }
+
+    #[test]
+    fn from_slice_utf16() {
+        setup_cx!(cx);
+
+        letroot!(js_string =
+            JsString::from_slice(JsStr::utf16(utf16_value().as_slice()), &mut cx); [cx]);
+        assert_eq!(Some(true), js_string.equals_std(VALUE, &mut cx));
+        assert_eq!(Some(false), js_string.equals_std("hello", &mut cx));
+    }
+
+    #[test]
+    fn from_slice_latin1() {
+        setup_cx!(cx);
+
+        letroot!(js_string =
+            JsString::from_slice(JsStr::latin1("hello world".as_bytes()), &mut cx); [cx]);
+        assert_eq!(Some(true), js_string.equals_std("hello world", &mut cx));
+        assert_eq!(Some(false), js_string.equals_std("hello", &mut cx));
+    }
+
+    #[test]
+    fn new() {
+        setup_cx!(cx);
+
+        // latin1 string
+        letroot!(js_string = JsString::new("hello world", &mut cx); [cx]);
+        assert!(js_string.is_latin1());
+        assert!(!js_string.is_utf16());
+        assert!(js_string.equals_std("hello world", &mut cx).unwrap());
+
+        // utf16 string
+        letroot!(js_string = JsString::new("hello world🚀", &mut cx); [cx]);
+        assert!(js_string.is_utf16());
+        assert!(!js_string.is_latin1());
+        assert!(js_string.equals_std("hello world🚀", &mut cx).unwrap())
+    }
+
+    #[test]
+    fn as_str() {
+        setup_cx!(cx);
+
+        // utf16 initial value -> utf16
+        let value = utf16_value();
+        let utf16 = JsStr::utf16(value.as_slice());
+        letroot!(js_string = JsString::from_slice(utf16, &mut cx); [cx]);
+        let js_str = js_string.as_str(&mut cx);
+        assert_eq!(utf16, js_str);
+
+        // latin1 initial value -> latin1
+        let latin1 = JsStr::latin1(VALUE.as_bytes());
+        letroot!(js_string = JsString::from_slice(latin1, &mut cx); [cx]);
+        let js_str = js_string.as_str(&mut cx);
+        assert_eq!(latin1, js_str);
+
+        // latin1 encoded as utf16 -> latin1
+        let latin1_as_utf16: Vec<u16> = "hello world".encode_utf16().collect();
+        let utf16 = JsStr::utf16(latin1_as_utf16.as_slice());
+        letroot!(js_string = JsString::from_slice(utf16, &mut cx); [cx]);
+        let js_str = js_string.as_str(&mut cx);
+        assert_eq!(JsStr::latin1("hello world".as_bytes()), js_str);
+    }
+
+    #[test]
+    fn code_point_at() {
+        setup_cx!(cx);
+
+        letroot!(js_string = JsString::new("a🌟", &mut cx); [cx]);
+        assert_eq!(97, js_string.code_point_at(0, &mut cx));
+        assert_eq!(55356, js_string.code_point_at(1, &mut cx));
+    }
+
+    #[test]
+    fn concat() {
+        setup_cx!(cx);
+
+        // Safety: These are perfecly safe to extend lifetime in this test as s1
+        // and s2 are rooted in `concat`
+        letroot!(hello = JsString::new("hello", &mut cx); [cx]);
+        letroot!(world = JsString::new("world", &mut cx); [cx]);
+        letroot!(rocket = JsString::new("🚀", &mut cx); [cx]);
+
+        letroot!(result = hello.concat(&world, &mut cx); [cx]);
+        assert_eq!(Some(true), result.equals_std("helloworld", &mut cx));
+
+        letroot!(result = hello.concat(&rocket, &mut cx); [cx]);
+        assert_eq!(Some(true), result.equals_std("hello🚀", &mut cx));
+
+        letroot!(result = rocket.concat(&world, &mut cx); [cx]);
+        assert_eq!(Some(true), result.equals_std("🚀world", &mut cx));
+
+        letroot!(result = rocket.concat(&rocket, &mut cx); [cx]);
+        assert_eq!(Some(true), result.equals_std("🚀🚀", &mut cx));
+        assert_eq!(Some(false), result.equals_std("🚀", &mut cx));
+    }
+
+    #[test]
+    fn equals() {
+        setup_cx!(cx);
+
+        // Check utf16 strings are equal
+        letroot!(js_string = JsString::from_slice(JsStr::utf16(utf16_value().as_slice()), &mut cx); [cx]);
+        assert_eq!(Some(true), js_string.equals_std(VALUE, &mut cx));
+        assert_eq!(Some(false), js_string.equals_std("hello", &mut cx));
+
+        // Check latin1 strings are equal
+        letroot!(
+            js_string =
+                JsString::from_slice(JsStr::latin1("hello world".as_bytes()), &mut cx); [cx]
+        );
+        assert_eq!(Some(true), js_string.equals_std("hello world", &mut cx));
+
+        // Check utf16 encoded latin1 strings are equal;
+        letroot!(js_string = JsString::from_slice(
+            JsStr::utf16(
+                "hello world"
+                    .encode_utf16()
+                    .collect::<Vec<u16>>()
+                    .as_slice(),
+            ),
+            &mut cx,
+        ); [cx]);
+        assert_eq!(Some(true), js_string.equals_std("hello world", &mut cx));
+    }
+
+    #[test]
+    fn is_empty() {
+        setup_cx!(cx);
+
+        let js_string = JsString::empty(&mut cx);
+        assert!(js_string.is_empty())
+    }
+
+    #[test]
+    fn is_latin1() {
+        setup_cx!(cx);
+
+        // Raw 8-bit char strings are encoded as Latin-1 athough this will produce
+        // gibberish when console.logged
+        let v = "hello world";
+        let v_u8 = v.as_bytes();
+        let js_string = JsString::from_slice(JsStr::latin1(v_u8), &mut cx);
+        assert!(js_string.is_latin1());
+
+        // Since Latin-1 code points are subset of utf16 code points, a utf16
+        // encoded string that uses only Latin-1 code points (0-255) will be represented
+        // as Latin-1 string
+        let v_utf16: Vec<u16> = v.encode_utf16().collect();
+        let js_string = JsString::from_slice(JsStr::utf16(v_utf16.as_slice()), &mut cx);
+        assert!(js_string.is_latin1());
+    }
+
+    #[test]
+    fn is_utf16() {
+        setup_cx!(cx);
+
+        let js_string =
+            JsString::from_slice(JsStr::utf16(utf16_value().as_slice()), &mut cx);
+        assert!(js_string.is_utf16())
+    }
+
+    #[test]
+    fn len() {
+        setup_cx!(cx);
+
+        let js_string =
+            JsString::from_slice(JsStr::utf16(utf16_value().as_slice()), &mut cx);
+        assert_eq!(utf16_value().len(), js_string.len())
+    }
+
+    #[test]
+    fn to_std_string() {
+        setup_cx!(cx);
+
+        letroot!(js_string = JsString::from_slice(JsStr::utf16(utf16_value().as_slice()), &mut cx); [cx]);
+        assert_eq!(VALUE.to_string(), js_string.to_std_string(&mut cx).unwrap())
+    }
+}

--- a/crates/jstz_engine/src/string/str.rs
+++ b/crates/jstz_engine/src/string/str.rs
@@ -1,0 +1,164 @@
+/// Inner representation of a [`JsStr`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum JsStrVariant<'a> {
+    /// Latin1 string representation.
+    Latin1(&'a [u8]),
+
+    /// U16 string representation.
+    Utf16(&'a [u16]),
+}
+
+/// This is equivalent to Rust's `&str`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct JsStr<'a> {
+    inner: JsStrVariant<'a>,
+}
+
+impl<'a> JsStr<'a> {
+    /// This represents an empty string.
+    pub const EMPTY: Self = Self::latin1("".as_bytes());
+
+    /// Creates a [`JsStr`] from codepoints that can fit in a `u8`.
+    /// The caller is responsible for ensuring the given string is
+    /// indeed a valid Latin-1 string
+    #[inline]
+    #[must_use]
+    pub const fn latin1(value: &'a [u8]) -> Self {
+        Self {
+            inner: JsStrVariant::Latin1(value),
+        }
+    }
+
+    /// Creates a [`JsStr`] from utf16 encoded string.
+    /// The caller is responsible for ensuring the given string is
+    /// indeed a valid utf16 string
+    #[inline]
+    #[must_use]
+    pub const fn utf16(value: &'a [u16]) -> Self {
+        Self {
+            inner: JsStrVariant::Utf16(value),
+        }
+    }
+
+    /// Get the length of the [`JsStr`].
+    #[inline]
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        match self.inner {
+            JsStrVariant::Latin1(v) => v.len(),
+            JsStrVariant::Utf16(v) => v.len(),
+        }
+    }
+
+    /// Return the inner [`JsStrVariant`] varient of the [`JsStr`].
+    #[inline]
+    #[must_use]
+    pub const fn variant(self) -> JsStrVariant<'a> {
+        self.inner
+    }
+
+    /// Check if the [`JsStr`] is latin1 encoded.
+    #[inline]
+    #[must_use]
+    pub const fn is_latin1(&self) -> bool {
+        matches!(self.inner, JsStrVariant::Latin1(_))
+    }
+
+    /// Returns [`u8`] slice if the [`JsStr`] is latin1 encoded, otherwise [`None`].
+    #[inline]
+    #[must_use]
+    pub const fn as_latin1(&self) -> Option<&[u8]> {
+        if let JsStrVariant::Latin1(slice) = self.inner {
+            return Some(slice);
+        }
+
+        None
+    }
+
+    /// Check if the [`JsStr`] is empty.
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Convert the [`JsStr`] into a [`Vec<u16>`].
+    #[inline]
+    #[must_use]
+    pub fn code_points(&self) -> Vec<u16> {
+        match self.variant() {
+            JsStrVariant::Latin1(v) => v.iter().copied().map(u16::from).collect(),
+            JsStrVariant::Utf16(v) => v.to_vec(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use crate::setup_cx;
+
+    use super::*;
+
+    #[test]
+    fn latin1() {
+        setup_cx!(cx);
+
+        // Any 8 bit string can be represented as Latin-1
+        let v = [0xff, 0xff, 0xff];
+        let js_str = JsStr::latin1(v.as_slice());
+        assert!(matches!(
+            js_str,
+            JsStr {
+                inner: JsStrVariant::Latin1(v)
+            }
+        ))
+    }
+
+    #[test]
+    fn utf16() {
+        setup_cx!(cx);
+
+        // Any 16 bit string can be represented as utf16
+        let v = [0xffab, 0xffcd, 0xffff];
+        let js_str = JsStr::utf16(v.as_slice());
+        assert!(matches!(
+            js_str,
+            JsStr {
+                inner: JsStrVariant::Utf16(v)
+            }
+        ));
+    }
+
+    #[test]
+    fn len() {}
+
+    #[test]
+    fn is_latin() {
+        assert!(JsStr::latin1("jstz".as_bytes()).is_latin1());
+        assert!(!JsStr::utf16(&[]).is_latin1())
+    }
+
+    fn as_latin1() {
+        assert!(JsStr::latin1("jstz".as_bytes()).as_latin1().is_some());
+    }
+
+    fn is_empty() {
+        assert!(JsStr::latin1(&[]).is_empty());
+        assert!(JsStr::utf16(&[]).is_empty());
+    }
+
+    fn code_points() {
+        let code_points: Vec<u16> = "jstz".chars().map(|c| c as u16).collect();
+        let latin1_cp = JsStr::latin1("jstz".as_bytes()).code_points();
+        assert_eq!(code_points, latin1_cp);
+        let utf16_cp =
+            JsStr::utf16("jstz".encode_utf16().collect::<Vec<u16>>().as_slice())
+                .code_points();
+        assert_eq!(code_points, utf16_cp);
+
+        let cp: Vec<u16> = "⭐️🤖🚀".encode_utf16().collect();
+        let utf16_cp = JsStr::utf16(utf16_cp.as_slice()).code_points();
+        assert_eq!(cp, utf16_cp)
+    }
+}


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
**Related Tasks**: [jstz-214](https://linear.app/tezos/issue/JSTZ-214/implement-jsstring-and-jsstr)

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
**Dependencies**: #739 

Adds type definitions for `JsString` and `JsStr`. 
Additionally wraps most (if not all) functions that operate on strings.

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->
