### PR TITLE
remove validation check for new address 

### DIFF
--- a/crates/jstz_cli/src/account.rs
+++ b/crates/jstz_cli/src/account.rs
@@ -342,11 +342,10 @@ pub enum Command {
     },
 }
 
+// TODO: use sf address
+// // TODO: https://linear.app/tezos/issue/JSTZ-260/add-validation-check-for-address-type
 fn parse_smart_function_address(s: &str) -> Result<NewAddress> {
     let address = NewAddress::from_str(s).map_err(|e| user_error!("{}", e))?;
-    address
-        .check_is_smart_function()
-        .map_err(|e| user_error!("{}", e))?;
     Ok(address)
 }
 
@@ -369,11 +368,5 @@ mod tests {
         let address =
             parse_smart_function_address("KT1TxqZ8QtKvLu3V3JH7Gx58n7Co8pgtpQU5").unwrap();
         assert!(matches!(address, NewAddress::SmartFunction(_)));
-    }
-
-    #[test]
-    fn test_pasrse_smart_function_throws_error_for_user_address() {
-        let result = parse_smart_function_address("tz1cD5CuvAALcxgypqBXcBQEA8dkLJivoFjU");
-        assert!(result.is_err_and(|e| e.to_string().contains("AddressTypeMismatch")));
     }
 }

--- a/crates/jstz_cli/src/jstz.rs
+++ b/crates/jstz_cli/src/jstz.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use jstz_proto::{
     api::KvValue,
     context::{account::Nonce, new_account::NewAddress},
@@ -50,9 +50,6 @@ impl JstzClient {
     }
 
     pub async fn get_nonce(&self, address: &NewAddress) -> Result<Nonce> {
-        address
-            .check_is_user()
-            .map_err(|e| anyhow!(format!("{}", e)))?;
         let response = self
             .get(&format!("{}/accounts/{}/nonce", self.endpoint, address))
             .await?;

--- a/crates/jstz_core/src/kv/transaction.rs
+++ b/crates/jstz_core/src/kv/transaction.rs
@@ -473,7 +473,7 @@ impl<'a, V> Entry<'a, V> {
 
     pub fn or_insert_with<F>(self, default: F) -> &'a mut V
     where
-        V: Value + Default,
+        V: Value,
         F: FnOnce() -> V,
     {
         match self {

--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -648,17 +648,6 @@
           }
         }
       },
-      "NewAddress": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/PublicKeyHash"
-          },
-          {
-            "$ref": "#/components/schemas/SmartFunctionHash"
-          }
-        ],
-        "description": "TODO: rename to Address"
-      },
       "Nonce": {
         "type": "integer",
         "format": "int64",

--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -648,6 +648,17 @@
           }
         }
       },
+      "NewAddress": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/PublicKeyHash"
+          },
+          {
+            "$ref": "#/components/schemas/SmartFunctionHash"
+          }
+        ],
+        "description": "TODO: rename to Address"
+      },
       "Nonce": {
         "type": "integer",
         "format": "int64",

--- a/crates/jstz_proto/src/context/account.rs
+++ b/crates/jstz_proto/src/context/account.rs
@@ -20,7 +20,7 @@ pub type Amount = u64;
 #[derive(
     Clone, Copy, Default, Debug, PartialEq, Eq, Serialize, Deserialize, ToSchema,
 )]
-pub struct Nonce(u64);
+pub struct Nonce(pub u64);
 
 impl Nonce {
     pub fn next(&self) -> Nonce {
@@ -44,7 +44,7 @@ impl Display for Nonce {
     format = "javascript",
     example = "export default (request) => new Response('Hello world!')"
 )]
-pub struct ParsedCode(String);
+pub struct ParsedCode(pub String);
 impl From<ParsedCode> for String {
     fn from(ParsedCode(code): ParsedCode) -> Self {
         code

--- a/crates/jstz_proto/src/context/new_account.rs
+++ b/crates/jstz_proto/src/context/new_account.rs
@@ -56,22 +56,6 @@ impl FromStr for NewAddress {
 }
 
 impl NewAddress {
-    pub fn check_is_user(&self) -> Result<()> {
-        match self {
-            Self::User(_) => Ok(()),
-            _ => Err(Error::AddressTypeMismatch),
-        }
-    }
-
-    pub fn check_is_smart_function(&self) -> Result<()> {
-        match self {
-            Self::SmartFunction(_) => Ok(()),
-            _ => Err(Error::AddressTypeMismatch),
-        }
-    }
-}
-
-impl NewAddress {
     pub fn from_base58(data: &str) -> Result<Self> {
         if data.len() < 3 {
             return Err(Error::InvalidAddress);
@@ -162,29 +146,6 @@ mod test {
 
         // Test invalid KT1
         assert!(NewAddress::from_str("KT1invalid").is_err());
-    }
-
-    #[test]
-    fn test_type_checks() {
-        // Test tz1 type checks
-        let tz1_addr = NewAddress::from_str(TZ1).unwrap();
-        assert!(tz1_addr.check_is_user().is_ok());
-        assert!(tz1_addr.check_is_smart_function().is_err());
-
-        // Test tz2 type checks
-        let tz2_addr = NewAddress::from_str(TZ2).unwrap();
-        assert!(tz2_addr.check_is_user().is_ok());
-        assert!(tz2_addr.check_is_smart_function().is_err());
-
-        // Test tz3 type checks
-        let tz3_addr = NewAddress::from_str(TZ3).unwrap();
-        assert!(tz3_addr.check_is_user().is_ok());
-        assert!(tz3_addr.check_is_smart_function().is_err());
-
-        // Test KT1 type checks
-        let kt1_addr = NewAddress::from_str(KT1).unwrap();
-        assert!(kt1_addr.check_is_user().is_err());
-        assert!(kt1_addr.check_is_smart_function().is_ok());
     }
 
     #[test]


### PR DESCRIPTION
# Context

preparation step for [754](https://github.com/jstz-dev/jstz/pull/754)

# Description

1. The validation check for the address type is removed as we intend to use the sf hash address directly in the following PRs.
2. the value for entry.or_insert_with doesn't need a `Default` trait

# Manually testing the PR

existing test pass
