### PR TITLE
fix(cli): add `container` flag to sandbox config

### DIFF
--- a/crates/jstz_cli/src/bridge/deposit.rs
+++ b/crates/jstz_cli/src/bridge/deposit.rs
@@ -43,7 +43,7 @@ pub async fn exec(
     let pkh = to_pkh.to_base58();
     debug!("resolved `to` -> {}", &pkh);
 
-    let contract = match using_jstzd() {
+    let contract = match using_jstzd() || cfg.sandbox().is_ok_and(|c| c.container) {
         // Since jstz contracts are loaded as bootstrap contracts in jstzd,
         // octez-client does not recognise them by alias, but addresses
         // remain constant for bootstrap contracts, so we can use the KT1 address here

--- a/crates/jstz_cli/src/config.rs
+++ b/crates/jstz_cli/src/config.rs
@@ -272,6 +272,9 @@ pub struct SandboxConfig {
     pub octez_rollup_node_dir: PathBuf,
     /// Pid of the pid
     pub pid: u32,
+    /// Flag indicating if the sandbox is using jstzd in a container
+    #[serde(default)]
+    pub container: bool,
 }
 
 #[derive(SerializeDisplay, DeserializeFromStr, Debug, Clone, PartialEq, Eq, Hash)]
@@ -363,12 +366,14 @@ impl Config {
         Ok(config)
     }
 
+    // for running jstzd in the host environment only
     fn fill_in_jstzd_config(&mut self, jstzd_config: JstzdConfig) -> Result<()> {
         self.sandbox = Some(SandboxConfig {
             octez_client_dir: PathBuf::from_str(&jstzd_config.octez_client.base_dir)?,
             octez_node_dir: PathBuf::new(),
             octez_rollup_node_dir: PathBuf::new(),
             pid: 0,
+            container: false,
         });
         self.jstzd_config = Some(jstzd_config);
         Ok(())
@@ -584,7 +589,8 @@ mod tests {
                 octez_client_dir: PathBuf::from_str("/base").unwrap(),
                 octez_node_dir: PathBuf::new(),
                 octez_rollup_node_dir: PathBuf::new(),
-                pid: 0
+                pid: 0,
+                container: false
             }
         );
     }

--- a/crates/jstz_cli/src/sandbox/container.rs
+++ b/crates/jstz_cli/src/sandbox/container.rs
@@ -71,6 +71,7 @@ pub(crate) async fn start_container(
         octez_node_dir: PathBuf::new(),
         octez_rollup_node_dir: PathBuf::new(),
         pid: 0,
+        container: true,
     });
     cfg.save()?;
 

--- a/crates/jstz_cli/src/sandbox/daemon.rs
+++ b/crates/jstz_cli/src/sandbox/daemon.rs
@@ -616,6 +616,7 @@ pub async fn run_sandbox(cfg: &mut Config) -> Result<()> {
         octez_client_dir: TempDir::with_prefix("octez_client")?.into_path(), // into_path() causes temp directories to be persisted!
         octez_node_dir: TempDir::with_prefix("octez_node")?.into_path(),
         octez_rollup_node_dir: TempDir::with_prefix("octez_rollup_node")?.into_path(),
+        container: false,
     };
 
     cfg.sandbox = Some(sandbox_cfg);


### PR DESCRIPTION
# Context

Part of JSTZ-274.
[JSTZ-274](https://linear.app/tezos/issue/JSTZ-274/run-jstzd-with-jstz-sandbox-start).

# Description

Since now jstzd can also run in a container, we need to identify such cases to use the fixed address for the bridge contract rather than using the alias. To achieve this, a flag `container` is added to the sandbox config. This flag is set only when the sandbox container is in use.

# Manually testing the PR

Tested this manually.
