### PR TITLE
fix(jstzd): remove job limit in docker build

### DIFF
--- a/crates/jstzd/Dockerfile
+++ b/crates/jstzd/Dockerfile
@@ -11,7 +11,7 @@ ADD . .
 ARG KERNEL_PATH
 COPY $KERNEL_PATH crates/jstzd/resources/jstz_rollup/jstz_kernel.wasm
 # release build is required for rust-embed to pack the resource files into the executable
-RUN KERNEL_DEST_DIR=/jstzd_kernel_files RUSTFLAGS='-C target-feature=-crt-static' cargo build --jobs 1 --bin jstzd --release --features build-image
+RUN KERNEL_DEST_DIR=/jstzd_kernel_files RUSTFLAGS='-C target-feature=-crt-static' cargo build --bin jstzd --release --features build-image
 
 FROM alpine AS jstzd
 # libcrypto3, openssl, and musl are needed for jstz-rollup binary


### PR DESCRIPTION
# Context

Closes JSTZ-286.
[JSTZ-286](https://linear.app/tezos/issue/JSTZ-286/build-multiplatform-images)

# Description

Remove the job limit in building docker images for jstzd. The config value `--jobs` was set to prevent the system from using too much resource during cross-compilation, but now there is no need to do cross-compilation, this config value can be removed to speed up the build process.

# Manually testing the PR

N/A
