### PR TITLE
fix(stainless): fix wrong indentation level for logs

### DIFF
--- a/crates/jstz_node/stainless.yml
+++ b/crates/jstz_node/stainless.yml
@@ -59,17 +59,17 @@ resources:
     subresources:
       logs:
         models:
-          logRecord: LogRecord
-      methods:
-        stream: get /logs/{address}/stream
-      subresources:
-        persistent:
-          methods:
-            get: get /logs/{address}/persistent/requests/{request_id}
-            list:
-              type: http
-              endpoint: get /logs/{address}/persistent/requests
-              paginated: false
+          log: LogRecord
+        methods:
+          stream: get /logs/{address}/stream
+        subresources:
+          persistent:
+            methods:
+              get: get /logs/{address}/persistent/requests/{request_id}
+              list:
+                type: http
+                endpoint: get /logs/{address}/persistent/requests
+                paginated: false
   operations:
     models:
       operation: Operation


### PR DESCRIPTION
# Context
Wrong indentation causing incorrect generations for log.  
This should fix `Account` resource having a `methods` and `subresources` field (https://github.com/jstz-dev/jstz-client/blob/main/src/resources/accounts/accounts.ts#L15) 