### PR TITLE
feat(jstzd): create dockerfile

### DIFF
--- a/crates/jstzd/Cargo.toml
+++ b/crates/jstzd/Cargo.toml
@@ -51,6 +51,7 @@ tezos_crypto_rs.workspace = true
 
 [features]
 skip-rollup-tests = []
+build-image = ["octez/disable-alpha", "octez/disable-slow-pvm"]
 
 [[bin]]
 name = "jstzd"

--- a/crates/jstzd/Dockerfile
+++ b/crates/jstzd/Dockerfile
@@ -1,0 +1,28 @@
+ARG OCTEZ_TAG
+FROM tezos/tezos:${OCTEZ_TAG} AS octez
+USER root
+RUN mkdir /octez-bin && mv /usr/local/bin/octez-client /usr/local/bin/octez-node /usr/local/bin/octez-smart-rollup-node /usr/local/bin/octez-baker-* /octez-bin
+
+FROM rust:1.80.0-alpine AS builder
+RUN apk --no-cache add musl-dev libcrypto3 openssl-dev clang make
+ENV OPENSSL_DIR=/usr
+WORKDIR /
+ADD . .
+ARG KERNEL_PATH
+COPY $KERNEL_PATH crates/jstzd/resources/jstz_rollup/jstz_kernel.wasm
+# release build is required for rust-embed to pack the resource files into the executable
+RUN KERNEL_DEST_DIR=/jstzd_kernel_files RUSTFLAGS='-C target-feature=-crt-static' cargo build --jobs 1 --bin jstzd --release --features build-image
+
+FROM alpine AS jstzd
+# libcrypto3, openssl, and musl are needed for jstz-rollup binary
+# hidapi, gmp, and libev are needed for octez-client binary
+# libffi, libgmpxx are needed for octez-smart-rollup-node binary
+# sqlite-dev is needed for octez-node binary
+RUN apk --no-cache add binutils bash libcrypto3 openssl musl hidapi gmp libev libffi libgmpxx sqlite-dev
+COPY --from=octez /octez-bin /usr/local/bin
+COPY --from=octez /usr/share/zcash-params /root/.zcash-params
+# Copy the jstzd binary & dependencies
+COPY --from=builder /target/release/jstzd /usr/bin/jstzd
+COPY --from=builder /jstzd_kernel_files /usr/share/jstzd
+
+ENTRYPOINT [ "/usr/bin/jstzd" ]


### PR DESCRIPTION
# Context

Closes JSTZ-278.
[JSTZ-278](https://linear.app/tezos/issue/JSTZ-278/create-docker-file-for-jstzd)

# Description

Create a dockerfile that builds jstzd as an image based on a designated octez image. One feature flag is added specifically for this docker build because
* jstzd in the image must not suffer from the slow PVM issue, which means the base image needs either the old version v20.3 or newer versions with the slow PVM fix
* jstzd in the image needs to have quebec support, which means the old version v20.3 is not suitable as the base image

and therefore we need to use a newer version as the base image. Since alpha is not yet stabilised, it's better that we don't allow users to use alpha at all, so this new feature flag includes `octez/disable-alpha`. The default protocol version used by jstzd will be quebec.

# Manually testing the PR

```
$ cd $(git rev-parse --show-toplevel) && \
docker build -t ghcr.io/jstz-dev/jstz/jstz:0.1.0 --build-arg OCTEZ_TAG=master_d21359af_20241220171048 \
-f crates/jstzd/Dockerfile .
...
$ docker images
REPOSITORY                   TAG           IMAGE ID       CREATED          SIZE
ghcr.io/jstz-dev/jstz/jstz   0.1.0         b5f373cb09e1   58 seconds ago   1.64GB
```
