### PR TITLE
feat(jstzd): set default import path for jstzd kernel files

### DIFF
--- a/crates/jstzd/build.rs
+++ b/crates/jstzd/build.rs
@@ -178,12 +178,18 @@ fn generate_path_getter_code(out_dir: &Path, fn_name: &str, path_suffix: &str) -
         r#"
         const {}_PATH: &str = "{}";
         pub fn {}_path() -> std::path::PathBuf {{
-            std::path::PathBuf::from({}_PATH)
+            let path = std::path::PathBuf::from({}_PATH);
+            if path.exists() {{
+                path
+            }} else {{
+                std::path::PathBuf::from("/usr/share/jstzd/{}")
+            }}
         }}
         "#,
         &name_upper,
         out_dir.join(path_suffix).to_str().expect("Invalid path"),
         fn_name,
         &name_upper,
+        path_suffix
     )
 }


### PR DESCRIPTION
# Context

Completes JSTZ-277.
[JSTZ-277](https://linear.app/tezos/issue/JSTZ-277/make-built-kernel-files-easily-accessible)

Part of [JSTZ-273](https://linear.app/tezos/issue/JSTZ-273/ship-jstzd-in-a-container).

# Description

Currently building the kernel wasm file into the installer file and preimages is part of the build process. These files are kept somewhere in the build environment, which is accessible through the environment variable `OUT_DIR` _only at build time_. Some pieces of code are generated and used by jstzd to find the kernel files. These pieces of code are then built into jstzd at compile time. In these pieces of code, the path known as `OUT_DIR` at build time is referenced as the directory that contains the kernel files. This becomes an issue when jstzd is launched outside the build environment because the path known by jstzd (as sealed in those pieces of code generated) no longer exists.

To mitigate this problem for now, especially for the jstzd image case, this PR introduces a fallback directory `/usr/share/jstzd` when the path specified in `OUT_DIR` does not exist.

# Manually testing the PR

Since `build.rs` cannot be tested with unit tests, these changes were tested manually:
```sh
$ KERNEL_DEST_DIR=/tmp/foo cargo build --bin jstzd --release
...
   Compiling jstzd v0.1.0-alpha.0 (/code/crates/jstzd)
   Compiling octez v0.1.0-alpha.0 (/code/crates/octez)
   Compiling jstz_node v0.1.0-alpha.0 (/code/crates/jstz_node)
warning: jstzd@0.1.0-alpha.0: Build script output directory: /code/target/release/build/jstzd-cb92e6b31c692d92/out
warning: jstzd@0.1.0-alpha.0: Copying content in output directory to: /tmp/foo
    Finished `release` profile [optimized] target(s) in 4m 52s
$ head -n10 /tmp/foo/jstz_rollup_path.rs 

        const KERNEL_INSTALLER_PATH: &str = "/code/target/release/build/jstzd-cb92e6b31c692d92/out/kernel_installer.hex";
        pub fn kernel_installer_path() -> std::path::PathBuf {
            let path = std::path::PathBuf::from(KERNEL_INSTALLER_PATH);
            if path.exists() {
                path
            } else {
                std::path::PathBuf::from("/usr/share/jstzd/kernel_installer.hex")
            }
        }
```
In the generated code `jstz_rollup_path.rs`, the fallback path indeed points to `/usr/share/jstzd`. The built jstzd executable can launch in a test container without any error.
