### PR TITLE
Jstz proto: handle tx properly in script run

### DIFF
--- a/crates/jstz_proto/src/executor/smart_function.rs
+++ b/crates/jstz_proto/src/executor/smart_function.rs
@@ -307,14 +307,13 @@ impl Script {
             result,
             |value, _context| {
                 runtime::with_js_hrt_and_tx(|hrt, tx| -> JsResult<()> {
-                    let response = Response::try_from_js(value)?;
-
-                    // If status code is 2xx, commit transaction
-                    if response.ok() {
-                        tx.commit(hrt)?;
-                    } else {
-                        tx.rollback()?;
-                    }
+                    match Response::try_from_js(value) {
+                        // commit if the value returned is a response with a 2xx status code
+                        Ok(response) if response.ok() => {
+                            tx.commit(hrt)?;
+                        }
+                        _ => tx.rollback()?,
+                    };
 
                     Ok(())
                 })


### PR DESCRIPTION
# Context

There is a bug in jstz protocol where the tx isn't properly committed nor rolled back due to the incorrect handling of the parsing of the response type. This will result in incorrect rollup state in case users deploy a smart function that doesn't return a correct `Response` type.

One example is that when we add [support](https://linear.app/tezos/issue/JSTZ-294/support-transfer-in-request) for transfer in request object, we need to ensure that the state updated by the transfer and execution of the smart functions is atomic. This bug will violates the atomicity if the smart function doesn't return a proper response type.



[issue link](https://linear.app/tezos/issue/JSTZ-297/fix-jstz-proto-not-handling-invalid-return-type)

# Description

Change Script.run so that it will match on the result of parsing of response. 
the tx is only committed if the response is parsed and the status is `2**`. the tx is rolled back otherwise

# Manually testing the PR

This is tested as part of #792 
