### PR TITLE
refactor(jstz_proto): move kv api

### DIFF
--- a/crates/jstz_api/src/lib.rs
+++ b/crates/jstz_api/src/lib.rs
@@ -4,7 +4,6 @@ pub mod file;
 pub mod http;
 pub mod idl;
 pub mod js_log;
-mod kv;
 pub mod random;
 pub mod stream;
 pub mod todo;
@@ -12,7 +11,4 @@ pub mod url;
 pub mod urlpattern;
 
 pub use console::ConsoleApi;
-pub use kv::Kv;
-pub use kv::KvApi;
-pub use kv::KvValue;
 pub use random::RandomApi;

--- a/crates/jstz_cli/src/jstz.rs
+++ b/crates/jstz_cli/src/jstz.rs
@@ -1,10 +1,9 @@
 use std::time::Duration;
 
 use anyhow::{anyhow, bail, Result};
-use jstz_api::KvValue;
 use jstz_proto::{
-    context::account::Nonce,
-    context::new_account::NewAddress,
+    api::KvValue,
+    context::{account::Nonce, new_account::NewAddress},
     operation::{OperationHash, SignedOperation},
     receipt::Receipt,
 };

--- a/crates/jstz_cli/src/repl/debug_api/kv.rs
+++ b/crates/jstz_cli/src/repl/debug_api/kv.rs
@@ -4,8 +4,8 @@ use boa_engine::{
     js_string, object::ObjectInitializer, Context, JsArgs, JsObject, JsResult, JsValue,
     NativeFunction,
 };
-use jstz_api::{Kv, KvValue};
 use jstz_core::runtime;
+use jstz_proto::api::{Kv, KvValue};
 
 pub struct KvApi;
 

--- a/crates/jstz_node/src/services/accounts.rs
+++ b/crates/jstz_node/src/services/accounts.rs
@@ -3,8 +3,10 @@ use axum::{
     extract::{Path, Query, State},
     Json,
 };
-use jstz_api::KvValue;
-use jstz_proto::context::account::{Account, Nonce, ParsedCode};
+use jstz_proto::{
+    api::KvValue,
+    context::account::{Account, Nonce, ParsedCode},
+};
 use serde::Deserialize;
 use utoipa_axum::{router::OpenApiRouter, routes};
 

--- a/crates/jstz_proto/src/api/kv.rs
+++ b/crates/jstz_proto/src/api/kv.rs
@@ -6,10 +6,11 @@ use boa_engine::{
 };
 use boa_gc::{Finalize, Trace};
 use jstz_core::{host::HostRuntime, kv::Transaction, runtime, Result};
-use jstz_crypto::public_key_hash::PublicKeyHash;
 use serde::{Deserialize, Serialize};
 use tezos_smart_rollup::storage::path::{self, OwnedPath, RefPath};
 use utoipa::ToSchema;
+
+use crate::context::new_account::NewAddress;
 
 #[derive(Debug, Trace, Finalize, JsData)]
 pub struct Kv {
@@ -101,7 +102,7 @@ macro_rules! preamble {
 }
 
 pub struct KvApi {
-    pub address: PublicKeyHash,
+    pub address: NewAddress,
 }
 
 impl KvApi {

--- a/crates/jstz_proto/src/api/mod.rs
+++ b/crates/jstz_proto/src/api/mod.rs
@@ -1,5 +1,7 @@
+mod kv;
 mod ledger;
 mod smart_function;
 
+pub use kv::{Kv, KvApi, KvValue};
 pub use ledger::LedgerApi;
 pub use smart_function::{SmartFunctionApi, TraceData};

--- a/crates/jstz_proto/src/executor/smart_function.rs
+++ b/crates/jstz_proto/src/executor/smart_function.rs
@@ -137,15 +137,9 @@ pub fn register_jstz_apis(
     seed: u64,
     context: &mut Context,
 ) {
-    // TODO: remove once smart function address is supported
-    // https://linear.app/tezos/issue/JSTZ-260/add-validation-check-for-address-type
-    let pkh = match address {
-        NewAddress::User(pkh) => pkh,
-        _ => panic!("Smart function address is not supported yet"),
-    };
     realm.register_api(
-        jstz_api::KvApi {
-            address: pkh.clone(),
+        api::KvApi {
+            address: address.clone(),
         },
         context,
     );


### PR DESCRIPTION
# Context
preparation step for [271](https://linear.app/tezos/issue/JSTZ-271/use-smart-function-hash-for-new-account)

we need to move the kv api from jstz_api to jstz_proto since rust doesn't support cyclic dependencies

# Description

move the KvApi to `jstz_proto`, this way we could use the new address type in the Kv, which is set when jstz runtime apis are registered

# Manually testing the PR

manually tested kv on the cli to verify kv works 
```
─(15:51:17 on leounoki-jstz-271-2/move-kv ✹ ✭)──> jstz run tezos://tz1ayVniHHVwhhzZZC5PQxnaxMBQct8PV3U5/ --network dev --trace
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.35s
warning: the following packages contain code that will be rejected by a future version of Rust: parse-display-derive v0.4.1
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
     Running `target/debug/jstz run 'tezos://tz1ayVniHHVwhhzZZC5PQxnaxMBQct8PV3U5/' --network dev --trace`
Running function at tezos://tz1ayVniHHVwhhzZZC5PQxnaxMBQct8PV3U5/ 
Connected to trace smart function "tz1ayVniHHVwhhzZZC5PQxnaxMBQct8PV3U5"
[🪵]: Counter: 0
Status code: 200 OK
Headers: {}
┌─(~/tezos/jstz)────────────────────────────────────────────────────(leo@Leos-MacBook-Pro:s023)─┐
└─(15:51:22 on leounoki-jstz-271-2/move-kv ✹ ✭)──> jstz run tezos://tz1ayVniHHVwhhzZZC5PQxnaxMBQct8PV3U5/ --network dev --trace
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.71s
warning: the following packages contain code that will be rejected by a future version of Rust: parse-display-derive v0.4.1
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
     Running `target/debug/jstz run 'tezos://tz1ayVniHHVwhhzZZC5PQxnaxMBQct8PV3U5/' --network dev --trace`
Running function at tezos://tz1ayVniHHVwhhzZZC5PQxnaxMBQct8PV3U5/ 
Connected to trace smart function "tz1ayVniHHVwhhzZZC5PQxnaxMBQct8PV3U5"
[🪵]: Counter: 1
Status code: 200 OK
Headers: {}
```
