### PR TITLE
ci: build and upload cli binary

### DIFF
--- a/.github/actions/build-cli/action.yml
+++ b/.github/actions/build-cli/action.yml
@@ -1,0 +1,33 @@
+name: Build CLI binary
+inputs:
+  platform:
+    description: Platform that the binary can run on, e.g. linux, macos
+    required: true
+  arch:
+    description: Architecture of CPU that the binary can run on, e.g. arm64, amd64
+    required: true
+  repo_token:
+    description: API token that gives access to manage the target repo
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v4
+    - run: nix --version
+      shell: bash
+    - name: Format
+      shell: bash
+      run: nix --accept-flake-config fmt -- --fail-on-change
+    - name: Prevent blst
+      shell: bash
+      run: nix --accept-flake-config develop -j auto --command sh -c '[ -z "$(cargo tree | grep blst)" ]'
+    - name: Build
+      shell: bash
+      run: nix --accept-flake-config --log-format raw -L build -j auto .#jstz_cli
+    - name: Upload binaries to release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ inputs.repo_token }}
+        file: result/bin/jstz
+        asset_name: jstz_${{ inputs.platform }}_${{ inputs.arch }}
+        tag: ${{ github.ref_name }}

--- a/.github/workflows/cli-npm.yaml
+++ b/.github/workflows/cli-npm.yaml
@@ -1,0 +1,26 @@
+name: Build npm package for jstz CLI
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  mac:
+    name: Build CLI for MacOS Arm64
+    runs-on: macos
+    steps:
+      - uses: jstz-dev/jstz/.github/actions/build-cli@main
+        with:
+          platform: macos
+          arch: arm64
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+  linux-amd64:
+    name: Build CLI for Linux AMD64
+    runs-on: [x86_64, linux, nix]
+    steps:
+      - uses: jstz-dev/jstz/.github/actions/build-cli@main
+        with:
+          platform: linux
+          arch: amd64
+          repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Context

Part of JSTZ-275.
[JSTZ-275](https://linear.app/tezos/issue/JSTZ-275/ship-cli-as-an-npm-package)

# Description

Add a new workflow for building the `jstz` CLI binary and uploading it to a release. This workflow will be triggered when a new tag is created. It builds the CLI based on the tagged commit and publishes the binaries to a release with that tag in this repo.

# Manually testing the PR

Tested uploading binaries to a test repo to avoid contaminating this one:
[release](https://github.com/huancheng-trili/test-cli/releases/tag/769%2Fmerge)
[workflow run](https://github.com/jstz-dev/jstz/actions/runs/12806216038)
