### PR TITLE
feat(octez): introduce feature 'disable-alpha'

### DIFF
--- a/crates/octez/Cargo.toml
+++ b/crates/octez/Cargo.toml
@@ -28,3 +28,6 @@ tempfile.workspace = true
 tezos_crypto_rs.workspace = true
 tezos-smart-rollup-encoding.workspace = true
 tokio.workspace = true
+
+[features]
+disable-alpha = []

--- a/crates/octez/src/async/baker.rs
+++ b/crates/octez/src/async/baker.rs
@@ -23,6 +23,7 @@ impl FromStr for BakerBinaryPath {
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         Ok(match s {
+            #[cfg(not(feature = "disable-alpha"))]
             "octez-baker-alpha" => BakerBinaryPath::Env(Protocol::Alpha),
             "octez-baker-PsParisC" => BakerBinaryPath::Env(Protocol::ParisC),
             "octez-baker-PsQuebec" => BakerBinaryPath::Env(Protocol::Quebec),
@@ -34,6 +35,7 @@ impl FromStr for BakerBinaryPath {
 impl Display for BakerBinaryPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            #[cfg(not(feature = "disable-alpha"))]
             BakerBinaryPath::Env(Protocol::Alpha) => write!(f, "octez-baker-alpha"),
             BakerBinaryPath::Env(Protocol::ParisC) => {
                 write!(f, "octez-baker-PsParisC")
@@ -179,6 +181,7 @@ mod test {
 
     #[test]
     fn serialize_baker_path() {
+        #[cfg(not(feature = "disable-alpha"))]
         assert_eq!(
             serde_json::to_string(&BakerBinaryPath::Env(Protocol::Alpha)).unwrap(),
             "\"octez-baker-alpha\""
@@ -205,7 +208,7 @@ mod test {
             Endpoint::try_from(Uri::from_static("http://localhost:8732")).unwrap();
         let log_file = NamedTempFile::new().unwrap().into_temp_path();
         let config = OctezBakerConfigBuilder::new()
-            .set_binary_path(BakerBinaryPath::Env(Protocol::Alpha))
+            .set_binary_path(BakerBinaryPath::Env(Protocol::ParisC))
             .set_octez_client_base_dir(base_dir.path().to_str().unwrap())
             .set_octez_node_endpoint(&endpoint)
             .set_log_file(log_file.to_path_buf().as_path())
@@ -216,7 +219,7 @@ mod test {
             serde_json::json!({
                 "octez_client_base_dir": base_dir.path().to_string_lossy(),
                 "octez_node_endpoint": "http://localhost:8732",
-                "binary_path": "octez-baker-alpha",
+                "binary_path": "octez-baker-PsParisC",
                 "log_file": log_file.to_string_lossy()
             })
         )
@@ -224,6 +227,7 @@ mod test {
 
     #[test]
     fn baker_path_from_str() {
+        #[cfg(not(feature = "disable-alpha"))]
         assert_eq!(
             BakerBinaryPath::from_str("octez-baker-alpha").unwrap(),
             BakerBinaryPath::Env(Protocol::Alpha)
@@ -240,6 +244,7 @@ mod test {
 
     #[test]
     fn deserialize_baker_path() {
+        #[cfg(not(feature = "disable-alpha"))]
         assert_eq!(
             serde_json::from_str::<BakerBinaryPath>("\"octez-baker-alpha\"").unwrap(),
             BakerBinaryPath::Env(Protocol::Alpha)

--- a/crates/octez/src/async/protocol.rs
+++ b/crates/octez/src/async/protocol.rs
@@ -55,6 +55,7 @@ impl Display for ProtocolConstants {
 
 #[derive(PartialEq, Eq, Debug, Clone, SerializeDisplay, DeserializeFromStr)]
 pub enum Protocol {
+    #[cfg(not(feature = "disable-alpha"))]
     Alpha,
     ParisC,
     Quebec,
@@ -65,7 +66,9 @@ impl FromStr for Protocol {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
+            #[cfg(not(feature = "disable-alpha"))]
             "alpha" => Ok(Protocol::Alpha),
+            #[cfg(not(feature = "disable-alpha"))]
             "ProtoALphaALphaALphaALphaALphaALphaALphaALphaDdp3zK" => Ok(Protocol::Alpha),
             "parisC" => Ok(Protocol::ParisC),
             "PsParisCZo7KAh1Z1smVd9ZMZ1HHn5gkzbM94V3PLCpknFWhUAi" => Ok(Protocol::ParisC),
@@ -77,7 +80,11 @@ impl FromStr for Protocol {
 
 impl Default for Protocol {
     fn default() -> Self {
-        Self::Alpha
+        #[cfg(not(feature = "disable-alpha"))]
+        return Self::Alpha;
+
+        #[cfg(feature = "disable-alpha")]
+        Self::ParisC
     }
 }
 
@@ -90,6 +97,7 @@ impl Display for Protocol {
 impl Protocol {
     pub fn hash(&self) -> &'static str {
         match self {
+            #[cfg(not(feature = "disable-alpha"))]
             Protocol::Alpha => "ProtoALphaALphaALphaALphaALphaALphaALphaALphaDdp3zK",
             Protocol::ParisC => "PsParisCZo7KAh1Z1smVd9ZMZ1HHn5gkzbM94V3PLCpknFWhUAi",
             Protocol::Quebec => "PsQubecQubecQubecQubecQubecQubecQubecQubecQubec",
@@ -446,14 +454,14 @@ mod tests {
         .unwrap();
         builder
             .set_constants(ProtocolConstants::Sandbox)
-            .set_protocol(Protocol::Alpha)
+            .set_protocol(Protocol::ParisC)
             .set_source_path("/test/path")
             .set_bootstrap_accounts([account.clone()])
             .set_bootstrap_contracts([contract.clone()])
             .set_bootstrap_smart_rollups([rollup.clone()]);
         assert_eq!(builder.constants.unwrap(), ProtocolConstants::Sandbox);
         assert_eq!(builder.source_path.unwrap().to_str().unwrap(), "/test/path");
-        assert_eq!(builder.protocol.unwrap().hash(), Protocol::Alpha.hash());
+        assert_eq!(builder.protocol.unwrap().hash(), Protocol::ParisC.hash());
         assert_eq!(builder.bootstrap_accounts.accounts().len(), 1);
         assert_eq!(
             *builder.bootstrap_accounts.accounts().last().unwrap(),
@@ -474,7 +482,10 @@ mod tests {
         // and write an output file, so we check if the result is ok here
         match builder.build() {
             Ok(p) => {
+                #[cfg(not(feature = "disable-alpha"))]
                 assert_eq!(p.protocol(), Protocol::Alpha);
+                #[cfg(feature = "disable-alpha")]
+                assert_eq!(p.protocol(), Protocol::ParisC);
             }
             _ => panic!("builder.build should not fail"),
         }
@@ -761,8 +772,8 @@ mod tests {
     #[test]
     fn serialize_protocol() {
         assert_eq!(
-            serde_json::to_string(&Protocol::Alpha).unwrap(),
-            "\"ProtoALphaALphaALphaALphaALphaALphaALphaALphaDdp3zK\""
+            serde_json::to_string(&Protocol::ParisC).unwrap(),
+            "\"PsParisCZo7KAh1Z1smVd9ZMZ1HHn5gkzbM94V3PLCpknFWhUAi\""
         )
     }
 
@@ -780,6 +791,7 @@ mod tests {
 
     #[test]
     fn deserialize_protocol() {
+        #[cfg(not(feature = "disable-alpha"))]
         assert_eq!(
             serde_json::from_str::<Protocol>(
                 "\"ProtoALphaALphaALphaALphaALphaALphaALphaALphaDdp3zK\""
@@ -787,6 +799,7 @@ mod tests {
             .unwrap(),
             Protocol::Alpha
         );
+        #[cfg(not(feature = "disable-alpha"))]
         assert_eq!(
             serde_json::from_str::<Protocol>("\"alpha\"").unwrap(),
             Protocol::Alpha


### PR DESCRIPTION
# Context

Part of JSTZ-273.
[JSTZ-273](https://linear.app/tezos/issue/JSTZ-273/ship-jstzd-in-a-container)

# Description

Introduce one feature flag `disable-alpha` in the octez crate that hides the alpha protocol version. This is handy when the octez executables for alpha might not be available in an environment, e.g. when the base image of the jstzd image does not have alpha executables at all. This happens when the base image is tagged, e.g. `octez-v20.3`, `octez-v21.0`, including release candidates. The alpha executables are removed when those tagged images are built.

Also replaced Alpha with ParisC in some test cases just to avoid having to add the flag check.

# Manually testing the PR

Tested locally with a feature flag temporarily added to the jstzd crate:
```
[features]
build-image = ["octez/disable-alpha"]
```
The jstzd executable built with this feature flag then launched using `ParisC` as the default protocol version. The jstzd executable built without this feature flag still ran with `Alpha` by default.
