### PR TITLE
refactor(jstz_proto): mirgrate to new_address

### DIFF
--- a/crates/jstz_cli/src/bridge/withdraw.rs
+++ b/crates/jstz_cli/src/bridge/withdraw.rs
@@ -6,8 +6,6 @@ use crate::{
     term::styles,
     utils::AddressOrAlias,
 };
-use anyhow::bail;
-use jstz_proto::context::{account::Address, new_account::NewAddress};
 use log::debug;
 
 pub async fn exec(
@@ -25,24 +23,14 @@ pub async fn exec(
         );
     }
 
-    let to_pkh = to.resolve_l1(&cfg, &network)?;
-    debug!("resolved `to` -> {}", &to_pkh.to_base58());
-
-    // TODO: use NewAddress after jstz-proto is updated
-    // https://linear.app/tezos/issue/JSTZ-261/use-newaddress-for-jstz-proto
-    let to_pkh: Result<Address> = match to_pkh {
-        NewAddress::User(address) => Ok(address),
-        _ => bail!("address type mismatch - expected user address"),
-    };
+    let receiver = to.resolve_l1(&cfg, &network)?;
+    debug!("resolved `to` -> {}", &receiver.to_base58());
 
     let amount = convert_tez_to_mutez(amount)?;
     let url = "tezos://jstz/withdraw".to_string();
     let http_method = "POST".to_string();
     let gas_limit = 10; // TODO: set proper gas limit
-    let withdraw = jstz_proto::executor::withdraw::Withdrawal {
-        amount,
-        receiver: to_pkh?,
-    };
+    let withdraw = jstz_proto::executor::withdraw::Withdrawal { amount, receiver };
     let json_data = serde_json::to_string(&withdraw)?;
     run::exec(url, http_method, gas_limit, Some(json_data), network, false).await
 }

