### PR TITLE
Remove enum from smart function hash

### DIFF
--- a/crates/jstz_crypto/src/smart_function_hash.rs
+++ b/crates/jstz_crypto/src/smart_function_hash.rs
@@ -13,9 +13,11 @@ use tezos_crypto_rs::{
     blake2b,
     hash::{ContractKt1Hash, HashTrait},
 };
-use utoipa::ToSchema;
+use utoipa::{schema, ToSchema};
 
 #[derive(
+    Deref,
+    From,
     Debug,
     Clone,
     PartialEq,
@@ -25,24 +27,15 @@ use utoipa::ToSchema;
     Deserialize,
     Finalize,
     ToSchema,
-    Encode,
-    Decode,
 )]
-pub enum SmartFunctionHash {
-    #[schema(
-        title = "KT1",
-        value_type = String,
-        example = json!("KT1RycYvM4EVs6BAXWEsGXaAaRqiMP53KT4w")
-    )]
-    Kt1(Kt1),
-}
-
-#[derive(
-    Deref, From, Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Finalize,
+#[schema(
+    title = "KT1",
+    value_type = String,
+    example = json!("KT1RycYvM4EVs6BAXWEsGXaAaRqiMP53KT4w")
 )]
-pub struct Kt1(pub ContractKt1Hash);
+pub struct SmartFunctionHash(pub ContractKt1Hash);
 
-impl_bincode_for_hash!(Kt1, ContractKt1Hash);
+impl_bincode_for_hash!(SmartFunctionHash, ContractKt1Hash);
 
 unsafe impl Trace for SmartFunctionHash {
     empty_trace!();
@@ -59,22 +52,20 @@ impl FromStr for SmartFunctionHash {
 impl<'a> Hash<'a> for SmartFunctionHash {
     fn to_base58(&self) -> String {
         match self {
-            SmartFunctionHash::Kt1(inner) => inner.to_b58check(),
+            SmartFunctionHash(inner) => inner.to_b58check(),
         }
     }
 
     fn from_base58(data: &str) -> Result<Self> {
         match &data[..3] {
-            "KT1" => Ok(SmartFunctionHash::Kt1(
-                ContractKt1Hash::from_base58_check(data)?.into(),
-            )),
+            "KT1" => Ok(SmartFunctionHash(ContractKt1Hash::from_base58_check(data)?)),
             _ => Err(Error::InvalidSmartFunctionHash),
         }
     }
 
     fn as_bytes(&self) -> &[u8] {
         match self {
-            SmartFunctionHash::Kt1(inner) => inner.as_ref(),
+            SmartFunctionHash(inner) => inner.as_ref(),
         }
     }
 
@@ -83,9 +74,7 @@ impl<'a> Hash<'a> for SmartFunctionHash {
     fn digest(data: &[u8]) -> Result<Self> {
         let out_len = ContractKt1Hash::hash_size();
         let bytes = blake2b::digest(data, out_len)?;
-        Ok(SmartFunctionHash::Kt1(
-            ContractKt1Hash::try_from_bytes(&bytes)?.into(),
-        ))
+        Ok(SmartFunctionHash(ContractKt1Hash::try_from_bytes(&bytes)?))
     }
 }
 
@@ -108,7 +97,7 @@ mod test {
     fn from_str_valid() {
         let hash = SmartFunctionHash::from_str(KT1_VALID).unwrap();
         match hash {
-            SmartFunctionHash::Kt1(inner) => {
+            SmartFunctionHash(inner) => {
                 assert_eq!(inner.to_b58check(), KT1_VALID);
             }
         }

--- a/crates/jstz_kernel/src/parsing.rs
+++ b/crates/jstz_kernel/src/parsing.rs
@@ -14,7 +14,7 @@ pub fn try_parse_contract(contract: &Contract) -> Result<NewAddress> {
             Ok(NewAddress::User(PublicKeyHash::Tz1(tz1.clone().into())))
         }
         Contract::Originated(contract_kt1_hash) => Ok(NewAddress::SmartFunction(
-            SmartFunctionHash::Kt1(contract_kt1_hash.clone().into()),
+            SmartFunctionHash(contract_kt1_hash.clone()),
         )),
         _ => Err(jstz_proto::Error::InvalidAddress),
     }

--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -1014,21 +1014,9 @@
         }
       },
       "SmartFunctionHash": {
-        "oneOf": [
-          {
-            "type": "object",
-            "title": "KT1",
-            "required": [
-              "Kt1"
-            ],
-            "properties": {
-              "Kt1": {
-                "type": "string"
-              }
-            },
-            "example": "KT1RycYvM4EVs6BAXWEsGXaAaRqiMP53KT4w"
-          }
-        ]
+        "type": "string",
+        "title": "KT1",
+        "example": "KT1RycYvM4EVs6BAXWEsGXaAaRqiMP53KT4w"
       },
       "String": {
         "type": "string"

--- a/crates/jstzd/build.rs
+++ b/crates/jstzd/build.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use jstz_crypto::smart_function_hash::Kt1;
+use jstz_crypto::smart_function_hash::SmartFunctionHash;
 use jstz_kernel::TICKETER;
 use std::{
     env, fs,
@@ -123,7 +123,7 @@ fn make_kernel_installer(kernel_file: &Path, preimages_dir: &Path) -> Result<Str
         // 2. Set `jstz` ticketer as the bridge contract address
         OwnedConfigInstruction::set_instr(
             OwnedBytes(bincode::encode_to_vec(
-                Kt1(ContractKt1Hash::from_base58_check(EXCHANGER_ADDRESS)?),
+                SmartFunctionHash(ContractKt1Hash::from_base58_check(EXCHANGER_ADDRESS)?),
                 bincode::config::legacy(),
             )?),
             OwnedPath::from(TICKETER),


### PR DESCRIPTION
# Context
Since there's only one type of contract address on tezos, we don't need to use an enum.

# Description

* removed the enum from sfh
* renamed KT1 to `SmartFunctionHash`

# Manually testing the PR

existing tests work
