### PR TITLE
feat(octez): introduce feature 'disable-slow-pvm'

### DIFF
--- a/crates/octez/Cargo.toml
+++ b/crates/octez/Cargo.toml
@@ -31,3 +31,4 @@ tokio.workspace = true
 
 [features]
 disable-alpha = []
+disable-slow-pvm = []

--- a/crates/octez/src/async/rollup.rs
+++ b/crates/octez/src/async/rollup.rs
@@ -221,6 +221,8 @@ impl OctezRollup {
             &self.rpc_endpoint.port().to_string(),
             "--acl-override",
             "allow-all",
+            #[cfg(feature = "disable-slow-pvm")]
+            "--unsafe-disable-wasm-kernel-checks",
         ]);
         if let Some(boot_sector_file) = boot_sector_file {
             command.args(["--boot-sector-file", &boot_sector_file.to_string_lossy()]);


### PR DESCRIPTION
# Context

Part of JSTZ-273.
[JSTZ-273](https://linear.app/tezos/issue/JSTZ-273/ship-jstzd-in-a-container)

# Description

Introduce one feature flag `disable-slow-pvm` in the octez crate that adds one flag for the rollup node executable. This will force the rollup node not to raise any error or fall back to the slow PVM when it detects floating point operations in the kernel, which was enforced in octez-v21. A temporary solution that allows users to skip this behaviour by launching the rollup node with a new flag was implemented by the core team and was finalised in [90773bc](https://gitlab.com/tezos/tezos/-/commit/90773bcbea7ec941ea0f3e26cba742a0928e686e) after a few MRs. This PR simply adds that flag.

Note that this feature flag does not work with the current octez version (v21.0-rc2) referenced by nix, which is why it needs to sit behind a feature flag. This feature flag will be used to build jstzd into an image.

# Manually testing the PR

Tested locally with a feature flag temporarily added to the jstzd crate:
```
[features]
build-image = ["octez/disable-slow-pvm"]
```
The jstzd executable built with this feature flag then launched successfully in a container with the latest octez dev build instead of suffering from the slowness as observed before.
