### PR TITLE
feat(cli): set up cli npm package

### DIFF
--- a/packages/cli/main/install.js
+++ b/packages/cli/main/install.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+const https = require("https");
+
+const BINARY_NAME = "jstz";
+const FALLBACK_BINARY_PATH = path.join(__dirname, BINARY_NAME);
+const BINARY_DISTRIBUTION = {
+  darwin_arm64: "jstz_darwin_arm64",
+  linux_x64: "jstz_linux_x64",
+  linux_arm64: "jstz_linux_arm64",
+};
+const BINARY_DISTRIBUTION_PACKAGE = {
+  darwin_arm64: "cli-darwin-arm64",
+  linux_arm64: "cli-linux-arm64",
+  linux_x64: "cli-linux-x64",
+};
+const PLATFORM_ARCH_KEY = `${process.platform}_${process.arch}`;
+
+function makeRequest(url) {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, (response) => {
+        if (response.statusCode >= 200 && response.statusCode < 300) {
+          const chunks = [];
+          response.on("data", (chunk) => chunks.push(chunk));
+          response.on("end", () => {
+            resolve(Buffer.concat(chunks));
+          });
+        } else if (
+          response.statusCode >= 300 &&
+          response.statusCode < 400 &&
+          response.headers.location
+        ) {
+          // Follow redirects
+          makeRequest(response.headers.location).then(resolve, reject);
+        } else {
+          reject(
+            new Error(
+              `npm responded with status code ${response.statusCode} when downloading the package!`,
+            ),
+          );
+        }
+      })
+      .on("error", (error) => {
+        reject(error);
+      });
+  });
+}
+
+async function downloadBinaryFromGithubRelease(binName) {
+  const downloadBuffer = await makeRequest(
+    `https://github.com/jstz-dev/jstz/releases/download/${process.env.npm_package_version}/${binName}`,
+  );
+
+  fs.writeFileSync(FALLBACK_BINARY_PATH, downloadBuffer);
+
+  fs.chmodSync(FALLBACK_BINARY_PATH, "755");
+}
+
+function isPlatformSpecificPackageInstalled() {
+  try {
+    // Resolving will fail if the optionalDependency was not installed
+    require.resolve(
+      `${BINARY_DISTRIBUTION_PACKAGE[PLATFORM_ARCH_KEY]}/bin/${BINARY_NAME}`,
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+if (!isPlatformSpecificPackageInstalled()) {
+  let binName = BINARY_DISTRIBUTION[PLATFORM_ARCH_KEY];
+  if (binName === undefined) {
+    throw new Error(`Unsupported platform ${PLATFORM_ARCH_KEY}`);
+  }
+  downloadBinaryFromGithubRelease(binName);
+}

--- a/packages/cli/main/package.json
+++ b/packages/cli/main/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@jstz-dev/cli",
+  "version": "0.1.0",
+  "dependencies": {},
+  "scripts": {
+    "postinstall": "node install.js"
+  },
+  "bin": {
+    "jstz": "run.mjs"
+  }
+}

--- a/packages/cli/main/run.mjs
+++ b/packages/cli/main/run.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+import { promises as fs } from "fs";
+import path from "path";
+import childProcess from "child_process";
+import { exit } from "process";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const BINARY_NAME = "jstz";
+const BINARY_DISTRIBUTION_PACKAGE = {
+  darwin_arm64: "cli-darwin-arm64",
+  linux_arm64: "cli-linux-arm64",
+  linux_x64: "cli-linux-x64",
+};
+const PLATFORM_ARCH_KEY = `${process.platform}_${process.arch}`;
+
+function getBinaryPath() {
+  try {
+    // Resolving will fail if the optionalDependency was not installed
+    return require.resolve(
+      `${BINARY_DISTRIBUTION_PACKAGE[PLATFORM_ARCH_KEY]}/bin/${BINARY_NAME}`,
+    );
+  } catch {
+    return path.join(__dirname, BINARY_NAME);
+  }
+}
+
+try {
+  await fs.access(getBinaryPath());
+} catch (e) {
+  console.error(`Fail to load jstz: ${e}`);
+  exit(1);
+}
+
+try {
+  childProcess.execFileSync(getBinaryPath(), process.argv.slice(2), {
+    stdio: "inherit",
+  });
+} catch (e) {
+  if (e.code) {
+    exit(1);
+  } else {
+    exit(e.status);
+  }
+}


### PR DESCRIPTION
# Context

Part of JSTZ-275.
[JSTZ-275](https://linear.app/tezos/issue/JSTZ-275/ship-cli-as-an-npm-package)

# Description

Create an NPM package for jstz CLI.

This package is usable but not in its complete shape. Ideally the package should have `optionalDependencies` that are used to install the actual CLI binary, but those smaller packages make testing a bit more complicated without publishing them to NPM, and publishing these packages needs some more careful planning, so for simplicity, this package uses a rather naive approach before the publish plan gets finalised. Lines about `BINARY_DISTRIBUTION_PACKAGE` are here in preparation for the optional dependencies. They have no effect at the moment.

What happens when a user runs `npm install -g @jstz-dev/cli` or `yarn global add @jstz-dev/cli` is that the package manager fetches the package from the remote repository and then runs `install.js` that actually downloads the CLI binary from the release page of this repository. The actual executable that gets hit when a user runs `jstz` is this `run.mjs` file that spawns the CLI process.

# Manually testing the PR

To test this before releases are created in this repository, I prepared a test repo with a release. A test branch `huanchengchang-jstz-275-4-test` is also created for demonstration before this branch is merged.

```sh
$ yarn global add yarn add 'https://gitpkg.vercel.app/jstz-dev/jstz/packages/cli/main?huanchengchang-jstz-275-4-test'
$ which jstz
$ jstz account list
```
and the CLI should work. Can also try with a linux container:
```sh
$ docker run -it --rm --entrypoint sh node:16-alpine -c "yarn global add 'https://gitpkg.vercel.app/jstz-dev/jstz/packages/cli/main?huanchengchang-jstz-275-4-test' && sh"
```

Tested with node v14, 16, 18, and 23.