--- a/crates/jstz_cli/src/config.rs
+++ b/crates/jstz_cli/src/config.rs
@@ -57,6 +57,8 @@ impl Account {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct User {
+    // TODO: change to PublicKeyHash
+    // https://linear.app/tezos/issue/JSTZ-268/cli-use-publickeyhash-and-smartfunctionhash-in-user
     pub address: NewAddress,
     pub secret_key: SecretKey,
     pub public_key: PublicKey,
@@ -64,6 +66,8 @@ pub struct User {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SmartFunction {
+    // TODO: change to SmartFunctionHash
+    // https://linear.app/tezos/issue/JSTZ-268/cli-use-publickeyhash-and-smartfunctionhash-in-user
     pub address: NewAddress,
 }
 

--- a/crates/jstz_cli/src/deploy.rs
+++ b/crates/jstz_cli/src/deploy.rs
@@ -1,9 +1,7 @@
 use boa_engine::JsError;
+use jstz_crypto::public_key_hash::PublicKeyHash;
 use jstz_proto::{
-    context::{
-        account::{Address, ParsedCode},
-        new_account::NewAddress,
-    },
+    context::{account::ParsedCode, new_account::NewAddress},
     operation::{Content, DeployFunction, Operation, SignedOperation},
     receipt::{ReceiptContent, ReceiptResult},
 };
@@ -72,9 +70,9 @@ pub async fn exec(
     let code: ParsedCode = code
         .try_into()
         .map_err(|err: JsError| user_error!("{err}"))?;
-    // TODO: use NewAddress after jstz-proto is updated
-    // https://linear.app/tezos/issue/JSTZ-261/use-newaddress-for-jstz-proto
-    let source: Result<Address> = match user.address.clone() {
+    // TODO: remove
+    //  https://linear.app/tezos/issue/JSTZ-268/cli-use-publickeyhash-and-smartfunctionhash-in-user
+    let source: Result<PublicKeyHash> = match user.address.clone() {
         NewAddress::User(address) => Ok(address),
         _ => bail!("address type mismatch - expected user address"),
     };
@@ -133,14 +131,7 @@ pub async fn exec(
     );
 
     if let Some(name) = name {
-        cfg.accounts.insert(
-            name,
-            SmartFunction {
-                // TODO: use sf address after jstz-proto is updated
-                // https://linear.app/tezos/issue/JSTZ-261/use-newaddress-for-jstz-proto
-                address: NewAddress::User(address),
-            },
-        );
+        cfg.accounts.insert(name, SmartFunction { address });
     }
 
     cfg.save()?;

--- a/crates/jstz_cli/src/repl/mod.rs
+++ b/crates/jstz_cli/src/repl/mod.rs
@@ -1,6 +1,5 @@
 use std::{borrow::Cow, fmt::Write};
 
-use anyhow::bail;
 use boa_engine::{js_string, Context, JsResult, JsValue, Source};
 use jstz_api::{js_log::set_js_logger, stream::StreamApi};
 use jstz_core::{
@@ -8,10 +7,7 @@ use jstz_core::{
     kv::Transaction,
     runtime::{self, Runtime},
 };
-use jstz_proto::{
-    context::new_account::NewAddress,
-    executor::smart_function::{register_jstz_apis, register_web_apis},
-};
+use jstz_proto::executor::smart_function::{register_jstz_apis, register_web_apis};
 use log::{debug, error, info, warn};
 use rustyline::{
     completion::Completer, error::ReadlineError, highlight::Highlighter, hint::Hinter,
@@ -118,12 +114,6 @@ pub async fn exec(account: Option<AddressOrAlias>) -> Result<()> {
             .expect("`DEFAULT_SMART_FUNCTION_ADDRESS` is an invalid address."),
     };
     debug!("resolved `account` -> {:?}", address);
-    // TODO: use NewAddress after jstz-proto is updated
-    // https://linear.app/tezos/issue/JSTZ-261/use-newaddress-for-jstz-proto
-    let address = match address {
-        NewAddress::User(address) => address,
-        _ => bail!("address type mismatch - expected user address"),
-    };
 
     // 1. Setup editor
     let mut rl = Editor::<JsHighlighter, _>::new()?;

--- a/crates/jstz_cli/src/run.rs
+++ b/crates/jstz_cli/src/run.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use anyhow::bail;
 use http::{HeaderMap, Method, Uri};
-use jstz_proto::context::account::Address;
+use jstz_crypto::public_key_hash::PublicKeyHash;
 use jstz_proto::context::new_account::NewAddress;
 use jstz_proto::executor::JSTZ_HOST;
 use jstz_proto::{
@@ -117,9 +117,9 @@ pub async fn exec(
 
     debug!("Body: {:?}", body);
 
-    // TODO: use NewAddress after jstz-proto is updated
-    // https://linear.app/tezos/issue/JSTZ-261/use-newaddress-for-jstz-proto
-    let user_address: Result<Address> = match user.address.clone() {
+    // TODO: remove
+    //  https://linear.app/tezos/issue/JSTZ-268/cli-use-publickeyhash-and-smartfunctionhash-in-user
+    let user_address: Result<PublicKeyHash> = match user.address.clone() {
         NewAddress::User(address) => Ok(address),
         _ => bail!("address type mismatch - expected user address"),
     };

--- a/crates/jstz_mock/src/message/fa_deposit.rs
+++ b/crates/jstz_mock/src/message/fa_deposit.rs
@@ -44,6 +44,8 @@ impl Default for MockFaDeposit {
             ticket_amount: 300,
             ticket_content: (12345, Some(b"123967145810851823941234".to_vec())),
             smart_rollup,
+            // use sf hash
+            // https://linear.app/tezos/issue/JSTZ-260/add-validation-check-for-address-type
             proxy_contract: Some(
                 jstz_crypto::public_key_hash::PublicKeyHash::from_base58(MOCK_PROXY)
                     .unwrap(),

--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -456,6 +456,17 @@
   },
   "components": {
     "schemas": {
+      "Address": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/PublicKeyHash"
+          },
+          {
+            "$ref": "#/components/schemas/SmartFunctionHash"
+          }
+        ],
+        "description": "Tezos Address"
+      },
       "Blake2b": {
         "type": "array",
         "items": {
@@ -539,7 +550,7 @@
         ],
         "properties": {
           "address": {
-            "$ref": "#/components/schemas/PublicKeyHash"
+            "$ref": "#/components/schemas/Address"
           }
         }
       },
@@ -551,7 +562,7 @@
         ],
         "properties": {
           "account": {
-            "$ref": "#/components/schemas/PublicKeyHash"
+            "$ref": "#/components/schemas/Address"
           },
           "updated_balance": {
             "type": "integer",
@@ -568,7 +579,7 @@
         ],
         "properties": {
           "receiver": {
-            "$ref": "#/components/schemas/PublicKeyHash"
+            "$ref": "#/components/schemas/Address"
           },
           "run_function": {
             "oneOf": [
@@ -596,7 +607,7 @@
             "$ref": "#/components/schemas/String"
           },
           "source": {
-            "$ref": "#/components/schemas/PublicKeyHash"
+            "$ref": "#/components/schemas/Address"
           }
         }
       },
@@ -624,7 +635,7 @@
         ],
         "properties": {
           "address": {
-            "$ref": "#/components/schemas/PublicKeyHash"
+            "$ref": "#/components/schemas/Address"
           },
           "level": {
             "$ref": "#/components/schemas/LogLevel"
@@ -1001,6 +1012,23 @@
             "$ref": "#/components/schemas/Signature"
           }
         }
+      },
+      "SmartFunctionHash": {
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "KT1",
+            "required": [
+              "Kt1"
+            ],
+            "properties": {
+              "Kt1": {
+                "type": "string"
+              }
+            },
+            "example": "KT1RycYvM4EVs6BAXWEsGXaAaRqiMP53KT4w"
+          }
+        ]
       },
       "String": {
         "type": "string"

--- a/crates/jstz_node/src/services/logs/mod.rs
+++ b/crates/jstz_node/src/services/logs/mod.rs
@@ -158,10 +158,8 @@ impl LogsService {
                                 #[cfg(not(feature = "persistent-logging"))]
                                 #[allow(irrefutable_let_patterns)]
                                 if let Line::Js(log) = line {
-                                    // TODO: use smart function address once jstz-proto is updated
-                                    // https://linear.app/tezos/issue/JSTZ-261/use-newaddress-for-jstz-proto
                                     broadcaster
-                                        .broadcast(&NewAddress::User(log.address.clone()), &line_str[LOG_PREFIX.len()..])
+                                        .broadcast(&log.address.clone(), &line_str[LOG_PREFIX.len()..])
                                        .await;
                                 }
                             }

--- a/crates/jstz_proto/src/api/ledger.rs
+++ b/crates/jstz_proto/src/api/ledger.rs
@@ -12,10 +12,12 @@ use jstz_core::{
     accessor, host::HostRuntime, kv::Transaction, native::Accessor, runtime,
     value::IntoJs,
 };
-use jstz_crypto::hash::Hash;
 
 use crate::{
-    context::account::{Account, Address, Amount},
+    context::{
+        account::{Account, Amount},
+        new_account::NewAddress,
+    },
     error::Result,
 };
 
@@ -25,7 +27,7 @@ use crate::{
 
 #[derive(JsData)]
 struct Ledger {
-    address: Address,
+    address: NewAddress,
 }
 
 impl Finalize for Ledger {}
@@ -42,7 +44,7 @@ impl Ledger {
     fn balance(
         rt: &impl HostRuntime,
         tx: &mut Transaction,
-        addr: &Address,
+        addr: &NewAddress,
     ) -> Result<u64> {
         let balance = Account::balance(rt, tx, addr)?;
 
@@ -53,7 +55,7 @@ impl Ledger {
         &self,
         rt: &impl HostRuntime,
         tx: &mut Transaction,
-        dst: &Address,
+        dst: &NewAddress,
         amount: Amount,
     ) -> Result<()> {
         Account::transfer(rt, tx, &self.address, dst, amount)?;
@@ -63,10 +65,10 @@ impl Ledger {
 }
 
 pub struct LedgerApi {
-    pub address: Address,
+    pub address: NewAddress,
 }
 
-pub(crate) fn js_value_to_pkh(value: &JsValue) -> Result<Address> {
+pub(crate) fn js_value_to_pkh(value: &JsValue) -> Result<NewAddress> {
     let pkh_string = value
         .as_string()
         .ok_or_else(|| {
@@ -75,7 +77,7 @@ pub(crate) fn js_value_to_pkh(value: &JsValue) -> Result<Address> {
         })
         .map(JsString::to_std_string_escaped)?;
 
-    Ok(Address::from_base58(&pkh_string)?)
+    NewAddress::from_base58(&pkh_string)
 }
 
 impl Ledger {

--- a/crates/jstz_proto/src/executor/deposit.rs
+++ b/crates/jstz_proto/src/executor/deposit.rs
@@ -35,6 +35,7 @@ mod test {
     use tezos_smart_rollup_mock::MockHost;
 
     use crate::{
+        context::new_account::NewAddress,
         operation::external::Deposit,
         receipt::{DepositReceipt, ReceiptContent, ReceiptResult},
     };
@@ -49,7 +50,7 @@ mod test {
         let deposit = Deposit {
             inbox_id: 1,
             amount: 20,
-            receiver: receiver.clone(),
+            receiver: NewAddress::User(receiver.clone()),
         };
         tx.begin();
         let receipt = execute(&mut host, &mut tx, deposit);
@@ -58,7 +59,7 @@ mod test {
             ReceiptResult::Success(ReceiptContent::Deposit(DepositReceipt {
                 account,
                 updated_balance,
-            })) if account == receiver && updated_balance == 20
+            })) if account == NewAddress::User(receiver) && updated_balance == 20
         ));
         let raw_json_payload = r#"{"hash":[39,12,7,148,87,7,176,168,111,219,214,147,14,123,179,202,232,151,138,59,207,182,101,158,128,98,239,57,236,88,195,42],"result":{"_type":"Success","inner":{"_type":"Deposit","account":"tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx","updated_balance":20}}}"#;
         assert_eq!(raw_json_payload, serde_json::to_string(&receipt).unwrap());

--- a/crates/jstz_proto/src/executor/mod.rs
+++ b/crates/jstz_proto/src/executor/mod.rs
@@ -2,6 +2,7 @@ use jstz_core::{host::HostRuntime, kv::Transaction};
 use tezos_crypto_rs::hash::ContractKt1Hash;
 
 use crate::{
+    context::new_account::NewAddress,
     operation::{self, ExternalOperation, Operation, SignedOperation},
     receipt::{self, Receipt},
     Result,
@@ -31,7 +32,12 @@ fn execute_operation_inner(
             content: operation::Content::DeployFunction(deployment),
             ..
         } => {
-            let result = smart_function::deploy::execute(hrt, tx, &source, deployment)?;
+            let result = smart_function::deploy::execute(
+                hrt,
+                tx,
+                &NewAddress::User(source.clone()),
+                deployment,
+            )?;
 
             Ok(receipt::ReceiptContent::DeployFunction(result))
         }
@@ -42,10 +48,20 @@ fn execute_operation_inner(
             ..
         } => {
             let result = match run.uri.host() {
-                Some(JSTZ_HOST) => {
-                    smart_function::jstz_run::execute(hrt, tx, ticketer, &source, run)?
-                }
-                _ => smart_function::run::execute(hrt, tx, &source, run, operation_hash)?,
+                Some(JSTZ_HOST) => smart_function::jstz_run::execute(
+                    hrt,
+                    tx,
+                    ticketer,
+                    &NewAddress::User(source.clone()),
+                    run,
+                )?,
+                _ => smart_function::run::execute(
+                    hrt,
+                    tx,
+                    &NewAddress::User(source.clone()),
+                    run,
+                    operation_hash,
+                )?,
             };
             Ok(receipt::ReceiptContent::RunFunction(result))
         }

--- a/crates/jstz_proto/src/js_logger.rs
+++ b/crates/jstz_proto/src/js_logger.rs
@@ -6,7 +6,8 @@ use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-use crate::{api::TraceData, context::account::Address};
+use crate::api::TraceData;
+use crate::context::new_account::NewAddress;
 
 pub use jstz_api::js_log::{JsLog, LogData, LogLevel};
 
@@ -14,7 +15,7 @@ pub const LOG_PREFIX: &str = "[JSTZ:SMART_FUNCTION:LOG] ";
 
 #[derive(Serialize, Deserialize, ToSchema)]
 pub struct LogRecord {
-    pub address: Address,
+    pub address: NewAddress,
     pub request_id: String,
     pub level: LogLevel,
     pub text: String,

--- a/crates/jstz_proto/src/receipt.rs
+++ b/crates/jstz_proto/src/receipt.rs
@@ -1,5 +1,5 @@
 use crate::{
-    context::account::Address,
+    context::new_account::NewAddress,
     executor::{fa_deposit::FaDepositReceipt, fa_withdraw::FaWithdrawReceipt},
     operation::OperationHash,
     Result,
@@ -49,7 +49,7 @@ impl Receipt {
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct DeployFunctionReceipt {
-    pub address: Address,
+    pub address: NewAddress,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -68,7 +68,7 @@ pub struct RunFunctionReceipt {
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct DepositReceipt {
-    pub account: Address,
+    pub account: NewAddress,
     pub updated_balance: u64,
 }
 

--- a/crates/jstz_proto/src/request_logger.rs
+++ b/crates/jstz_proto/src/request_logger.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Display};
 use jstz_core::{host::HostRuntime, runtime};
 use serde::{Deserialize, Serialize};
 
-use crate::context::account::Address;
+use crate::context::new_account::NewAddress;
 
 pub const REQUEST_START_PREFIX: &str = "[JSTZ:SMART_FUNCTION:REQUEST_START] ";
 pub const REQUEST_END_PREFIX: &str = "[JSTZ:SMART_FUNCTION:REQUEST_END] ";
@@ -12,11 +12,11 @@ pub const REQUEST_END_PREFIX: &str = "[JSTZ:SMART_FUNCTION:REQUEST_END] ";
 #[serde(tag = "type")]
 pub enum RequestEvent {
     Start {
-        address: Address,
+        address: NewAddress,
         request_id: String,
     },
     End {
-        address: Address,
+        address: NewAddress,
         request_id: String,
         // TODO: Add more fields
     },
@@ -36,7 +36,7 @@ impl RequestEvent {
     }
 }
 
-pub fn log_request_start(address: Address, request_id: String) {
+pub fn log_request_start(address: NewAddress, request_id: String) {
     let request_log = RequestEvent::Start {
         address,
         request_id,
@@ -48,7 +48,7 @@ pub fn log_request_start(address: Address, request_id: String) {
     });
 }
 
-pub fn log_request_end(address: Address, request_id: String) {
+pub fn log_request_end(address: NewAddress, request_id: String) {
     let request_log = RequestEvent::End {
         address,
         request_id,


### PR DESCRIPTION
# Context

[task link](https://linear.app/tezos/issue/JSTZ-261/use-newaddress-for-jstz-proto)
In preparation for [171](https://linear.app/tezos/issue/JSTZ-171/change-smart-function-addresses-to-kt1)

# Description
final step of migrating to the new address type in jstz_proto
removed the old address type completely and use the new addres type
NOTE: this PR doesn't change the behaviour of jstz proto and KT address will be supported in the upcoming PRs 

# Manually testing the PR
1. add unit tests 

2. manually tested with 
* deploy, running smart function
* deposit/withdrawal
```
cargo run --bin jstz -- account create test

cargo run --bin jstz -- bridge deposit --from bootstrap1 --to test --amount 2 --network dev

cargo run --bin jstz -- account balance -a test --network dev

cargo run --bin jstz -- bridge withdraw --to tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx --amount 1 --network dev
```
