### PR TITLE
fix(jstzd): replace localhost with 0.0.0.0

### DIFF
--- a/crates/jstz_cli/src/sandbox/container.rs
+++ b/crates/jstz_cli/src/sandbox/container.rs
@@ -181,11 +181,11 @@ async fn create_config_file_and_client_dir() -> Result<(PathBuf, PathBuf)> {
         .into_path();
     let content = serde_json::to_string(&serde_json::json!({
         "octez_client": {
-            "octez_node_endpoint": format!("http://localhost:{SANDBOX_OCTEZ_NODE_RPC_PORT}"),
+            "octez_node_endpoint": format!("http://0.0.0.0:{SANDBOX_OCTEZ_NODE_RPC_PORT}"),
             "base_dir": JSTZD_OCTEZ_CLIENT_DIR_PATH,
         },
         "octez_node": {
-            "rpc_endpoint": format!("localhost:{SANDBOX_OCTEZ_NODE_RPC_PORT}")
+            "rpc_endpoint": format!("0.0.0.0:{SANDBOX_OCTEZ_NODE_RPC_PORT}")
         },
     })).context("Failed to serialise sandbox config")?;
     let config_file_path = NamedTempFile::new()
@@ -239,6 +239,7 @@ fn new_create_container_config(
             mounts: create_mounts(mounts),
             port_bindings: create_port_bindings(ports.as_ref()),
             auto_remove: Some(true),
+            network_mode: Some("bridge".to_string()),
             ..Default::default()
         }),
         attach_stdin: Some(true),
@@ -439,6 +440,7 @@ mod tests {
                             host_port: Some("1234".to_owned()),
                         }])
                     )])),
+                    network_mode: Some("bridge".to_owned()),
                     auto_remove: Some(true),
                     ..Default::default()
                 }),
@@ -478,11 +480,11 @@ mod tests {
             value,
             serde_json::json!({
                 "octez_client": {
-                    "octez_node_endpoint": format!("http://localhost:{SANDBOX_OCTEZ_NODE_RPC_PORT}"),
+                    "octez_node_endpoint": format!("http://0.0.0.0:{SANDBOX_OCTEZ_NODE_RPC_PORT}"),
                     "base_dir": super::JSTZD_OCTEZ_CLIENT_DIR_PATH,
                 },
                 "octez_node": {
-                    "rpc_endpoint": format!("localhost:{SANDBOX_OCTEZ_NODE_RPC_PORT}")
+                    "rpc_endpoint": format!("0.0.0.0:{SANDBOX_OCTEZ_NODE_RPC_PORT}")
                 },
             })
         );

--- a/crates/jstzd/src/config.rs
+++ b/crates/jstzd/src/config.rs
@@ -6,6 +6,7 @@ use crate::{
     jstz_rollup_path, EXCHANGER_ADDRESS, JSTZ_NATIVE_BRIDGE_ADDRESS, JSTZ_ROLLUP_ADDRESS,
 };
 use anyhow::{Context, Result};
+use http::Uri;
 use jstz_node::config::JstzNodeConfig;
 use octez::r#async::endpoint::Endpoint;
 use octez::r#async::protocol::{
@@ -24,7 +25,7 @@ use tezos_crypto_rs::hash::SmartRollupHash;
 use tokio::io::AsyncReadExt;
 
 const DEFAULT_JSTZD_SERVER_PORT: u16 = 54321;
-const DEFAULT_JSTZ_NODE_PORT: u16 = 8933;
+const DEFAULT_JSTZ_NODE_ENDPOINT: &str = "0.0.0.0:8933";
 const ACTIVATOR_PK: &str = "edpkuSLWfVU1Vq7Jg9FucPyKmma6otcMHac9zG4oU1KMHSTBpJuGQ2";
 pub const BOOTSTRAP_CONTRACT_NAMES: [(&str, &str); 2] = [
     ("exchanger", EXCHANGER_ADDRESS),
@@ -111,7 +112,8 @@ pub(crate) async fn build_config(
     .build()
     .unwrap();
 
-    let jstz_node_rpc_endpoint = Endpoint::localhost(DEFAULT_JSTZ_NODE_PORT);
+    let jstz_node_rpc_endpoint =
+        Endpoint::try_from(Uri::from_static(DEFAULT_JSTZ_NODE_ENDPOINT)).unwrap();
     let jstz_node_config = JstzNodeConfig::new(
         &jstz_node_rpc_endpoint,
         &octez_rollup_config.rpc_endpoint,

--- a/crates/octez/src/async/node.rs
+++ b/crates/octez/src/async/node.rs
@@ -46,6 +46,8 @@ impl OctezNode {
                 // the node executable does not accept the scheme part
                 "--rpc-addr",
                 &rpc_endpoint.to_authority(),
+                "--allow-all-rpc",
+                &rpc_endpoint.to_authority(),
                 "--connections",
                 num_connections.to_string().as_str(),
                 "--net-addr",


### PR DESCRIPTION
# Context

Part of JSTZ-273.
[JSTZ-273](https://linear.app/tezos/issue/JSTZ-273/ship-jstzd-in-a-container)

# Description

Since for now jstzd lives in a container and interacts with the host environment, everything inside the container that is exposed to the host environment needs to sit at address 0.0.0.0 instead of 127.0.0.1 or localhost to ensure that traffic can be sent back to the host environment. For octez node specifically, one new flag `--allow-all-rpc` is required for 0.0.0.0.

# Manually testing the PR

Tested manually by calling `curl localhost:18730/chains/main/blocks/head` from the host environment. Block information was returned as expected.
