### PR TITLE
feat(storage): use bincode for value storage

### DIFF
--- a/crates/jstz_core/src/bin_encodable.rs
+++ b/crates/jstz_core/src/bin_encodable.rs
@@ -1,0 +1,77 @@
+use bincode::{
+    config::{Configuration, Fixint, LittleEndian},
+    Decode, Encode,
+};
+
+use crate::error::{Error, Result};
+
+const BINCODE_CONFIGURATION: Configuration<LittleEndian, Fixint> =
+    bincode::config::legacy();
+
+/// Trait for types that can be encoded to and decoded from binary format
+pub trait BinEncodable {
+    fn encode(&self) -> Result<Vec<u8>>;
+    fn decode(bytes: &[u8]) -> Result<Self>
+    where
+        Self: Sized;
+}
+
+/// Default implementation for types that can be encoded to and decoded from binary format
+impl<T: Encode + Decode> BinEncodable for T {
+    fn encode(&self) -> Result<Vec<u8>> {
+        bincode::encode_to_vec(self, BINCODE_CONFIGURATION).map_err(|err| {
+            Error::SerializationError {
+                description: format!("{err}"),
+            }
+        })
+    }
+
+    fn decode(bytes: &[u8]) -> Result<Self> {
+        let (value, _) = bincode::decode_from_slice(bytes, BINCODE_CONFIGURATION)
+            .map_err(|err| Error::SerializationError {
+                description: format!("{err}"),
+            })?;
+        Ok(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq, Encode, Decode)]
+    struct TestData {
+        field1: String,
+        field2: i32,
+    }
+
+    #[test]
+    fn test_binencodable_roundtrip() {
+        let original = TestData {
+            field1: "test".to_string(),
+            field2: 42,
+        };
+
+        // Test encode
+        let encoded = BinEncodable::encode(&original).unwrap();
+        assert!(!encoded.is_empty());
+
+        // Test decode
+        let decoded = BinEncodable::decode(&encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_binencodable_invalid_data() {
+        // Try to decode invalid bytes
+        let invalid_bytes = vec![1, 2, 3];
+        let result = <TestData as BinEncodable>::decode(&invalid_bytes);
+        assert!(result.is_err());
+
+        // Verify error type
+        match result {
+            Err(Error::SerializationError { description: _ }) => (),
+            _ => panic!("Expected SerializationError"),
+        }
+    }
+}

--- a/crates/jstz_core/src/kv/mod.rs
+++ b/crates/jstz_core/src/kv/mod.rs
@@ -3,7 +3,6 @@
 //! This module provides a persistent transactional key-value store.
 
 use boa_gc::{Finalize, Trace};
-use serde::de::DeserializeOwned;
 use tezos_smart_rollup_host::runtime::ValueType;
 use tezos_smart_rollup_host::{path::Path, runtime::Runtime};
 
@@ -42,10 +41,10 @@ pub struct Storage;
 
 impl Storage {
     /// Retrieve a value from the persistent store if it exists
-    pub fn get<V>(rt: &impl Runtime, key: &impl Path) -> Result<Option<V>>
-    where
-        V: Value + DeserializeOwned,
-    {
+    pub fn get<V: bincode::Decode>(
+        rt: &impl Runtime,
+        key: &impl Path,
+    ) -> Result<Option<V>> {
         match rt.store_has(key)? {
             Some(ValueType::Value | ValueType::ValueWithSubtree) => {
                 let bytes = rt.store_read_all(key)?;
@@ -66,11 +65,12 @@ impl Storage {
     }
 
     /// Insert a key-value pair into the persistent store
-    pub fn insert<V>(rt: &mut impl Runtime, key: &impl Path, value: &V) -> Result<()>
-    where
-        V: Value + ?Sized + serde::Serialize,
-    {
-        rt.store_write(key, &value::serialize(value)?, 0)?;
+    pub fn insert<V: Value + ?Sized>(
+        rt: &mut impl Runtime,
+        key: &impl Path,
+        value: &V,
+    ) -> Result<()> {
+        rt.store_write(key, value.encode()?.as_slice(), 0)?;
         Ok(())
     }
 

--- a/crates/jstz_core/src/kv/mod.rs
+++ b/crates/jstz_core/src/kv/mod.rs
@@ -41,14 +41,11 @@ pub struct Storage;
 
 impl Storage {
     /// Retrieve a value from the persistent store if it exists
-    pub fn get<V: bincode::Decode>(
-        rt: &impl Runtime,
-        key: &impl Path,
-    ) -> Result<Option<V>> {
+    pub fn get<V: Value>(rt: &impl Runtime, key: &impl Path) -> Result<Option<V>> {
         match rt.store_has(key)? {
             Some(ValueType::Value | ValueType::ValueWithSubtree) => {
                 let bytes = rt.store_read_all(key)?;
-                let value = value::deserialize(&bytes)?;
+                let value = V::decode(&bytes)?;
                 Ok(Some(value))
             }
             _ => Ok(None),

--- a/crates/jstz_core/src/kv/outbox.rs
+++ b/crates/jstz_core/src/kv/outbox.rs
@@ -1,4 +1,5 @@
 use crate::error::Result;
+use bincode::{Decode, Encode};
 use derive_more::{Display, Error, From};
 use serde::{Deserialize, Serialize};
 use tezos_smart_rollup::{
@@ -222,7 +223,7 @@ impl PersistentOutboxQueue {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode)]
 pub(crate) struct OutboxQueueMeta {
     /// Combined queue length of the rollup and snapshots'
     /// outbox queues

--- a/crates/jstz_core/src/kv/value.rs
+++ b/crates/jstz_core/src/kv/value.rs
@@ -2,14 +2,20 @@ use std::any::Any;
 use std::fmt::Debug;
 
 use derive_more::{Deref, DerefMut};
-use erased_serde::serialize_trait_object;
-use serde::de::DeserializeOwned;
 
 use crate::{Error, Result, BINCODE_CONFIGURATION};
 
-pub fn serialize<T: ?Sized + serde::Serialize>(value: &T) -> Result<Vec<u8>> {
-    let result =
-        bincode::serde::encode_to_vec(value, BINCODE_CONFIGURATION).map_err(|err| {
+pub fn serialize<T: bincode::Encode>(value: &T) -> Result<Vec<u8>> {
+    bincode::encode_to_vec(value, BINCODE_CONFIGURATION).map_err(|err| {
+        Error::SerializationError {
+            description: format!("{err}"),
+        }
+    })
+}
+
+pub fn deserialize<T: bincode::Decode>(bytes: &[u8]) -> Result<T> {
+    let (result, _) =
+        bincode::decode_from_slice(bytes, BINCODE_CONFIGURATION).map_err(|err| {
             Error::SerializationError {
                 description: format!("{err}"),
             }
@@ -18,28 +24,18 @@ pub fn serialize<T: ?Sized + serde::Serialize>(value: &T) -> Result<Vec<u8>> {
     Ok(result)
 }
 
-pub(crate) fn deserialize<T: DeserializeOwned>(bytes: &[u8]) -> Result<T> {
-    let (result, _) = bincode::serde::decode_from_slice(bytes, BINCODE_CONFIGURATION)
-        .map_err(|err| Error::SerializationError {
-            description: format!("{err}"),
-        })?;
-
-    Ok(result)
-}
-
 /// A key-value 'value' is a value that is can be dynamically
 /// coerced (using `Any`) and serialized.
-pub trait Value: Any + Debug + erased_serde::Serialize {
+pub trait Value: Any + Debug {
     fn as_any(&self) -> &dyn Any;
     fn as_any_mut(&mut self) -> &mut dyn Any;
     fn clone_box(&self) -> Box<dyn Value>;
+    fn encode(&self) -> Result<Vec<u8>>;
 }
-
-serialize_trait_object!(Value);
 
 impl<T> Value for T
 where
-    T: Any + Debug + Clone + erased_serde::Serialize,
+    T: Any + Debug + Clone + bincode::Encode,
 {
     fn as_any(&self) -> &dyn Any {
         self
@@ -51,6 +47,10 @@ where
 
     fn clone_box(&self) -> Box<dyn Value> {
         Box::new(self.clone())
+    }
+
+    fn encode(&self) -> Result<Vec<u8>> {
+        serialize(self)
     }
 }
 

--- a/crates/jstz_core/src/lib.rs
+++ b/crates/jstz_core/src/lib.rs
@@ -1,9 +1,5 @@
+mod bin_encodable;
 pub mod error;
-
-use bincode::config::{Configuration, Fixint, LittleEndian};
-use boa_engine::Context;
-
-pub use error::{Error, Result};
 pub mod future;
 pub mod host;
 pub mod iterators;
@@ -14,6 +10,10 @@ pub mod realm;
 pub mod runtime;
 pub mod value;
 
+pub use bin_encodable::*;
+use boa_engine::Context;
+pub use error::{Error, Result};
+
 /// A generic runtime API
 pub trait Api {
     /// Initialize a runtime API
@@ -22,8 +22,3 @@ pub trait Api {
 
 pub use realm::{Module, Realm};
 pub use runtime::Runtime;
-
-pub use crate::kv::value::{deserialize, serialize};
-
-pub static BINCODE_CONFIGURATION: Configuration<LittleEndian, Fixint> =
-    bincode::config::legacy();

--- a/crates/jstz_core/src/lib.rs
+++ b/crates/jstz_core/src/lib.rs
@@ -23,5 +23,7 @@ pub trait Api {
 pub use realm::{Module, Realm};
 pub use runtime::Runtime;
 
+pub use crate::kv::value::{deserialize, serialize};
+
 pub static BINCODE_CONFIGURATION: Configuration<LittleEndian, Fixint> =
     bincode::config::legacy();

--- a/crates/jstz_crypto/src/public_key_hash.rs
+++ b/crates/jstz_crypto/src/public_key_hash.rs
@@ -57,17 +57,17 @@ pub enum PublicKeyHash {
 #[derive(
     Deref, From, Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Finalize,
 )]
-pub struct Tz1(ContractTz1Hash);
+pub struct Tz1(pub ContractTz1Hash);
 
 #[derive(
     Deref, From, Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Finalize,
 )]
-pub struct Tz2(ContractTz2Hash);
+pub struct Tz2(pub ContractTz2Hash);
 
 #[derive(
     Deref, From, Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Finalize,
 )]
-pub struct Tz3(ContractTz3Hash);
+pub struct Tz3(pub ContractTz3Hash);
 
 // Bincode implementation
 impl_bincode_for_hash!(Tz1, ContractTz1Hash);

--- a/crates/jstz_kernel/src/inbox.rs
+++ b/crates/jstz_kernel/src/inbox.rs
@@ -1,4 +1,4 @@
-use jstz_core::BINCODE_CONFIGURATION;
+use jstz_core::BinEncodable;
 use jstz_proto::context::new_account::NewAddress;
 use jstz_proto::operation::{external::Deposit, ExternalOperation, SignedOperation};
 use num_traits::ToPrimitive;
@@ -106,10 +106,7 @@ fn read_transfer(
 }
 
 fn read_external_message(rt: &mut impl Runtime, bytes: &[u8]) -> Option<ExternalMessage> {
-    let result: Result<(ExternalMessage, usize), bincode::error::DecodeError> =
-        bincode::decode_from_slice(bytes, BINCODE_CONFIGURATION);
-    let (msg, _): (ExternalMessage, _) = result.ok()?;
-
+    let msg = ExternalMessage::decode(bytes).ok()?;
     debug_msg!(rt, "External message: {msg:?}\n");
     Some(msg)
 }

--- a/crates/jstz_kernel/src/inbox.rs
+++ b/crates/jstz_kernel/src/inbox.rs
@@ -106,8 +106,9 @@ fn read_transfer(
 }
 
 fn read_external_message(rt: &mut impl Runtime, bytes: &[u8]) -> Option<ExternalMessage> {
-    let (msg, _): (ExternalMessage, _) =
-        bincode::serde::decode_from_slice(bytes, BINCODE_CONFIGURATION).ok()?;
+    let result: Result<(ExternalMessage, usize), bincode::error::DecodeError> =
+        bincode::decode_from_slice(bytes, BINCODE_CONFIGURATION);
+    let (msg, _): (ExternalMessage, _) = result.ok()?;
 
     debug_msg!(rt, "External message: {msg:?}\n");
     Some(msg)

--- a/crates/jstz_kernel/src/lib.rs
+++ b/crates/jstz_kernel/src/lib.rs
@@ -1,4 +1,5 @@
 use jstz_core::kv::{Storage, Transaction};
+use jstz_crypto::smart_function_hash::SmartFunctionHash;
 use jstz_proto::{executor, Result};
 use tezos_crypto_rs::hash::ContractKt1Hash;
 use tezos_smart_rollup::{
@@ -13,7 +14,7 @@ pub mod parsing;
 
 pub const TICKETER: RefPath = RefPath::assert_from(b"/ticketer");
 
-fn read_ticketer(rt: &impl Runtime) -> Option<ContractKt1Hash> {
+fn read_ticketer(rt: &impl Runtime) -> Option<SmartFunctionHash> {
     Storage::get(rt, &TICKETER).ok()?
 }
 

--- a/crates/jstz_mock/src/host.rs
+++ b/crates/jstz_mock/src/host.rs
@@ -2,6 +2,7 @@ use std::io::empty;
 
 use jstz_core::{host::HostRuntime, kv::Storage};
 
+use jstz_crypto::smart_function_hash::SmartFunctionHash;
 use tezos_crypto_rs::hash::ContractKt1Hash;
 use tezos_smart_rollup::{
     michelson::{
@@ -67,8 +68,10 @@ impl JstzMockHost {
         self.0.add_transfer(payload, &metadata)
     }
 
-    pub fn get_ticketer(&self) -> ContractKt1Hash {
-        ContractKt1Hash::from_base58_check(NATIVE_TICKETER).unwrap()
+    pub fn get_ticketer(&self) -> SmartFunctionHash {
+        ContractKt1Hash::from_base58_check(NATIVE_TICKETER)
+            .unwrap()
+            .into()
     }
 
     pub fn rt(&mut self) -> &mut MockHost {
@@ -79,7 +82,10 @@ impl JstzMockHost {
 impl Default for JstzMockHost {
     fn default() -> Self {
         let mut mock_host = MockHost::default();
-        let ticketer = ContractKt1Hash::from_base58_check(NATIVE_TICKETER).unwrap();
+        let ticketer: SmartFunctionHash =
+            ContractKt1Hash::from_base58_check(NATIVE_TICKETER)
+                .unwrap()
+                .into();
         Storage::insert(&mut mock_host, &TICKETER_PATH, &ticketer)
             .expect("Could not insert ticketer");
         mock_host.set_debug_handler(empty());

--- a/crates/jstz_node/src/services/operations.rs
+++ b/crates/jstz_node/src/services/operations.rs
@@ -71,11 +71,8 @@ async fn receipt(
     let value = rollup_client.get_value(&key).await?;
 
     let receipt = match value {
-        Some(value) => bincode::serde::decode_borrowed_from_slice(
-            value.as_slice(),
-            BINCODE_CONFIGURATION,
-        )
-        .map_err(|_| anyhow!("Failed to deserialize receipt"))?,
+        Some(value) => jstz_core::deserialize::<Receipt>(value.as_slice())
+            .map_err(|_| anyhow!("Failed to deserialize receipt"))?,
         None => Err(ServiceError::NotFound)?,
     };
 

--- a/crates/jstz_proto/src/executor/fa_deposit.rs
+++ b/crates/jstz_proto/src/executor/fa_deposit.rs
@@ -24,7 +24,6 @@ const NULL_ADDRESS: &str = "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx";
 const DEPOSIT_URI: &str = "/-/deposit";
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Encode, Decode)]
-#[serde(tag = "_type")]
 pub struct FaDepositReceipt {
     pub receiver: NewAddress,
     pub ticket_balance: Amount,

--- a/crates/jstz_proto/src/executor/fa_withdraw.rs
+++ b/crates/jstz_proto/src/executor/fa_withdraw.rs
@@ -80,7 +80,6 @@ impl TryFrom<FA2_1Ticket> for Ticket {
 type OutboxMessageId = String;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema, Encode, Decode)]
-#[serde(tag = "_type")]
 pub struct FaWithdrawReceipt {
     pub source: NewAddress,
     pub outbox_message_id: OutboxMessageId,

--- a/crates/jstz_proto/src/executor/smart_function.rs
+++ b/crates/jstz_proto/src/executor/smart_function.rs
@@ -532,6 +532,7 @@ pub mod run {
 
 pub mod jstz_run {
     use jstz_core::kv::Storage;
+    use jstz_crypto::smart_function_hash::SmartFunctionHash;
     use serde::Deserialize;
     use tezos_crypto_rs::hash::ContractKt1Hash;
     use tezos_smart_rollup::storage::path::{OwnedPath, RefPath};
@@ -618,7 +619,7 @@ pub mod jstz_run {
         run: RunFunction,
     ) -> Result<receipt::RunFunctionReceipt> {
         let ticketer_path = OwnedPath::from(&RefPath::assert_from(b"/ticketer"));
-        let ticketer: ContractKt1Hash =
+        let ticketer: SmartFunctionHash =
             Storage::get(hrt, &ticketer_path)?.expect("ticketer should be set");
         execute(hrt, tx, &ticketer, source, run)
     }

--- a/crates/jstz_proto/src/operation.rs
+++ b/crates/jstz_proto/src/operation.rs
@@ -246,6 +246,7 @@ mod test {
     use super::{DeployFunction, RunFunction};
     use crate::{context::account::ParsedCode, operation::Content};
     use http::{HeaderMap, Method, Uri};
+    use jstz_core::BinEncodable;
     use serde_json::json;
 
     fn run_function_content() -> Content {
@@ -295,14 +296,8 @@ mod test {
     #[test]
     fn test_run_function_bin_round_trip() {
         let run_function = run_function_content();
-        let binary =
-            bincode::encode_to_vec(&run_function, jstz_core::BINCODE_CONFIGURATION)
-                .unwrap();
-        let (bin_decoded, _): (Content, _) = bincode::decode_from_slice(
-            binary.as_slice(),
-            jstz_core::BINCODE_CONFIGURATION,
-        )
-        .unwrap();
+        let binary = run_function.encode().unwrap();
+        let bin_decoded = Content::decode(binary.as_slice()).unwrap();
         assert_eq!(run_function, bin_decoded);
     }
 
@@ -325,14 +320,8 @@ mod test {
     #[test]
     fn test_deploy_function_bin_round_trip() {
         let deploy_function = deploy_function_content();
-        let binary =
-            bincode::encode_to_vec(&deploy_function, jstz_core::BINCODE_CONFIGURATION)
-                .unwrap();
-        let (bin_decoded, _): (Content, _) = bincode::decode_from_slice(
-            binary.as_slice(),
-            jstz_core::BINCODE_CONFIGURATION,
-        )
-        .unwrap();
+        let binary = deploy_function.encode().unwrap();
+        let bin_decoded = Content::decode(binary.as_slice()).unwrap();
         assert_eq!(deploy_function, bin_decoded);
     }
 }


### PR DESCRIPTION
# Context
This PRs switches the encoding library for value storage from `serde` to `bincode` which ensure binary serialization is independent of serde. This is important because serde manipulation on enums can break bincode, thus an encoding scheme independrnt of serde increases reliability.

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
* The main change is o embed encode as part of `Value` and replace `DeserializeOwned` with `bincode::Decode` in `Storage`.
* Changed anywhere using `bincode::serde` to strictly `bincode` to avoid serde-bincode complications
* Cleaned up some redundant serde tags
<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
```
make build && make test-unit
```
<!-- Describe how reviewers and approvers can test this PR. -->
