### PR TITLE
NewAddress -> Address

### DIFF
--- a/crates/jstz_cli/src/bridge/deposit.rs
+++ b/crates/jstz_cli/src/bridge/deposit.rs
@@ -1,4 +1,4 @@
-use jstz_proto::context::new_account::Addressable;
+use jstz_proto::context::account::Addressable;
 use log::{debug, info};
 
 use crate::{

--- a/crates/jstz_cli/src/bridge/withdraw.rs
+++ b/crates/jstz_cli/src/bridge/withdraw.rs
@@ -6,7 +6,7 @@ use crate::{
     term::styles,
     utils::AddressOrAlias,
 };
-use jstz_proto::context::new_account::Addressable;
+use jstz_proto::context::account::Addressable;
 use log::debug;
 
 pub async fn exec(

--- a/crates/jstz_cli/src/config.rs
+++ b/crates/jstz_cli/src/config.rs
@@ -3,7 +3,7 @@ use jstz_crypto::{
     public_key::PublicKey, public_key_hash::PublicKeyHash, secret_key::SecretKey,
     smart_function_hash::SmartFunctionHash,
 };
-use jstz_proto::context::new_account::NewAddress;
+use jstz_proto::context::account::Address;
 use log::debug;
 use octez::{OctezClient, OctezNode, OctezRollupNode};
 use serde::{Deserialize, Serialize};
@@ -50,7 +50,7 @@ pub enum Account {
 }
 
 impl Account {
-    pub fn address(&self) -> NewAddress {
+    pub fn address(&self) -> Address {
         match self {
             Account::User(user) => user.address.clone().into(),
             Account::SmartFunction(sf) => sf.address.clone().into(),
@@ -149,7 +149,7 @@ impl AccountConfig {
 }
 
 impl AddressOrAlias {
-    pub fn resolve(&self, cfg: &Config) -> Result<NewAddress> {
+    pub fn resolve(&self, cfg: &Config) -> Result<Address> {
         match self {
             AddressOrAlias::Address(address) => Ok(address.clone()),
             AddressOrAlias::Alias(alias) => {
@@ -166,7 +166,7 @@ impl AddressOrAlias {
     pub fn resolve_or_use_current_user(
         account: Option<AddressOrAlias>,
         cfg: &Config,
-    ) -> Result<NewAddress> {
+    ) -> Result<Address> {
         match account {
             Some(account) => account.resolve(cfg),
             None => cfg
@@ -183,7 +183,7 @@ impl AddressOrAlias {
         &self,
         cfg: &Config,
         network: &Option<NetworkName>,
-    ) -> Result<NewAddress> {
+    ) -> Result<Address> {
         match self {
             AddressOrAlias::Address(address) => Ok(address.clone()),
             AddressOrAlias::Alias(alias) => {
@@ -196,7 +196,7 @@ impl AddressOrAlias {
                         alias
                     ))?;
 
-                let address = NewAddress::from_base58(&alias_info.address)
+                let address = Address::from_base58(&alias_info.address)
                     .map_err(|e| user_error!("{}", e))?;
 
                 Ok(address)

--- a/crates/jstz_cli/src/deploy.rs
+++ b/crates/jstz_cli/src/deploy.rs
@@ -1,6 +1,6 @@
 use boa_engine::JsError;
 use jstz_proto::{
-    context::new_account::ParsedCode,
+    context::account::ParsedCode,
     operation::{Content, DeployFunction, Operation, SignedOperation},
     receipt::{ReceiptContent, ReceiptResult},
 };

--- a/crates/jstz_cli/src/jstz.rs
+++ b/crates/jstz_cli/src/jstz.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Result};
 use jstz_crypto::smart_function_hash::SmartFunctionHash;
 use jstz_proto::{
     api::KvValue,
-    context::new_account::{Addressable, NewAddress, Nonce},
+    context::account::{Address, Addressable, Nonce},
     operation::{OperationHash, SignedOperation},
     receipt::Receipt,
 };
@@ -28,7 +28,7 @@ impl JstzClient {
         }
     }
 
-    pub fn logs_stream(&self, address: &NewAddress) -> EventSource {
+    pub fn logs_stream(&self, address: &Address) -> EventSource {
         let url = format!("{}/logs/{}/stream", self.endpoint, address);
         EventSource::get(url)
     }
@@ -50,7 +50,7 @@ impl JstzClient {
         }
     }
 
-    pub async fn get_nonce(&self, address: &NewAddress) -> Result<Nonce> {
+    pub async fn get_nonce(&self, address: &Address) -> Result<Nonce> {
         let response = self
             .get(&format!("{}/accounts/{}/nonce", self.endpoint, address))
             .await?;
@@ -86,7 +86,7 @@ impl JstzClient {
         }
     }
 
-    pub async fn get_balance(&self, address: &NewAddress) -> Result<u64> {
+    pub async fn get_balance(&self, address: &Address) -> Result<u64> {
         let response = self
             .get(&format!("{}/accounts/{}/balance", self.endpoint, address))
             .await?;
@@ -105,7 +105,7 @@ impl JstzClient {
 
     pub async fn get_value(
         &self,
-        address: &NewAddress,
+        address: &Address,
         key: &str,
     ) -> Result<Option<KvValue>> {
         let response = self
@@ -128,7 +128,7 @@ impl JstzClient {
 
     pub async fn get_subkey_list(
         &self,
-        address: &NewAddress,
+        address: &Address,
         key: &Option<String>,
     ) -> Result<Option<Vec<String>>> {
         let url = match key {

--- a/crates/jstz_cli/src/repl/debug_api/account.rs
+++ b/crates/jstz_cli/src/repl/debug_api/account.rs
@@ -6,10 +6,10 @@ use boa_engine::{
 };
 use jstz_core::runtime;
 use jstz_crypto::{hash::Hash, smart_function_hash::SmartFunctionHash};
-use jstz_proto::context::new_account::{Account, NewAddress};
+use jstz_proto::context::account::{Account, Address};
 
-fn try_parse_address(account: &str) -> JsResult<NewAddress> {
-    NewAddress::from_base58(account).map_err(|_| {
+fn try_parse_address(account: &str) -> JsResult<Address> {
+    Address::from_base58(account).map_err(|_| {
         JsNativeError::typ()
             .with_message("Could not parse the address.")
             .into()
@@ -124,7 +124,7 @@ impl AccountApi {
 
 #[cfg(test)]
 mod tests {
-    use jstz_proto::context::new_account::Addressable;
+    use jstz_proto::context::account::Addressable;
 
     use super::*;
 
@@ -135,12 +135,12 @@ mod tests {
     fn test_try_parse_address() {
         // Test valid tz1 address
         let result = try_parse_address(TEST_TZ1).unwrap();
-        assert!(matches!(result, NewAddress::User(_)));
+        assert!(matches!(result, Address::User(_)));
         assert_eq!(result.to_base58(), TEST_TZ1);
 
         // Test valid KT1 address
         let result = try_parse_address(TEST_KT1).unwrap();
-        assert!(matches!(result, NewAddress::SmartFunction(_)));
+        assert!(matches!(result, Address::SmartFunction(_)));
         assert_eq!(result.to_base58(), TEST_KT1);
     }
 

--- a/crates/jstz_cli/src/run.rs
+++ b/crates/jstz_cli/src/run.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use anyhow::bail;
 use http::{HeaderMap, Method, Uri};
-use jstz_proto::context::new_account::{Addressable, NewAddress};
+use jstz_proto::context::account::{Address, Addressable};
 use jstz_proto::executor::JSTZ_HOST;
 use jstz_proto::{
     operation::{Content as OperationContent, Operation, RunFunction, SignedOperation},
@@ -100,7 +100,7 @@ pub async fn exec(
 
     // 3. Construct the signed operation
     let nonce = jstz_client
-        .get_nonce(&NewAddress::User(user.address.clone()))
+        .get_nonce(&Address::User(user.address.clone()))
         .await?;
 
     // SAFETY: `url` is a valid URI since URLs are a subset of  URIs and `url_object` is a valid URL.
@@ -195,7 +195,7 @@ pub async fn exec(
     Ok(())
 }
 
-async fn spawn_trace(address: &NewAddress, jstz_client: &JstzClient) -> Result<()> {
+async fn spawn_trace(address: &Address, jstz_client: &JstzClient) -> Result<()> {
     let event_source = jstz_client.logs_stream(address);
     // need to use mpsc instead of oneshot because of the loop
     let (tx, mut rx) = mpsc::channel::<()>(1);

--- a/crates/jstz_cli/src/utils.rs
+++ b/crates/jstz_cli/src/utils.rs
@@ -1,6 +1,6 @@
 use crate::error::{Error, Result};
 use anyhow::anyhow;
-use jstz_proto::context::new_account::NewAddress;
+use jstz_proto::context::account::Address;
 use std::{
     env,
     fmt::{self, Display},
@@ -13,7 +13,7 @@ const JSTZ_ADDRESS_PREFIXES: [&str; 4] = ["tz1", "tz2", "tz3", "KT1"];
 
 #[derive(Clone, Debug)]
 pub enum AddressOrAlias {
-    Address(NewAddress),
+    Address(Address),
     Alias(String),
 }
 
@@ -28,7 +28,7 @@ impl FromStr for AddressOrAlias {
         if is_jstz_address {
             Ok(Self::Address(
                 address_or_alias
-                    .parse::<NewAddress>()
+                    .parse::<Address>()
                     .map_err(|e| anyhow!("{}", e))?,
             ))
         } else {
@@ -102,15 +102,12 @@ mod tests {
         let result = AddressOrAlias::from_str(TEST_KT1).unwrap();
         assert!(matches!(
             result,
-            AddressOrAlias::Address(NewAddress::SmartFunction(_))
+            AddressOrAlias::Address(Address::SmartFunction(_))
         ));
 
         // Test valid tz1 address
         let result = AddressOrAlias::from_str(TEST_TZ1).unwrap();
-        assert!(matches!(
-            result,
-            AddressOrAlias::Address(NewAddress::User(_))
-        ));
+        assert!(matches!(result, AddressOrAlias::Address(Address::User(_))));
 
         // Test alias
         let result = AddressOrAlias::from_str(TEST_ALIAS).unwrap();

--- a/crates/jstz_kernel/src/inbox.rs
+++ b/crates/jstz_kernel/src/inbox.rs
@@ -1,5 +1,5 @@
 use jstz_core::BinEncodable;
-use jstz_proto::context::new_account::NewAddress;
+use jstz_proto::context::account::Address;
 use jstz_proto::operation::{external::Deposit, ExternalOperation, SignedOperation};
 use num_traits::ToPrimitive;
 use tezos_crypto_rs::hash::ContractKt1Hash;
@@ -82,7 +82,7 @@ fn read_transfer(
             if is_valid_native_deposit(rt, &ticket, ticketer) {
                 let amount = ticket.amount().to_u64()?;
                 let address = tez_ticket.0 .0.to_b58check();
-                let receiver = NewAddress::from_base58(&address).ok()?;
+                let receiver = Address::from_base58(&address).ok()?;
                 let content = Deposit {
                     inbox_id,
                     amount,
@@ -195,7 +195,7 @@ mod test {
     use jstz_crypto::smart_function_hash::SmartFunctionHash;
     use jstz_mock::message::native_deposit::MockNativeDeposit;
     use jstz_mock::{host::JstzMockHost, message::fa_deposit::MockFaDeposit};
-    use jstz_proto::context::new_account::{Addressable, NewAddress};
+    use jstz_proto::context::account::{Address, Addressable};
     use jstz_proto::operation::external;
     use tezos_crypto_rs::hash::{ContractKt1Hash, HashTrait};
     use tezos_smart_rollup::types::SmartRollupAddress;
@@ -299,8 +299,8 @@ mod test {
                 ),
                 proxy_smart_function.map(|p| {
                     match p {
-                        NewAddress::User(_) => panic!("Unexpected proxy"),
-                        NewAddress::SmartFunction(sfh) => sfh,
+                        Address::User(_) => panic!("Unexpected proxy"),
+                        Address::SmartFunction(sfh) => sfh,
                     }
                 })
             );

--- a/crates/jstz_kernel/src/lib.rs
+++ b/crates/jstz_kernel/src/lib.rs
@@ -66,8 +66,8 @@ mod test {
         message::{fa_deposit::MockFaDeposit, native_deposit::MockNativeDeposit},
     };
     use jstz_proto::context::{
-        new_account::NewAddress,
-        new_account::{Account, ParsedCode},
+        account::Address,
+        account::{Account, ParsedCode},
         ticket_table::TicketTable,
     };
     use tezos_smart_rollup::types::{Contract, PublicKeyHash};
@@ -95,7 +95,7 @@ mod test {
                 let amount = Account::balance(
                     host.rt(),
                     tx,
-                    &NewAddress::User(jstz_crypto::public_key_hash::PublicKeyHash::Tz1(
+                    &Address::User(jstz_crypto::public_key_hash::PublicKeyHash::Tz1(
                         tz1.into(),
                     )),
                 )
@@ -118,7 +118,7 @@ mod test {
         let proxy = crate::executor::smart_function::Script::deploy(
             host.rt(),
             tx,
-            &NewAddress::User(
+            &Address::User(
                 jstz_crypto::public_key_hash::PublicKeyHash::from_base58(MOCK_SOURCE)
                     .unwrap(),
             ),
@@ -142,7 +142,7 @@ mod test {
                 let proxy_balance = TicketTable::get_balance(
                     host.rt(),
                     tx,
-                    &NewAddress::SmartFunction(proxy),
+                    &Address::SmartFunction(proxy),
                     &ticket_hash,
                 )
                 .unwrap();
@@ -173,7 +173,7 @@ mod test {
                 let proxy_balance = TicketTable::get_balance(
                     host.rt(),
                     &mut tx,
-                    &NewAddress::SmartFunction(proxy),
+                    &Address::SmartFunction(proxy),
                     &ticket_hash,
                 )
                 .unwrap();

--- a/crates/jstz_node/src/services/accounts.rs
+++ b/crates/jstz_node/src/services/accounts.rs
@@ -6,7 +6,7 @@ use axum::{
 use jstz_core::BinEncodable;
 use jstz_proto::{
     api::KvValue,
-    context::new_account::{
+    context::account::{
         Account, Nonce, ParsedCode, SmartFunctionAccount, UserAccount,
         ACCOUNTS_PATH_PREFIX,
     },

--- a/crates/jstz_node/src/services/logs/db.rs
+++ b/crates/jstz_node/src/services/logs/db.rs
@@ -6,7 +6,7 @@ use anyhow::{anyhow, Result};
 use jstz_api::js_log::LogLevel;
 use jstz_crypto::public_key_hash::PublicKeyHash;
 use jstz_proto::{
-    context::new_account::NewAddress, js_logger::LogRecord, request_logger::RequestEvent,
+    context::account::Address, js_logger::LogRecord, request_logger::RequestEvent,
 };
 use r2d2::{Pool, PooledConnection};
 use r2d2_sqlite::SqliteConnectionManager;
@@ -103,7 +103,7 @@ impl Db {
 
     pub async fn logs_by_address(
         &self,
-        function_address: NewAddress,
+        function_address: Address,
         limit: usize,
         offset: usize,
     ) -> QueryResponseResult {
@@ -117,7 +117,7 @@ impl Db {
 
     pub async fn logs_by_address_and_request_id(
         &self,
-        function_address: NewAddress,
+        function_address: Address,
         request_id: String,
     ) -> QueryResponseResult {
         let conn = self.connection().await?;

--- a/crates/jstz_node/src/services/logs/mod.rs
+++ b/crates/jstz_node/src/services/logs/mod.rs
@@ -50,7 +50,7 @@ mod persistent_logging {
         extract::{Path, Query, State},
         Json,
     };
-    use jstz_proto::context::new_account::NewAddress;
+    use jstz_proto::context::account::Address;
 
     pub async fn persistent_logs(
         State(AppState { db, .. }): State<AppState>,

--- a/crates/jstz_node/src/services/logs/mod.rs
+++ b/crates/jstz_node/src/services/logs/mod.rs
@@ -57,7 +57,7 @@ mod persistent_logging {
         Path(address): Path<String>,
         Query(Pagination { limit, offset }): Query<Pagination>,
     ) -> ServiceResult<Json<Vec<LogRecord>>> {
-        let address = NewAddress::from_base58(&address)
+        let address = Address::from_base58(&address)
             .map_err(|e| ServiceError::BadRequest(e.to_string()))?;
         let result = db.logs_by_address(address, offset, limit).await?;
 
@@ -69,7 +69,7 @@ mod persistent_logging {
         Path(address): Path<String>,
         Path(request_id): Path<String>,
     ) -> ServiceResult<Json<Vec<LogRecord>>> {
-        let address = NewAddress::from_base58(&address)
+        let address = Address::from_base58(&address)
             .map_err(|e| ServiceError::BadRequest(e.to_string()))?;
 
         let result = db

--- a/crates/jstz_proto/src/api/ledger.rs
+++ b/crates/jstz_proto/src/api/ledger.rs
@@ -15,7 +15,7 @@ use jstz_core::{
 use jstz_crypto::smart_function_hash::SmartFunctionHash;
 
 use crate::{
-    context::new_account::{Account, Amount, NewAddress},
+    context::account::{Account, Address, Amount},
     error::Result,
 };
 
@@ -42,7 +42,7 @@ impl Ledger {
     fn balance(
         rt: &impl HostRuntime,
         tx: &mut Transaction,
-        addr: &NewAddress,
+        addr: &Address,
     ) -> Result<u64> {
         let balance = Account::balance(rt, tx, addr)?;
 
@@ -53,7 +53,7 @@ impl Ledger {
         &self,
         rt: &impl HostRuntime,
         tx: &mut Transaction,
-        dst: &NewAddress,
+        dst: &Address,
         amount: Amount,
     ) -> Result<()> {
         Account::transfer(rt, tx, &self.address, dst, amount)?;
@@ -66,7 +66,7 @@ pub struct LedgerApi {
     pub address: SmartFunctionHash,
 }
 
-pub(crate) fn js_value_to_pkh(value: &JsValue) -> Result<NewAddress> {
+pub(crate) fn js_value_to_pkh(value: &JsValue) -> Result<Address> {
     let pkh_string = value
         .as_string()
         .ok_or_else(|| {
@@ -75,7 +75,7 @@ pub(crate) fn js_value_to_pkh(value: &JsValue) -> Result<NewAddress> {
         })
         .map(JsString::to_std_string_escaped)?;
 
-    NewAddress::from_base58(&pkh_string)
+    Address::from_base58(&pkh_string)
 }
 
 impl Ledger {

--- a/crates/jstz_proto/src/api/smart_function.rs
+++ b/crates/jstz_proto/src/api/smart_function.rs
@@ -15,7 +15,7 @@ use jstz_core::{
 use jstz_crypto::{hash::Hash, smart_function_hash::SmartFunctionHash};
 
 use crate::{
-    context::new_account::{Account, Amount, NewAddress, ParsedCode},
+    context::account::{Account, Address, Amount, ParsedCode},
     executor::{
         smart_function::{headers, HostScript, Script},
         JSTZ_HOST,
@@ -76,7 +76,7 @@ impl SmartFunction {
         }
 
         // 2. Deploy the smart function
-        let deployed = NewAddress::SmartFunction(Script::deploy(
+        let deployed = Address::SmartFunction(Script::deploy(
             hrt,
             tx,
             deployer,
@@ -115,7 +115,7 @@ impl SmartFunction {
                 // 2. Set the referrer of the request to the current smart function address
                 headers::test_and_set_referrer(
                     &request_deref,
-                    &NewAddress::SmartFunction(self_address.clone()),
+                    &Address::SmartFunction(self_address.clone()),
                 )?;
 
                 // 3. Load, init and run!
@@ -280,8 +280,8 @@ mod test {
 
     use crate::{
         context::{
-            new_account::NewAddress,
-            new_account::{Account, ParsedCode},
+            account::Address,
+            account::{Account, ParsedCode},
             ticket_table::TicketTable,
         },
         executor::smart_function::{self, register_web_apis, Script},
@@ -306,8 +306,7 @@ mod test {
         let amount = 100;
 
         let operation_hash = Blake2b::from(b"operation_hash".as_ref());
-        let receiver =
-            NewAddress::User(PublicKeyHash::digest(b"receiver address").unwrap());
+        let receiver = Address::User(PublicKeyHash::digest(b"receiver address").unwrap());
         let http_request = http::Request::builder()
             .method(Method::POST)
             .uri("tezos://jstz/withdraw")
@@ -348,7 +347,7 @@ mod test {
         let mut mock_host = JstzMockHost::default();
         let host = mock_host.rt();
         let mut tx = Transaction::default();
-        let source = NewAddress::User(jstz_mock::account1());
+        let source = Address::User(jstz_mock::account1());
         let code = r#"
         export default (request) => {
             const withdrawRequest = new Request("tezos://jstz/withdraw", {
@@ -417,8 +416,8 @@ mod test {
 
     #[test]
     fn host_script_fa_withdraw_from_smart_function_succeeds() {
-        let receiver = NewAddress::User(jstz_mock::account1());
-        let source = NewAddress::User(jstz_mock::account2());
+        let receiver = Address::User(jstz_mock::account1());
+        let source = Address::User(jstz_mock::account2());
         let ticketer = jstz_mock::kt1_account1();
         let ticketer_string = ticketer.clone();
         let l1_proxy_contract = ticketer.clone();
@@ -517,7 +516,7 @@ mod test {
         let balance = TicketTable::get_balance(
             host,
             &mut tx,
-            &NewAddress::SmartFunction(token_smart_function),
+            &Address::SmartFunction(token_smart_function),
             &ticket_hash,
         )
         .unwrap();

--- a/crates/jstz_proto/src/api/smart_function.rs
+++ b/crates/jstz_proto/src/api/smart_function.rs
@@ -113,10 +113,7 @@ impl SmartFunction {
                         )
                     })?;
                 // 2. Set the referrer of the request to the current smart function address
-                headers::test_and_set_referrer(
-                    &request_deref,
-                    &Address::SmartFunction(self_address.clone()),
-                )?;
+                headers::test_and_set_referrer(&request_deref, self_address)?;
 
                 // 3. Load, init and run!
                 Script::load_init_run(

--- a/crates/jstz_proto/src/context/mod.rs
+++ b/crates/jstz_proto/src/context/mod.rs
@@ -1,5 +1,5 @@
 // TODO: remove account and rename new_account to account
 // https://linear.app/tezos/issue/JSTZ-253/remove-old-accountrs
-pub mod new_account;
+pub mod account;
 pub mod receipt;
 pub mod ticket_table;

--- a/crates/jstz_proto/src/context/mod.rs
+++ b/crates/jstz_proto/src/context/mod.rs
@@ -1,5 +1,3 @@
-// TODO: remove account and rename new_account to account
-// https://linear.app/tezos/issue/JSTZ-253/remove-old-accountrs
 pub mod account;
 pub mod receipt;
 pub mod ticket_table;

--- a/crates/jstz_proto/src/context/ticket_table.rs
+++ b/crates/jstz_proto/src/context/ticket_table.rs
@@ -6,7 +6,7 @@ use tezos_smart_rollup::{
     storage::path::{self, OwnedPath, RefPath},
 };
 
-use super::new_account::{Addressable, Amount};
+use super::account::{Addressable, Amount};
 
 use crate::error::Result;
 
@@ -101,7 +101,7 @@ impl TicketTable {
 
 #[cfg(test)]
 mod test {
-    use crate::context::new_account::NewAddress;
+    use crate::context::account::Address;
 
     use super::*;
     use jstz_core::kv::Transaction;
@@ -112,15 +112,15 @@ mod test {
     use jstz_mock::host::JstzMockHost;
     use tezos_smart_rollup_mock::MockHost;
 
-    fn user_address() -> NewAddress {
-        NewAddress::User(
+    fn user_address() -> Address {
+        Address::User(
             PublicKeyHash::from_base58("tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx")
                 .expect("Could not parse pkh"),
         )
     }
 
-    fn smart_function_address() -> NewAddress {
-        NewAddress::SmartFunction(
+    fn smart_function_address() -> Address {
+        Address::SmartFunction(
             SmartFunctionHash::from_base58("KT1RycYvM4EVs6BAXWEsGXaAaRqiMP53KT4w")
                 .expect("Could not parse smart function hash"),
         )

--- a/crates/jstz_proto/src/executor/deposit.rs
+++ b/crates/jstz_proto/src/executor/deposit.rs
@@ -2,7 +2,7 @@ use jstz_core::{host::HostRuntime, kv::Transaction};
 use jstz_crypto::hash::Blake2b;
 
 use crate::{
-    context::new_account::Account,
+    context::account::Account,
     operation::external::Deposit,
     receipt::{DepositReceipt, Receipt},
 };
@@ -35,7 +35,7 @@ mod test {
     use tezos_smart_rollup_mock::MockHost;
 
     use crate::{
-        context::new_account::NewAddress,
+        context::account::Address,
         operation::external::Deposit,
         receipt::{DepositReceipt, ReceiptContent, ReceiptResult},
     };
@@ -50,7 +50,7 @@ mod test {
         let deposit = Deposit {
             inbox_id: 1,
             amount: 20,
-            receiver: NewAddress::User(receiver.clone()),
+            receiver: Address::User(receiver.clone()),
         };
         tx.begin();
         let receipt = execute(&mut host, &mut tx, deposit);
@@ -59,7 +59,7 @@ mod test {
             ReceiptResult::Success(ReceiptContent::Deposit(DepositReceipt {
                 account,
                 updated_balance,
-            })) if account == NewAddress::User(receiver) && updated_balance == 20
+            })) if account == Address::User(receiver) && updated_balance == 20
         ));
         let raw_json_payload = r#"{"hash":[39,12,7,148,87,7,176,168,111,219,214,147,14,123,179,202,232,151,138,59,207,182,101,158,128,98,239,57,236,88,195,42],"result":{"_type":"Success","inner":{"_type":"Deposit","account":"tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx","updated_balance":20}}}"#;
         assert_eq!(raw_json_payload, serde_json::to_string(&receipt).unwrap());

--- a/crates/jstz_proto/src/executor/fa_withdraw.rs
+++ b/crates/jstz_proto/src/executor/fa_withdraw.rs
@@ -19,7 +19,7 @@ use utoipa::ToSchema;
 
 use crate::{
     context::{
-        new_account::{Addressable, Amount, NewAddress},
+        account::{Address, Addressable, Amount},
         ticket_table::TicketTable,
     },
     Error, Result,
@@ -36,7 +36,7 @@ pub struct FaWithdraw {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RoutingInfo {
-    pub receiver: NewAddress,
+    pub receiver: Address,
     pub proxy_l1_contract: ContractKt1Hash,
 }
 
@@ -84,7 +84,7 @@ type OutboxMessageId = String;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema, Encode, Decode)]
 pub struct FaWithdrawReceipt {
-    pub source: NewAddress,
+    pub source: Address,
     pub outbox_message_id: OutboxMessageId,
 }
 
@@ -209,7 +209,7 @@ mod test {
             ticketer: jstz_mock::kt1_account1(),
         };
         let routing_info = RoutingInfo {
-            receiver: NewAddress::User(jstz_mock::account2()),
+            receiver: Address::User(jstz_mock::account2()),
             proxy_l1_contract: jstz_mock::kt1_account1(),
         };
         FaWithdraw {
@@ -223,7 +223,7 @@ mod test {
     fn execute_fa_withdraw_succeeds() {
         let mut rt = MockHost::default();
         let mut tx = Transaction::default();
-        let source = NewAddress::User(jstz_mock::account1());
+        let source = Address::User(jstz_mock::account1());
         let fa_withdrawal = create_fa_withdrawal();
         let FaWithdraw {
             amount,
@@ -291,7 +291,7 @@ mod test {
     fn execute_fa_withdraw_fails_on_insufficient_funds() {
         let mut rt = MockHost::default();
         let mut tx = Transaction::default();
-        let source = NewAddress::User(jstz_mock::account1());
+        let source = Address::User(jstz_mock::account1());
         let fa_withdrawal = create_fa_withdrawal();
 
         tx.begin();
@@ -318,14 +318,14 @@ mod test {
     fn execute_fa_withdraw_fails_on_zero_amount() {
         let mut rt = MockHost::default();
         let mut tx = Transaction::default();
-        let source = NewAddress::User(jstz_mock::account1());
+        let source = Address::User(jstz_mock::account1());
         let ticket_info = TicketInfo {
             id: 1234,
             content: Some(b"random ticket content".to_vec()),
             ticketer: jstz_mock::kt1_account1(),
         };
         let routing_info = RoutingInfo {
-            receiver: NewAddress::User(jstz_mock::account2()),
+            receiver: Address::User(jstz_mock::account2()),
             proxy_l1_contract: jstz_mock::kt1_account1(),
         };
         let fa_withdrawal = FaWithdraw {

--- a/crates/jstz_proto/src/executor/mod.rs
+++ b/crates/jstz_proto/src/executor/mod.rs
@@ -2,7 +2,6 @@ use jstz_core::{host::HostRuntime, kv::Transaction};
 use tezos_crypto_rs::hash::ContractKt1Hash;
 
 use crate::{
-    context::account::Address,
     operation::{self, ExternalOperation, Operation, SignedOperation},
     receipt::{self, Receipt},
     Result,
@@ -32,12 +31,7 @@ fn execute_operation_inner(
             content: operation::Content::DeployFunction(deployment),
             ..
         } => {
-            let result = smart_function::deploy::execute(
-                hrt,
-                tx,
-                &Address::User(source.clone()),
-                deployment,
-            )?;
+            let result = smart_function::deploy::execute(hrt, tx, &source, deployment)?;
 
             Ok(receipt::ReceiptContent::DeployFunction(result))
         }
@@ -48,20 +42,10 @@ fn execute_operation_inner(
             ..
         } => {
             let result = match run.uri.host() {
-                Some(JSTZ_HOST) => smart_function::jstz_run::execute(
-                    hrt,
-                    tx,
-                    ticketer,
-                    &Address::User(source.clone()),
-                    run,
-                )?,
-                _ => smart_function::run::execute(
-                    hrt,
-                    tx,
-                    &Address::User(source.clone()),
-                    run,
-                    operation_hash,
-                )?,
+                Some(JSTZ_HOST) => {
+                    smart_function::jstz_run::execute(hrt, tx, ticketer, &source, run)?
+                }
+                _ => smart_function::run::execute(hrt, tx, &source, run, operation_hash)?,
             };
             Ok(receipt::ReceiptContent::RunFunction(result))
         }

--- a/crates/jstz_proto/src/executor/mod.rs
+++ b/crates/jstz_proto/src/executor/mod.rs
@@ -2,7 +2,7 @@ use jstz_core::{host::HostRuntime, kv::Transaction};
 use tezos_crypto_rs::hash::ContractKt1Hash;
 
 use crate::{
-    context::new_account::NewAddress,
+    context::account::Address,
     operation::{self, ExternalOperation, Operation, SignedOperation},
     receipt::{self, Receipt},
     Result,
@@ -35,7 +35,7 @@ fn execute_operation_inner(
             let result = smart_function::deploy::execute(
                 hrt,
                 tx,
-                &NewAddress::User(source.clone()),
+                &Address::User(source.clone()),
                 deployment,
             )?;
 
@@ -52,13 +52,13 @@ fn execute_operation_inner(
                     hrt,
                     tx,
                     ticketer,
-                    &NewAddress::User(source.clone()),
+                    &Address::User(source.clone()),
                     run,
                 )?,
                 _ => smart_function::run::execute(
                     hrt,
                     tx,
-                    &NewAddress::User(source.clone()),
+                    &Address::User(source.clone()),
                     run,
                     operation_hash,
                 )?,

--- a/crates/jstz_proto/src/executor/smart_function.rs
+++ b/crates/jstz_proto/src/executor/smart_function.rs
@@ -26,7 +26,7 @@ use tezos_smart_rollup::prelude::debug_msg;
 
 use crate::{
     api::{self, TraceData},
-    context::new_account::{Account, Addressable, Amount, NewAddress, ParsedCode},
+    context::account::{Account, Address, Addressable, Amount, ParsedCode},
     js_logger::JsonLogger,
     operation::{OperationHash, RunFunction},
     receipt,
@@ -36,15 +36,12 @@ use crate::{
 
 pub mod headers {
 
-    use crate::context::new_account::Addressable;
+    use crate::context::account::Addressable;
 
     use super::*;
     pub const REFERRER: &str = "Referer";
 
-    pub fn test_and_set_referrer(
-        request: &Request,
-        referer: &NewAddress,
-    ) -> JsResult<()> {
+    pub fn test_and_set_referrer(request: &Request, referer: &Address) -> JsResult<()> {
         if request.headers().deref().contains_key(REFERRER) {
             return Err(JsError::from_native(
                 JsNativeError::error().with_message("Referer already set"),
@@ -452,7 +449,7 @@ pub mod run {
     pub fn execute(
         hrt: &mut impl HostRuntime,
         tx: &mut Transaction,
-        source: &NewAddress,
+        source: &Address,
         run: operation::RunFunction,
         operation_hash: OperationHash,
     ) -> Result<receipt::RunFunctionReceipt> {
@@ -638,7 +635,7 @@ pub mod jstz_run {
             Error,
         };
 
-        use super::{execute, NewAddress};
+        use super::{execute, Address};
 
         fn withdraw_request() -> RunFunction {
             RunFunction {
@@ -668,7 +665,7 @@ pub mod jstz_run {
                 ticketer: jstz_mock::kt1_account1(),
             };
             let routing_info = RoutingInfo {
-                receiver: NewAddress::User(jstz_mock::account2()),
+                receiver: Address::User(jstz_mock::account2()),
                 proxy_l1_contract: jstz_mock::kt1_account1(),
             };
             let fa_withdrawal = FaWithdraw {
@@ -693,7 +690,7 @@ pub mod jstz_run {
         fn execute_fails_on_invalid_host() {
             let mut host = MockHost::default();
             let mut tx = Transaction::default();
-            let source = NewAddress::User(jstz_mock::account1());
+            let source = Address::User(jstz_mock::account1());
             let req = RunFunction {
                 uri: Uri::try_from("tezos://example.com/withdraw").unwrap(),
                 ..withdraw_request()
@@ -709,7 +706,7 @@ pub mod jstz_run {
         fn execute_fails_on_unsupported_path() {
             let mut host = MockHost::default();
             let mut tx = Transaction::default();
-            let source = NewAddress::User(jstz_mock::account1());
+            let source = Address::User(jstz_mock::account1());
             let req = RunFunction {
                 uri: Uri::try_from("tezos://jstz/blahblah").unwrap(),
                 ..withdraw_request()
@@ -725,7 +722,7 @@ pub mod jstz_run {
         fn execute_wthdraw_fails_on_invalid_request_method() {
             let mut host = MockHost::default();
             let mut tx = Transaction::default();
-            let source = NewAddress::User(jstz_mock::account1());
+            let source = Address::User(jstz_mock::account1());
             let req = RunFunction {
                 method: Method::GET,
                 ..withdraw_request()
@@ -744,7 +741,7 @@ pub mod jstz_run {
         fn execute_wthdraw_fails_on_invalid_request_body() {
             let mut host = MockHost::default();
             let mut tx = Transaction::default();
-            let source = NewAddress::User(jstz_mock::account1());
+            let source = Address::User(jstz_mock::account1());
             let req = RunFunction {
                 body: Some(
                     json!({
@@ -775,7 +772,7 @@ pub mod jstz_run {
         fn execute_withdraw_succeeds() {
             let mut host = MockHost::default();
             let mut tx = Transaction::default();
-            let source = NewAddress::User(jstz_mock::account1());
+            let source = Address::User(jstz_mock::account1());
 
             tx.begin();
             Account::add_balance(&host, &mut tx, &source, 10).unwrap();
@@ -800,7 +797,7 @@ pub mod jstz_run {
         fn execute_without_ticketer_succeeds() {
             let mut host = JstzMockHost::default();
             let mut tx = Transaction::default();
-            let source = NewAddress::User(jstz_mock::account1());
+            let source = Address::User(jstz_mock::account1());
             let rt = host.rt();
 
             tx.begin();
@@ -823,7 +820,7 @@ pub mod jstz_run {
         fn execute_fa_withdraw_fails_on_invalid_request_method() {
             let mut host = MockHost::default();
             let mut tx = Transaction::default();
-            let source = NewAddress::User(jstz_mock::account1());
+            let source = Address::User(jstz_mock::account1());
             let req = RunFunction {
                 method: Method::GET,
                 ..fa_withdraw_request()
@@ -842,7 +839,7 @@ pub mod jstz_run {
         fn execute_fa_withdraw_fails_on_invalid_request_body() {
             let mut host = MockHost::default();
             let mut tx = Transaction::default();
-            let source = NewAddress::User(jstz_mock::account1());
+            let source = Address::User(jstz_mock::account1());
             let req = RunFunction {
                 body: Some(
                     json!({
@@ -873,7 +870,7 @@ pub mod jstz_run {
         fn execute_fa_withdraw_succeeds() {
             let mut host = MockHost::default();
             let mut tx = Transaction::default();
-            let source = NewAddress::User(jstz_mock::account1());
+            let source = Address::User(jstz_mock::account1());
 
             let ticket = TicketInfo {
                 id: 1234,
@@ -911,7 +908,7 @@ pub mod deploy {
     pub fn execute(
         hrt: &impl HostRuntime,
         tx: &mut Transaction,
-        source: &NewAddress,
+        source: &Address,
         deployment: operation::DeployFunction,
     ) -> Result<receipt::DeployFunctionReceipt> {
         let operation::DeployFunction {
@@ -935,7 +932,7 @@ pub mod deploy {
         fn execute_deploy_deploys_smart_function_with_kt1_account1() {
             let mut host = JstzMockHost::default();
             let mut tx = Transaction::default();
-            let source = NewAddress::User(jstz_mock::account1());
+            let source = Address::User(jstz_mock::account1());
             let hrt = host.rt();
             tx.begin();
 

--- a/crates/jstz_proto/src/executor/withdraw.rs
+++ b/crates/jstz_proto/src/executor/withdraw.rs
@@ -11,7 +11,7 @@ use tezos_smart_rollup::{
 use tezos_crypto_rs::hash::ContractKt1Hash;
 
 use crate::{
-    context::new_account::{Account, Addressable, Amount, NewAddress},
+    context::account::{Account, Address, Addressable, Amount},
     Error, Result,
 };
 
@@ -20,12 +20,12 @@ const BURN_ENTRYPOINT: &str = "burn";
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Withdrawal {
     pub amount: Amount,
-    pub receiver: NewAddress,
+    pub receiver: Address,
 }
 
 fn create_withdrawal(
     amount: Amount,
-    receiver: &NewAddress,
+    receiver: &Address,
     ticketer: &ContractKt1Hash,
 ) -> Result<OutboxMessage> {
     let receiver_pkh = receiver.to_base58();
@@ -89,7 +89,7 @@ mod test {
     use tezos_smart_rollup_mock::MockHost;
 
     use crate::{
-        context::{new_account::Account, new_account::NewAddress},
+        context::{account::Account, account::Address},
         executor::withdraw::execute_withdraw,
         Error,
     };
@@ -100,10 +100,10 @@ mod test {
     fn execute_withdraw_fails_on_insufficient_funds() {
         let mut host = MockHost::default();
         let mut tx = Transaction::default();
-        let source = NewAddress::User(jstz_mock::account1());
+        let source = Address::User(jstz_mock::account1());
         let withdrawal = Withdrawal {
             amount: 11,
-            receiver: NewAddress::User(jstz_mock::account2()),
+            receiver: Address::User(jstz_mock::account2()),
         };
         let ticketer =
             ContractKt1Hash::from_base58_check(jstz_mock::host::NATIVE_TICKETER).unwrap();
@@ -125,10 +125,10 @@ mod test {
     fn execute_withdraw_succeeds() {
         let mut host = MockHost::default();
         let mut tx = Transaction::default();
-        let source = NewAddress::User(jstz_mock::account1());
+        let source = Address::User(jstz_mock::account1());
         let withdrawal = Withdrawal {
             amount: 10,
-            receiver: NewAddress::User(jstz_mock::account2()),
+            receiver: Address::User(jstz_mock::account2()),
         };
         let ticketer =
             ContractKt1Hash::from_base58_check(jstz_mock::host::NATIVE_TICKETER).unwrap();

--- a/crates/jstz_proto/src/operation.rs
+++ b/crates/jstz_proto/src/operation.rs
@@ -1,5 +1,5 @@
 use crate::{
-    context::new_account::{Account, Amount, NewAddress, Nonce, ParsedCode},
+    context::account::{Account, Address, Amount, Nonce, ParsedCode},
     Error, Result,
 };
 use bincode::{Decode, Encode};
@@ -175,7 +175,7 @@ pub mod external {
         // Amount to deposit
         pub amount: Amount,
         // Receiver address
-        pub receiver: NewAddress,
+        pub receiver: Address,
     }
 
     #[derive(Debug, PartialEq, Eq)]
@@ -186,9 +186,9 @@ pub mod external {
         // Amount to deposit
         pub amount: Amount,
         // Final deposit receiver address
-        pub receiver: NewAddress,
+        pub receiver: Address,
         // Optional proxy contract
-        pub proxy_smart_function: Option<NewAddress>,
+        pub proxy_smart_function: Option<Address>,
         // Ticket hash
         pub ticket_hash: TicketHash,
     }
@@ -241,7 +241,7 @@ pub mod openapi {
 #[cfg(test)]
 mod test {
     use super::{DeployFunction, RunFunction};
-    use crate::{context::new_account::ParsedCode, operation::Content};
+    use crate::{context::account::ParsedCode, operation::Content};
     use http::{HeaderMap, Method, Uri};
     use jstz_core::BinEncodable;
     use serde_json::json;

--- a/crates/jstz_proto/src/receipt.rs
+++ b/crates/jstz_proto/src/receipt.rs
@@ -1,5 +1,5 @@
 use crate::{
-    context::new_account::NewAddress,
+    context::account::Address,
     executor::{fa_deposit::FaDepositReceipt, fa_withdraw::FaWithdrawReceipt},
     operation::OperationHash,
     Result,
@@ -70,7 +70,7 @@ pub struct RunFunctionReceipt {
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Encode, Decode)]
 pub struct DepositReceipt {
-    pub account: NewAddress,
+    pub account: Address,
     pub updated_balance: u64,
 }
 


### PR DESCRIPTION
# Context
final step of migration to support KT1 address
[task link](https://linear.app/tezos/issue/JSTZ-253/rename-old-accountrs)

# Description

* rename the `new_account`, `NewAddress` back to `account` and `Address`
* avoid unnecessary clone inside jstz_proto

# Manually testing the PR

existing test works
