### PR TITLE
fix(jstzd): change ports assigned to jstz node and jstzd server

### DIFF
--- a/crates/jstz_cli/src/config.rs
+++ b/crates/jstz_cli/src/config.rs
@@ -23,7 +23,7 @@ use crate::{
 
 // hardcoding it here instead of importing from jstzd simply to avoid adding jstzd
 // as a new depedency of jstz_cli just for this so that build time remains the same
-const JSTZD_SERVER_BASE_URL: &str = "http://127.0.0.1:55555";
+const JSTZD_SERVER_BASE_URL: &str = "http://127.0.0.1:54321";
 
 pub fn jstz_home_dir() -> PathBuf {
     if let Ok(value) = env::var("JSTZ_HOME") {

--- a/crates/jstzd/src/config.rs
+++ b/crates/jstzd/src/config.rs
@@ -1,5 +1,4 @@
 use octez::r#async::node_config::{OctezNodeHistoryMode, OctezNodeRunOptionsBuilder};
-use octez::unused_port;
 use rust_embed::Embed;
 
 use crate::task::jstzd::JstzdConfig;
@@ -24,7 +23,8 @@ use serde::Deserialize;
 use tezos_crypto_rs::hash::SmartRollupHash;
 use tokio::io::AsyncReadExt;
 
-const DEFAULT_JSTZD_SERVER_PORT: u16 = 55555;
+const DEFAULT_JSTZD_SERVER_PORT: u16 = 54321;
+const DEFAULT_JSTZ_NODE_PORT: u16 = 8933;
 const ACTIVATOR_PK: &str = "edpkuSLWfVU1Vq7Jg9FucPyKmma6otcMHac9zG4oU1KMHSTBpJuGQ2";
 pub const BOOTSTRAP_CONTRACT_NAMES: [(&str, &str); 2] = [
     ("exchanger", EXCHANGER_ADDRESS),
@@ -111,7 +111,7 @@ pub(crate) async fn build_config(
     .build()
     .unwrap();
 
-    let jstz_node_rpc_endpoint = Endpoint::localhost(unused_port());
+    let jstz_node_rpc_endpoint = Endpoint::localhost(DEFAULT_JSTZ_NODE_PORT);
     let jstz_node_config = JstzNodeConfig::new(
         &jstz_node_rpc_endpoint,
         &octez_rollup_config.rpc_endpoint,


### PR DESCRIPTION
# Context

Part of JSTZ-274.
[JSTZ-274](https://linear.app/tezos/issue/JSTZ-274/run-jstzd-with-jstz-sandbox-start)

# Description

Assign a constant port to jstz node. This is required for the container solution because for now the jstz node in jstzd is not configurable, which means there is no way to control the port assigned to jstz node beforehand and thus it's impossible to expose jstz node to jstz CLI in the host environment. Setting the port number to 8933 aligns with the old sandbox.

Also changed the port assigned to jstzd server from 55555 to 54321 because 55555 is a [secretly reserved port in MacOS](https://developer.apple.com/forums/thread/671197).

# Manually testing the PR

Launch jstzd locally to observe that the occupied ports have changed.
