### PR TITLE
ci: set default octez tag for images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,6 +34,17 @@ on:
         value: ${{ jobs.build-image.outputs.tag }}
 
 jobs:
+  set-octez-tag:
+    name: Set octez tag for workflows triggered by tags
+    runs-on: ubuntu-latest
+    outputs:
+      octez-tag: ${{ steps.run.outputs.OCTEZ_TAG }}
+    steps:
+      - id: run
+        run: |
+          input_tag=${{ inputs.octez-tag }}
+          octez_tag=${input_tag:-"master_d21359af_20241220171048"}
+          echo "OCTEZ_TAG=${octez_tag}" >> ${GITHUB_OUTPUT}
   build-kernel:
     name: Build (Kernel)
     runs-on: [x86_64, linux, nix]
@@ -54,7 +65,7 @@ jobs:
           path: result/lib/jstz_kernel.wasm
   build-image:
     name: Build image
-    needs: [build-kernel]
+    needs: [build-kernel, set-octez-tag]
     strategy:
       matrix:
         include:
@@ -68,7 +79,7 @@ jobs:
             dockerfile: ./crates/jstz_node/Dockerfile
     uses: jstz-dev/jstz/.github/workflows/docker-multiplatform.yml@main
     with:
-      octez-tag: ${{ inputs.octez-tag }}
+      octez-tag: ${{ needs.set-octez-tag.outputs.octez-tag }}
       docker_registry: ghcr.io
       docker_image_base: jstz-dev/jstz
       image: ${{ matrix.image }}


### PR DESCRIPTION
# Context

Part of JSTZ-286.
[JSTZ-286](https://linear.app/tezos/issue/JSTZ-286/build-multiplatform-images)

# Description

Set default octez tag for builds triggered by tag events. Normally when the workflow is triggered, an input value `octez-tag` is provided, but when the workflow is triggered by a tag event, there is no way of getting that value, so we need to set a default value. This value should be identical to the octez version that is used during development and testing, in our case, in nix, but currently the default value set in this PR is different from that nix version because the nix version does not work well and I don't have enough time figuring out how to update that for now.

# Manually testing the PR

Tested by temporarily setting the workflow input `octez-tag` to optional and triggered a run without any input value. The [test run](https://github.com/jstz-dev/jstz/actions/runs/12944764073) still worked and the default value was set.
