### PR TITLE
Use smart function address

### DIFF
--- a/crates/jstz_cli/src/bridge/deposit.rs
+++ b/crates/jstz_cli/src/bridge/deposit.rs
@@ -1,3 +1,4 @@
+use jstz_proto::context::new_account::Addressable;
 use log::{debug, info};
 
 use crate::{

--- a/crates/jstz_cli/src/bridge/withdraw.rs
+++ b/crates/jstz_cli/src/bridge/withdraw.rs
@@ -6,6 +6,7 @@ use crate::{
     term::styles,
     utils::AddressOrAlias,
 };
+use jstz_proto::context::new_account::Addressable;
 use log::debug;
 
 pub async fn exec(

--- a/crates/jstz_cli/src/jstz.rs
+++ b/crates/jstz_cli/src/jstz.rs
@@ -1,9 +1,10 @@
 use std::time::Duration;
 
 use anyhow::{bail, Result};
+use jstz_crypto::smart_function_hash::SmartFunctionHash;
 use jstz_proto::{
     api::KvValue,
-    context::{new_account::NewAddress, new_account::Nonce},
+    context::new_account::{Addressable, NewAddress, Nonce},
     operation::{OperationHash, SignedOperation},
     receipt::Receipt,
 };
@@ -67,13 +68,7 @@ impl JstzClient {
         }
     }
 
-    pub async fn get_code(&self, address: &NewAddress) -> Result<Option<String>> {
-        // TODO: https://linear.app/tezos/issue/JSTZ-260/add-validation-check-for-address-type
-        // validate address type === smart function
-        // address
-        //     .check_is_smart_function()
-        //     .map_err(|e| user_error!("{}", e))?;
-
+    pub async fn get_code(&self, address: &SmartFunctionHash) -> Result<Option<String>> {
         let response = self
             .get(&format!("{}/accounts/{}/code", self.endpoint, address))
             .await?;
@@ -84,7 +79,7 @@ impl JstzClient {
                 Ok(code)
             }
             StatusCode::NOT_FOUND => {
-                bail!("Account '{}' not found", address.to_base58())
+                bail!("Account '{}' not found", address)
             }
             // For any other status, return a generic error
             _ => bail!("Failed to get the code"),

--- a/crates/jstz_crypto/src/hash.rs
+++ b/crates/jstz_crypto/src/hash.rs
@@ -91,9 +91,7 @@ pub trait Hash<'a>:
     + Serialize
     + Deserialize<'a>
     + Finalize
-    // TODO: Add back when renamed
-    // https://linear.app/tezos/issue/JSTZ-253/remove-old-accountrs
-    // ToSchema,
+    + ToSchema
     + Trace
     + FromStr
     + Display

--- a/crates/jstz_kernel/src/inbox.rs
+++ b/crates/jstz_kernel/src/inbox.rs
@@ -195,7 +195,7 @@ mod test {
     use jstz_crypto::smart_function_hash::SmartFunctionHash;
     use jstz_mock::message::native_deposit::MockNativeDeposit;
     use jstz_mock::{host::JstzMockHost, message::fa_deposit::MockFaDeposit};
-    use jstz_proto::context::new_account::NewAddress;
+    use jstz_proto::context::new_account::{Addressable, NewAddress};
     use jstz_proto::operation::external;
     use tezos_crypto_rs::hash::{ContractKt1Hash, HashTrait};
     use tezos_smart_rollup::types::SmartRollupAddress;

--- a/crates/jstz_kernel/src/lib.rs
+++ b/crates/jstz_kernel/src/lib.rs
@@ -128,11 +128,6 @@ mod test {
         .unwrap();
         tx.commit(host.rt()).unwrap();
 
-        let proxy = match proxy {
-            NewAddress::User(_) => panic!("proxy is not a user address"),
-            NewAddress::SmartFunction(sfh) => sfh,
-        };
-
         let deposit = MockFaDeposit {
             proxy_contract: Some(proxy),
             ..MockFaDeposit::default()

--- a/crates/jstz_mock/src/message/fa_deposit.rs
+++ b/crates/jstz_mock/src/message/fa_deposit.rs
@@ -44,8 +44,6 @@ impl Default for MockFaDeposit {
             ticket_amount: 300,
             ticket_content: (12345, Some(b"123967145810851823941234".to_vec())),
             smart_rollup,
-            // use sf hash
-            // https://linear.app/tezos/issue/JSTZ-260/add-validation-check-for-address-type
             proxy_contract: Some(
                 jstz_crypto::smart_function_hash::SmartFunctionHash::from_base58(
                     MOCK_PROXY,

--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -613,7 +613,7 @@
         ],
         "properties": {
           "address": {
-            "$ref": "#/components/schemas/Address"
+            "$ref": "#/components/schemas/SmartFunctionHash"
           }
         }
       },
@@ -698,7 +698,7 @@
         ],
         "properties": {
           "address": {
-            "$ref": "#/components/schemas/Address"
+            "$ref": "#/components/schemas/SmartFunctionHash"
           },
           "level": {
             "$ref": "#/components/schemas/LogLevel"

--- a/crates/jstz_node/src/services/logs/mod.rs
+++ b/crates/jstz_node/src/services/logs/mod.rs
@@ -7,13 +7,11 @@ use axum::{
     Json,
 };
 use broadcaster::InfallibleSSeStream;
+use jstz_crypto::{hash::Hash, smart_function_hash::SmartFunctionHash};
+use jstz_proto::js_logger::{LogRecord, LOG_PREFIX};
 #[cfg(feature = "persistent-logging")]
 use jstz_proto::request_logger::{
     RequestEvent, REQUEST_END_PREFIX, REQUEST_START_PREFIX,
-};
-use jstz_proto::{
-    context::new_account::NewAddress,
-    js_logger::{LogRecord, LOG_PREFIX},
 };
 use serde::Deserialize;
 use tokio::task::JoinHandle;
@@ -229,13 +227,8 @@ async fn stream_log(
     State(AppState { broadcaster, .. }): State<AppState>,
     Path(address): Path<String>,
 ) -> ServiceResult<Sse<InfallibleSSeStream>> {
-    let address = NewAddress::from_base58(&address)
+    let address = SmartFunctionHash::from_base58(&address)
         .map_err(|e| ServiceError::BadRequest(e.to_string()))?;
-    // TODO: Add a check to see if the address is smart function
-    // https://linear.app/tezos/issue/JSTZ-260/add-validation-check-for-address-type
-    // address
-    //     .check_is_smart_function()
-    //     .map_err(|e| ServiceError::BadRequest(e.to_string()))?;
     Ok(broadcaster.new_client(address).await)
 }
 

--- a/crates/jstz_proto/src/api/kv.rs
+++ b/crates/jstz_proto/src/api/kv.rs
@@ -1,6 +1,5 @@
 use std::ops::Deref;
 
-use crate::context::new_account::NewAddress;
 use bincode::error::{DecodeError, EncodeError};
 use bincode::{de::Decoder, enc::Encoder, Decode, Encode};
 use boa_engine::{
@@ -9,6 +8,7 @@ use boa_engine::{
 };
 use boa_gc::{Finalize, Trace};
 use jstz_core::{host::HostRuntime, kv::Transaction, runtime, Result};
+use jstz_crypto::smart_function_hash::SmartFunctionHash;
 use serde::{Deserialize, Serialize};
 use tezos_smart_rollup::storage::path::{self, OwnedPath, RefPath};
 use utoipa::ToSchema;
@@ -110,7 +110,7 @@ macro_rules! preamble {
 }
 
 pub struct KvApi {
-    pub address: NewAddress,
+    pub address: SmartFunctionHash,
 }
 
 impl KvApi {

--- a/crates/jstz_proto/src/api/ledger.rs
+++ b/crates/jstz_proto/src/api/ledger.rs
@@ -12,12 +12,10 @@ use jstz_core::{
     accessor, host::HostRuntime, kv::Transaction, native::Accessor, runtime,
     value::IntoJs,
 };
+use jstz_crypto::smart_function_hash::SmartFunctionHash;
 
 use crate::{
-    context::{
-        new_account::NewAddress,
-        new_account::{Account, Amount},
-    },
+    context::new_account::{Account, Amount, NewAddress},
     error::Result,
 };
 
@@ -27,7 +25,7 @@ use crate::{
 
 #[derive(JsData)]
 struct Ledger {
-    address: NewAddress,
+    address: SmartFunctionHash,
 }
 
 impl Finalize for Ledger {}
@@ -65,7 +63,7 @@ impl Ledger {
 }
 
 pub struct LedgerApi {
-    pub address: NewAddress,
+    pub address: SmartFunctionHash,
 }
 
 pub(crate) fn js_value_to_pkh(value: &JsValue) -> Result<NewAddress> {

--- a/crates/jstz_proto/src/context/new_account.rs
+++ b/crates/jstz_proto/src/context/new_account.rs
@@ -88,7 +88,7 @@ pub enum AddressKind {
 
 // Represents the address in jstz, which can be converted to a base58 string.
 // This is required to avoid unnecessary cloning when getting the key path for the Account.
-pub trait Addressable: Into<NewAddress> {
+pub trait Addressable: Into<NewAddress> + Clone {
     fn kind(&self) -> AddressKind;
     fn to_base58(&self) -> String;
 }

--- a/crates/jstz_proto/src/executor/fa_deposit.rs
+++ b/crates/jstz_proto/src/executor/fa_deposit.rs
@@ -297,14 +297,7 @@ mod test {
         )
         .unwrap();
 
-        // TODO: use sf address
-        // https://linear.app/tezos/issue/JSTZ-260/add-validation-check-for-address-type
-        let proxy_sfh = match proxy.clone() {
-            NewAddress::User(_) => panic!("proxy is not a user address"),
-            NewAddress::SmartFunction(sfh) => sfh,
-        };
-
-        let fa_deposit = mock_fa_deposit(Some(proxy_sfh.clone()));
+        let fa_deposit = mock_fa_deposit(Some(proxy.clone()));
         let ticket_hash = fa_deposit.ticket_hash.clone();
 
         let Receipt { result: inner, .. } =
@@ -317,11 +310,15 @@ mod test {
                 run_function,
             })) => {
                 assert_eq!(42, ticket_balance);
-                assert_eq!(proxy, receiver);
+                assert_eq!(NewAddress::SmartFunction(proxy.clone()), receiver);
                 assert!(run_function.is_some());
-                let balance =
-                    TicketTable::get_balance(&mut host, &mut tx, &proxy, &ticket_hash)
-                        .unwrap();
+                let balance = TicketTable::get_balance(
+                    &mut host,
+                    &mut tx,
+                    &NewAddress::SmartFunction(proxy),
+                    &ticket_hash,
+                )
+                .unwrap();
                 assert_eq!(42, balance);
             }
             _ => panic!("Expected success"),
@@ -354,19 +351,12 @@ mod test {
         )
         .unwrap();
 
-        // TODO: use sf address
-        // https://linear.app/tezos/issue/JSTZ-260/add-validation-check-for-address-type
-        let proxy_sfh = match proxy.clone() {
-            NewAddress::User(_) => panic!("proxy is not a user address"),
-            NewAddress::SmartFunction(sfh) => sfh,
-        };
-
-        let fa_deposit1 = mock_fa_deposit(Some(proxy_sfh.clone()));
+        let fa_deposit1 = mock_fa_deposit(Some(proxy.clone()));
         let ticket_hash = fa_deposit1.ticket_hash.clone();
 
         let _ = super::execute(&mut host, &mut tx, fa_deposit1);
 
-        let fa_deposit2 = mock_fa_deposit(Some(proxy_sfh.clone()));
+        let fa_deposit2 = mock_fa_deposit(Some(proxy.clone()));
 
         let Receipt { result: inner, .. } =
             super::execute(&mut host, &mut tx, fa_deposit2);
@@ -378,11 +368,15 @@ mod test {
                 run_function,
             })) => {
                 assert_eq!(84, ticket_balance);
-                assert_eq!(proxy, receiver);
+                assert_eq!(NewAddress::SmartFunction(proxy.clone()), receiver);
                 assert!(run_function.is_some());
-                let balance =
-                    TicketTable::get_balance(&mut host, &mut tx, &proxy, &ticket_hash)
-                        .unwrap();
+                let balance = TicketTable::get_balance(
+                    &mut host,
+                    &mut tx,
+                    &NewAddress::SmartFunction(proxy),
+                    &ticket_hash,
+                )
+                .unwrap();
                 assert_eq!(84, balance);
             }
             _ => panic!("Expected success"),
@@ -411,13 +405,6 @@ mod test {
             100,
         )
         .unwrap();
-
-        // TODO: use sf address
-        // https://linear.app/tezos/issue/JSTZ-260/add-validation-check-for-address-type
-        let proxy = match proxy {
-            NewAddress::User(_) => panic!("proxy is not a user address"),
-            NewAddress::SmartFunction(sfh) => sfh,
-        };
 
         let fa_deposit = mock_fa_deposit(Some(proxy.clone()));
         let expected_receiver = fa_deposit.receiver.clone();

--- a/crates/jstz_proto/src/executor/fa_withdraw.rs
+++ b/crates/jstz_proto/src/executor/fa_withdraw.rs
@@ -18,7 +18,10 @@ use tezos_smart_rollup::{
 use utoipa::ToSchema;
 
 use crate::{
-    context::{new_account::Amount, new_account::NewAddress, ticket_table::TicketTable},
+    context::{
+        new_account::{Addressable, Amount, NewAddress},
+        ticket_table::TicketTable,
+    },
     Error, Result,
 };
 
@@ -118,7 +121,7 @@ fn create_fa_withdrawal_message(
 fn withdraw_from_ticket_owner(
     rt: &mut impl HostRuntime,
     tx: &mut Transaction,
-    ticket_owner: &NewAddress,
+    ticket_owner: &impl Addressable,
     routing_info: &RoutingInfo,
     amount: Amount,
     ticket: Ticket,

--- a/crates/jstz_proto/src/executor/fa_withdraw.rs
+++ b/crates/jstz_proto/src/executor/fa_withdraw.rs
@@ -147,7 +147,7 @@ impl FaWithdraw {
         self,
         rt: &mut impl HostRuntime,
         tx: &mut Transaction,
-        source: &NewAddress,
+        source: &impl Addressable,
     ) -> Result<FaWithdrawReceipt> {
         if self.amount == 0 {
             Err(Error::ZeroAmountNotAllowed)?
@@ -161,7 +161,7 @@ impl FaWithdraw {
         let outbox_message_id =
             withdraw_from_ticket_owner(rt, tx, source, &routing_info, amount, ticket)?;
         Ok(FaWithdrawReceipt {
-            source: source.clone(),
+            source: source.clone().into(),
             outbox_message_id,
         })
     }
@@ -172,7 +172,7 @@ impl FaWithdraw {
         self,
         rt: &mut impl HostRuntime,
         tx: &mut Transaction,
-        source: &NewAddress,
+        source: &impl Addressable,
         // TODO: https://linear.app/tezos/issue/JSTZ-114/fa-withdraw-gas-calculation
         // Properly consume gas
         _gas_limit: u64,

--- a/crates/jstz_proto/src/executor/smart_function.rs
+++ b/crates/jstz_proto/src/executor/smart_function.rs
@@ -402,12 +402,7 @@ impl HostScript {
             // 1. Begin a new transaction
             tx.begin();
             // 2. Execute jstz host smart function
-            let result = jstz_run::execute_without_ticketer(
-                hrt,
-                tx,
-                &self_address.clone().into(),
-                run,
-            );
+            let result = jstz_run::execute_without_ticketer(hrt, tx, self_address, run);
 
             // 3. Commit or rollback the transaction
             match result {
@@ -572,7 +567,7 @@ pub mod jstz_run {
         hrt: &mut impl HostRuntime,
         tx: &mut Transaction,
         ticketer: &ContractKt1Hash,
-        source: &NewAddress,
+        source: &impl Addressable,
         run: RunFunction,
     ) -> Result<receipt::RunFunctionReceipt> {
         let uri = run.uri.clone();
@@ -614,7 +609,7 @@ pub mod jstz_run {
     pub fn execute_without_ticketer(
         hrt: &mut impl HostRuntime,
         tx: &mut Transaction,
-        source: &NewAddress,
+        source: &impl Addressable,
         run: RunFunction,
     ) -> Result<receipt::RunFunctionReceipt> {
         let ticketer_path = OwnedPath::from(&RefPath::assert_from(b"/ticketer"));

--- a/crates/jstz_proto/src/executor/withdraw.rs
+++ b/crates/jstz_proto/src/executor/withdraw.rs
@@ -11,10 +11,7 @@ use tezos_smart_rollup::{
 use tezos_crypto_rs::hash::ContractKt1Hash;
 
 use crate::{
-    context::{
-        new_account::NewAddress,
-        new_account::{Account, Amount},
-    },
+    context::new_account::{Account, Addressable, Amount, NewAddress},
     Error, Result,
 };
 
@@ -50,7 +47,7 @@ fn create_withdrawal(
 fn withdraw(
     rt: &mut impl HostRuntime,
     tx: &mut Transaction,
-    source: &NewAddress,
+    source: &impl Addressable,
     withdrawal: Withdrawal,
     ticketer: &ContractKt1Hash,
 ) -> Result<()> {
@@ -70,7 +67,7 @@ fn withdraw(
 pub(crate) fn execute_withdraw(
     rt: &mut impl HostRuntime,
     tx: &mut Transaction,
-    source: &NewAddress,
+    source: &impl Addressable,
     withdrawal: Withdrawal,
     ticketer: &ContractKt1Hash,
 ) -> Result<()> {

--- a/crates/jstz_proto/src/js_logger.rs
+++ b/crates/jstz_proto/src/js_logger.rs
@@ -2,12 +2,12 @@ use std::fmt::{self, Display};
 
 use boa_engine::prelude::Context;
 use jstz_core::{host::HostRuntime, host_defined, runtime};
+use jstz_crypto::smart_function_hash::SmartFunctionHash;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
 use crate::api::TraceData;
-use crate::context::new_account::NewAddress;
 
 pub use jstz_api::js_log::{JsLog, LogData, LogLevel};
 
@@ -15,7 +15,7 @@ pub const LOG_PREFIX: &str = "[JSTZ:SMART_FUNCTION:LOG] ";
 
 #[derive(Serialize, Deserialize, ToSchema)]
 pub struct LogRecord {
-    pub address: NewAddress,
+    pub address: SmartFunctionHash,
     pub request_id: String,
     pub level: LogLevel,
     pub text: String,

--- a/crates/jstz_proto/src/operation.rs
+++ b/crates/jstz_proto/src/operation.rs
@@ -1,8 +1,5 @@
 use crate::{
-    context::{
-        new_account::NewAddress,
-        new_account::{Account, Amount, Nonce, ParsedCode},
-    },
+    context::new_account::{Account, Amount, NewAddress, Nonce, ParsedCode},
     Error, Result,
 };
 use bincode::{Decode, Encode};
@@ -44,7 +41,7 @@ impl Operation {
         rt: &impl HostRuntime,
         tx: &mut Transaction,
     ) -> Result<()> {
-        let next_nonce = Account::nonce(rt, tx, &NewAddress::User(self.source.clone()))?;
+        let next_nonce = Account::nonce(rt, tx, &self.source)?;
 
         if self.nonce == *next_nonce {
             next_nonce.increment();

--- a/crates/jstz_proto/src/receipt.rs
+++ b/crates/jstz_proto/src/receipt.rs
@@ -7,6 +7,7 @@ use crate::{
 use bincode::{Decode, Encode};
 use http::{HeaderMap, StatusCode};
 use jstz_api::http::body::HttpBody;
+use jstz_crypto::smart_function_hash::SmartFunctionHash;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -50,7 +51,7 @@ impl Receipt {
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Encode, Decode)]
 pub struct DeployFunctionReceipt {
-    pub address: NewAddress,
+    pub address: SmartFunctionHash,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/crates/jstz_proto/src/request_logger.rs
+++ b/crates/jstz_proto/src/request_logger.rs
@@ -1,9 +1,8 @@
 use std::fmt::{self, Display};
 
 use jstz_core::{host::HostRuntime, runtime};
+use jstz_crypto::smart_function_hash::SmartFunctionHash;
 use serde::{Deserialize, Serialize};
-
-use crate::context::new_account::NewAddress;
 
 pub const REQUEST_START_PREFIX: &str = "[JSTZ:SMART_FUNCTION:REQUEST_START] ";
 pub const REQUEST_END_PREFIX: &str = "[JSTZ:SMART_FUNCTION:REQUEST_END] ";
@@ -12,11 +11,11 @@ pub const REQUEST_END_PREFIX: &str = "[JSTZ:SMART_FUNCTION:REQUEST_END] ";
 #[serde(tag = "type")]
 pub enum RequestEvent {
     Start {
-        address: NewAddress,
+        address: SmartFunctionHash,
         request_id: String,
     },
     End {
-        address: NewAddress,
+        address: SmartFunctionHash,
         request_id: String,
         // TODO: Add more fields
     },
@@ -36,7 +35,7 @@ impl RequestEvent {
     }
 }
 
-pub fn log_request_start(address: NewAddress, request_id: String) {
+pub fn log_request_start(address: SmartFunctionHash, request_id: String) {
     let request_log = RequestEvent::Start {
         address,
         request_id,
@@ -48,7 +47,7 @@ pub fn log_request_start(address: NewAddress, request_id: String) {
     });
 }
 
-pub fn log_request_end(address: NewAddress, request_id: String) {
+pub fn log_request_end(address: SmartFunctionHash, request_id: String) {
     let request_log = RequestEvent::End {
         address,
         request_id,

--- a/examples/hello_world.js
+++ b/examples/hello_world.js
@@ -3,7 +3,7 @@ const handler = async (request) => {
     try {
         const message = await request.text()
         console.log(message);
-        console.log(\`My address is \${Ledger.selfAddress()}\`)
+        console.log(\`My address is \${Ledger.selfAddress}\`)
         const response = new Response("Success!");
         return response;
     } catch (error) { console.error("child function error", error)
@@ -14,7 +14,7 @@ export default handler`;
 
 const handler = async () => {
   console.log("Hello JS 👋");
-  console.log(`My address is ${Ledger.selfAddress()}`);
+  console.log(`My address is ${Ledger.selfAddress}`);
 
   try {
     const newSmartFunction = await SmartFunction.create(smartFunctionCode);
@@ -33,7 +33,7 @@ const handler = async () => {
   }
 
   console.log("The root smart function has control again!");
-  console.log(`And to confirm, my address is ${Ledger.selfAddress()}`);
+  console.log(`And to confirm, my address is ${Ledger.selfAddress}`);
   const response = new Response("😸");
   return response;
 };


### PR DESCRIPTION
# Context

Currently the `NewAddress` type (an enum of user and sf address) is used for places where only sf is supposed to be used(e.g. get/set function code). This PR refactors the codebase to restrict the type to sf address where possible.
[Use smart function hash](https://linear.app/tezos/issue/JSTZ-260/add-validation-check-for-address-type)

# Description
* re-exported the smart funciton hash and public key hash as `SmartFunctionAddress` and `UserAddress` respectively
* Replace `NewAddress` with `SmartFunctionAddress` where possible 
* Ledger, SmartFunction, Kv api all takes SmartFunctionAddress as it's self.address


# Manually testing the PR

manually test the sf deployment / execution and deposits/withdrawal
check [here](https://github.com/jstz-dev/jstz/pull/762) for the tests conducted