### PR TITLE
fix(operation): remove serde tag from operation variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2819,6 +2819,7 @@ name = "jstz_crypto"
 version = "0.1.0-alpha.0"
 dependencies = [
  "anyhow",
+ "bincode",
  "boa_gc",
  "derive_more",
  "hex",
@@ -2912,6 +2913,7 @@ dependencies = [
 name = "jstz_proto"
 version = "0.1.0-alpha.0"
 dependencies = [
+ "bincode",
  "boa_engine",
  "boa_gc",
  "derive_more",

--- a/crates/jstz_crypto/Cargo.toml
+++ b/crates/jstz_crypto/Cargo.toml
@@ -22,3 +22,4 @@ utoipa.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
+bincode.workspace = true

--- a/crates/jstz_crypto/src/public_key.rs
+++ b/crates/jstz_crypto/src/public_key.rs
@@ -132,4 +132,16 @@ mod test {
             "tz3QxNCB8HgxJyp5V9ZmCVGcTm6BzYc14k9C"
         );
     }
+
+    #[test]
+    #[ignore = "Fails because deserialization cannot handle untagged crypto enums"]
+    // FIXME: https://linear.app/tezos/issue/JSTZ-272/fix-binary-round-trip-for-tezos-cryptos
+    fn bin_round_trip() {
+        let pk = PublicKey::from_base58(TZ1).unwrap();
+        let bin = bincode::serialize(&pk).unwrap();
+        // Error message:
+        //      Result::unwrap()` on an `Err` value: DeserializeAnyNotSupported
+        let decoded = bincode::deserialize::<PublicKey>(bin.as_ref()).unwrap();
+        assert_eq!(pk, decoded);
+    }
 }

--- a/crates/jstz_crypto/src/public_key_hash.rs
+++ b/crates/jstz_crypto/src/public_key_hash.rs
@@ -202,4 +202,16 @@ mod test {
             "tz1cAnZVxXjLaDecxmBBgpeepZzZLFfisq1C".to_string()
         );
     }
+
+    #[test]
+    #[ignore = "Fails because deserialization cannot handle untagged crypto enums"]
+    // FIXME: https://linear.app/tezos/issue/JSTZ-272/fix-binary-round-trip-for-tezos-cryptos
+    fn bin_round_trip() {
+        let pkh = PublicKeyHash::from_base58(TZ1).unwrap();
+        let bin = bincode::serialize(&pkh).unwrap();
+        // Error message:
+        //      Result::unwrap()` on an `Err` value: DeserializeAnyNotSupported
+        let decoded = bincode::deserialize::<PublicKeyHash>(bin.as_ref()).unwrap();
+        assert_eq!(pkh, decoded);
+    }
 }

--- a/crates/jstz_crypto/src/secret_key.rs
+++ b/crates/jstz_crypto/src/secret_key.rs
@@ -68,4 +68,16 @@ mod test {
         );
         assert_eq!(serde_json::to_string(&sk).expect("Should not fail"), json);
     }
+
+    #[test]
+    #[ignore = "Fails because deserialization cannot handle untagged crypto enums"]
+    // FIXME: https://linear.app/tezos/issue/JSTZ-272/fix-binary-round-trip-for-tezos-cryptos
+    fn bin_round_trip() {
+        let sk = SecretKey::from_base58(SK).unwrap();
+        let bin = bincode::serialize(&sk).unwrap();
+        // Error message:
+        //      Result::unwrap()` on an `Err` value: DeserializeAnyNotSupported
+        let decoded = bincode::deserialize::<SecretKey>(bin.as_ref()).unwrap();
+        assert_eq!(sk, decoded);
+    }
 }

--- a/crates/jstz_proto/Cargo.toml
+++ b/crates/jstz_proto/Cargo.toml
@@ -31,3 +31,4 @@ utoipa.workspace = true
 [dev-dependencies]
 jstz_mock = { path = "../jstz_mock" }
 tezos-smart-rollup-mock.workspace = true
+bincode.workspace = true


### PR DESCRIPTION
# Context
Fixes an issue with json serialization  of `Content` printing the discriminator (`_type`) twice which causes problems when deserializing. 

This PR also identifies an issue with the binary encoding that is broken because `tezos_cryptos` cannot decode enums with `serde(untagged)`. This will be fixed in a follow up PR.

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
* Removes serde tag `_type` from operation struct types.

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
`cargo nextest run -p jstz_proto`
<!-- Describe how reviewers and approvers can test this PR. -->
