### PR TITLE
fix(jstzd): config route

### DIFF
--- a/crates/jstzd/src/task/jstzd.rs
+++ b/crates/jstzd/src/task/jstzd.rs
@@ -350,7 +350,7 @@ impl JstzdServer {
             .route("/health", get(health_check_handler))
             .route("/shutdown", put(shutdown_handler))
             .route("/config/:config_type", get(config_handler))
-            .route("/config/", get(all_config_handler))
+            .route("/config", get(all_config_handler))
             .with_state(self.inner.state.clone());
         let listener = TcpListener::bind(("0.0.0.0", self.port)).await?;
 


### PR DESCRIPTION
# Context

fix jstzd server config endpoint

# Description
Currenlty the config endpoint works for `/config/ ` instead of `/config` 
This PR fixes it

e.g. 
curl -v http://127.0.0.1:55555/config/

# Manually testing the PR

```
eos-MacBook-Pro:jstz leo$ curl -v http://127.0.0.1:55556/config
*   Trying 127.0.0.1:55556...
* Connected to 127.0.0.1 (127.0.0.1) port 55556
> GET /config HTTP/1.1
> Host: 127.0.0.1:55556
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< content-type: text/plain; charset=utf-8
< content-length: 1506
< date: Fri, 10 Jan 2025 10:17:36 GMT
< 
* Connection #0 to host 127.0.0.1 left intact
{"jstz_node":{"endpoint":"http://localhost:50472","kernel_log_file":"kernel.log","rollup_endpoint":"http://127.0.0.1:50471"},"octez_baker":{"binary_path":"octez-baker-alpha","log_file":"/var/folders/wl/37cx974n645bmsc931dfgvfw0000gp/T/nix-shell.RufWfB/.tmpqyX6KY","octez_client_base_dir":"/var/folders/wl/37cx974n645bmsc931dfgvfw0000gp/T/nix-shell.RufWfB/.tmpaXvUfr","octez_node_endpoint":"http://localhost:50469"},"octez_client":{"base_dir":"/var/folders/wl/37cx974n645bmsc931dfgvfw0000gp/T/nix-shell.RufWfB/.tmpaXvUfr","binary_path":"octez-client","disable_unsafe_disclaimer":false,"log_file":"/var/folders/wl/37cx974n645bmsc931dfgvfw0000gp/T/nix-shell.RufWfB/.tmpmRmZ1S","octez_node_endpoint":"http://localhost:50469"},"octez_node":{"binary_path":"octez-node","network":"sandbox","p2p_address":"http://127.0.0.1:50470","rpc_endpoint":"http://localhost:50469","run_options":{"network":"sandbox","synchronisation_threshold":0}},"octez_rollup":{"address":"sr1PuFMgaRUN12rKQ3J2ae5psNtwCxPNmGNK","binary_path":"octez-smart-rollup-node","boot_sector_file":"/Users/leo/tezos/jstz/target/debug/build/jstzd-2abf2968eec917ac/out/kernel_installer.hex","kernel_debug_file":"kernel.log","log_file":"/var/folders/wl/37cx974n645bmsc931dfgvfw0000gp/T/nix-shell.RufWfB/.tmpZYkxD1","octez_client_base_dir":"/var/folders/wl/37cx974n645bmsc931dfgvfw0000gp/T/nix-shell.RufWfB/.tmpaXvUfr","octez_node_endpoint":"http://localhost:50469","operator":"bootstrap1","pvm_kind":"wasm_2_0_0","rpc_endpoint":"http://127.0.0.1:50471"}}Leos-MacBook-Pro:jstz leo$ 
```
