### PR TITLE
refactor(jstz_engine): replace existing wrapper definitions with common `gcptr_wrapper` macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2650,6 +2650,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+
+[[package]]
 name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2864,6 +2870,7 @@ name = "jstz_engine"
 version = "0.1.0-alpha.0"
 dependencies = [
  "anyhow",
+ "indoc",
  "mozjs",
  "tezos-smart-rollup",
  "trybuild",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ http = "1.0.0"
 http-serde = "2.0.0"
 in-container = "^1"
 indicatif = "0.17.0"
+indoc = "2"
 log = "0.4.20"
 mozjs = "0.14.1"
 nix = { version = "^0.27.1", features = ["process", "signal"] }

--- a/crates/jstz_engine/Cargo.toml
+++ b/crates/jstz_engine/Cargo.toml
@@ -13,6 +13,7 @@ description = "A memory-safe JavaScript engine API in Rust"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 anyhow.workspace = true
+indoc.workspace = true
 mozjs.workspace = true
 tezos-smart-rollup.workspace = true
 

--- a/crates/jstz_engine/src/context.rs
+++ b/crates/jstz_engine/src/context.rs
@@ -29,8 +29,8 @@ use mozjs::{
 };
 
 use crate::{
-    compartment::Compartment,
     gc::{
+        compartment::Compartment,
         ptr::AsRawPtr,
         root::{unsafe_ffi_trace_context_roots, Root, ShadowStack},
         Trace,

--- a/crates/jstz_engine/src/gc/compartment.rs
+++ b/crates/jstz_engine/src/gc/compartment.rs
@@ -93,11 +93,11 @@ impl<'a> Ref<'a> {
 #[macro_export]
 macro_rules! alloc_compartment {
     ($name:ident) => {
-        let compartment_id = unsafe { $crate::compartment::Id::new() };
+        let compartment_id = unsafe { $crate::gc::compartment::Id::new() };
         #[allow(unused)]
         let compartment_region =
-            unsafe { $crate::compartment::Region::new(&compartment_id) };
-        let $name = unsafe { $crate::compartment::Ref::new(compartment_id) };
+            unsafe { $crate::gc::compartment::Region::new(&compartment_id) };
+        let $name = unsafe { $crate::gc::compartment::Ref::new(compartment_id) };
     };
 }
 

--- a/crates/jstz_engine/src/gc/mod.rs
+++ b/crates/jstz_engine/src/gc/mod.rs
@@ -27,3 +27,82 @@ pub mod trace;
 pub use compartment::Compartment;
 pub use root::Prolong;
 pub use trace::{Finalize, Trace, Tracer};
+
+#[macro_export]
+macro_rules! gcptr_wrapper {
+    ($doc:expr, $name: ident, $ptr_type: ty) => {
+        #[doc = $doc]
+        pub struct $name<'a, C: $crate::gc::Compartment> {
+            inner_ptr: std::pin::Pin<std::sync::Arc<$crate::gc::ptr::GcPtr<$ptr_type>>>,
+            marker: std::marker::PhantomData<(&'a (), C)>,
+        }
+
+        impl<'a, C: $crate::gc::Compartment> Clone for $name<'a, C> {
+            fn clone(&self) -> Self {
+                Self {
+                    inner_ptr: self.inner_ptr.clone(),
+                    marker: self.marker,
+                }
+            }
+        }
+
+        impl<'a, C: $crate::gc::Compartment> $crate::gc::ptr::AsRawPtr for $name<'a, C> {
+            type Ptr = $ptr_type;
+
+            unsafe fn as_raw_ptr(&self) -> Self::Ptr {
+                self.inner_ptr.as_raw_ptr()
+            }
+        }
+
+        impl<'a, C: $crate::gc::Compartment> $crate::gc::ptr::AsRawHandle
+            for $name<'a, C>
+        {
+            unsafe fn as_raw_handle(&self) -> $crate::gc::ptr::Handle<Self::Ptr> {
+                self.inner_ptr.as_raw_handle()
+            }
+        }
+
+        impl<'a, C: $crate::gc::Compartment> $crate::gc::ptr::AsRawHandleMut
+            for $name<'a, C>
+        {
+            unsafe fn as_raw_handle_mut(&self) -> $crate::gc::ptr::HandleMut<Self::Ptr> {
+                self.inner_ptr.as_raw_handle_mut()
+            }
+        }
+
+        impl<'a, C: $crate::gc::Compartment> $name<'a, C> {
+            /// Converts a raw pointer to the wrapped type.
+            ///
+            /// # Safety
+            ///
+            /// If the pointer does not correctly point to a valid GC object (of the expected type)
+            /// then `TypeError`s, segmentation faults, or Undefined Behaviour in general could
+            /// occur.
+            #[allow(dead_code)]
+            pub(crate) unsafe fn from_raw(ptr: $ptr_type) -> Self {
+                Self {
+                    inner_ptr: $crate::gc::ptr::GcPtr::pinned(ptr),
+                    marker: std::marker::PhantomData,
+                }
+            }
+        }
+
+        unsafe impl<'a, 'b, C: $crate::gc::Compartment> $crate::gc::Prolong<'a>
+            for $name<'b, C>
+        {
+            type Aged = $name<'a, C>;
+        }
+
+        impl<'a, C: $crate::gc::Compartment> $crate::gc::Finalize for $name<'a, C> {
+            fn finalize(&self) {
+                self.inner_ptr.finalize()
+            }
+        }
+
+        unsafe impl<'a, C: $crate::gc::Compartment> $crate::gc::Trace for $name<'a, C> {
+            $crate::custom_trace!(this, mark, {
+                mark(&this.inner_ptr);
+            });
+        }
+    };
+}

--- a/crates/jstz_engine/src/gc/mod.rs
+++ b/crates/jstz_engine/src/gc/mod.rs
@@ -19,9 +19,11 @@
 //!
 //! For further details, see the [GC Implementation Guide](https://udn.realityripple.com/docs/Mozilla/Projects/SpiderMonkey/Internals/Garbage_collection).
 
+pub mod compartment;
 pub mod ptr;
 pub mod root;
 pub mod trace;
 
+pub use compartment::Compartment;
 pub use root::Prolong;
 pub use trace::{Finalize, Trace, Tracer};

--- a/crates/jstz_engine/src/gc/ptr.rs
+++ b/crates/jstz_engine/src/gc/ptr.rs
@@ -69,9 +69,21 @@ pub trait AsRawHandleMut: AsRawHandle {
 ///
 pub unsafe trait WriteBarrieredPtr: Copy {
     /// Creates a uninitialized value
+    ///
+    /// # Safety
+    ///
+    /// - The returned value is uninitialized and must not be used before it is properly initialized.
+    /// - Using an uninitialized value in any operation (such as dereferencing) is undefined behavior.
     unsafe fn uninit() -> Self;
 
     /// Perform a write barrier on the given GC value
+    ///
+    /// # Safety
+    ///
+    /// - `v` must be a valid, properly allocated pointer to a GC-tracked value.
+    /// - `prev` and `next` must represent valid states for the GC-tracked value.
+    /// - Calling this function incorrectly could break GC invariants, leading to memory corruption,
+    ///   leaks, or use-after-free errors.
     unsafe fn write_barrier(v: *mut Self, prev: Self, next: Self);
 }
 

--- a/crates/jstz_engine/src/gc/root.rs
+++ b/crates/jstz_engine/src/gc/root.rs
@@ -328,6 +328,12 @@ macro_rules! letroot {
 pub unsafe trait Prolong<'a> {
     type Aged;
 
+    /// Extends (or limits) the lifetime of `self`
+    ///
+    /// # Safety
+    ///
+    /// - The caller must ensure that the new lifetime `'a` is valid for the returned value.
+    /// - Misuse can lead to memory corruption or undefined behaviour.
     unsafe fn extend_lifetime(self) -> Self::Aged
     where
         Self: Sized,

--- a/crates/jstz_engine/src/gc/trace.rs
+++ b/crates/jstz_engine/src/gc/trace.rs
@@ -38,6 +38,12 @@ use super::ptr::GcPtr;
 ///   can result in Undefined Behaviour.
 pub unsafe trait Trace: Finalize {
     /// Marks all contained traceable objects.
+    ///
+    /// # Safety
+    ///
+    /// - The `trc` pointer must be valid.
+    /// - Implementations must ensure that all reachable GC-managed objects are properly marked.
+    /// - Failure to trace all reachable objects may lead to premature deallocation and use-after-free errors.
     unsafe fn trace(&self, trc: *mut Tracer);
 
     /// Runs [`Finalize::finalize`] on the object and its children.

--- a/crates/jstz_engine/src/lib.rs
+++ b/crates/jstz_engine/src/lib.rs
@@ -5,9 +5,9 @@ use gc::ptr::AsRawPtr;
 use mozjs::jsval::JSVal;
 use mozjs::rust::{JSEngineHandle, Runtime};
 use script::Script;
-pub mod compartment;
+
 mod context;
-mod gc;
+pub mod gc;
 mod realm;
 mod script;
 mod value;

--- a/crates/jstz_engine/src/realm.rs
+++ b/crates/jstz_engine/src/realm.rs
@@ -30,10 +30,10 @@ use mozjs::{
 };
 
 use crate::{
-    compartment::Compartment,
     context::{CanAccess, CanAlloc, Context, InCompartment},
     custom_trace,
     gc::{
+        compartment::Compartment,
         ptr::{AsRawPtr, GcPtr},
         Finalize, Prolong, Trace,
     },

--- a/crates/jstz_engine/src/script.rs
+++ b/crates/jstz_engine/src/script.rs
@@ -18,12 +18,11 @@ use mozjs::{
 };
 
 use crate::{
-    compartment::Compartment,
     context::{CanAlloc, Context, InCompartment},
     custom_trace,
     gc::{
         ptr::{AsRawPtr, GcPtr},
-        Finalize, Prolong, Trace,
+        Compartment, Finalize, Prolong, Trace,
     },
     letroot,
     value::JsValue,

--- a/crates/jstz_engine/src/value/conversions.rs
+++ b/crates/jstz_engine/src/value/conversions.rs
@@ -1,4 +1,4 @@
-use crate::{compartment::Compartment, gc::ptr::AsRawPtr};
+use crate::gc::{compartment::Compartment, ptr::AsRawPtr};
 
 use super::JsValue;
 

--- a/crates/jstz_engine/src/value/mod.rs
+++ b/crates/jstz_engine/src/value/mod.rs
@@ -4,12 +4,11 @@ use mozjs::jsval::{JSVal, UndefinedValue};
 mod conversions;
 
 use crate::{
-    compartment::Compartment,
     context::{CanAlloc, Context, InCompartment},
     custom_trace,
     gc::{
         ptr::{AsRawHandle, AsRawHandleMut, AsRawPtr, GcPtr, Handle, HandleMut},
-        Finalize, Prolong, Trace,
+        Compartment, Finalize, Prolong, Trace,
     },
 };
 


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

This PR defines a macro `gcptr_wrapper` which defines a wrapper struct over a GC pointer with some phantom lifetime and compartment parameters.

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

- Move `compartment.rs` to `gc/` -- compartments are a gc concept
- Implement `gcptr_wrapper` macro and refactor existing code to make use of it. 

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

Refactoring -- existing tests should cover changes


