### PR TITLE
fix(jstz_node): rename client->jstz-client, add query param to openapi

### DIFF
--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -140,6 +140,17 @@
         "operationId": "get_kv_value",
         "parameters": [
           {
+            "name": "key",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
             "name": "address",
             "in": "path",
             "required": true,
@@ -177,6 +188,17 @@
         "description": "Get array of KV subkeys under a given key path for an account. If `key` is not provided,\nthe empty key path will be used.",
         "operationId": "get_kv_subkeys",
         "parameters": [
+          {
+            "name": "key",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
           {
             "name": "address",
             "in": "path",

--- a/crates/jstz_node/src/services/accounts.rs
+++ b/crates/jstz_node/src/services/accounts.rs
@@ -12,6 +12,7 @@ use jstz_proto::{
     },
 };
 use serde::Deserialize;
+use utoipa::IntoParams;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
 use super::{
@@ -37,7 +38,7 @@ fn construct_accounts_key(address: &str) -> String {
     format!("{}/{}", ACCOUNTS_PATH_PREFIX, address)
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, IntoParams)]
 struct KvQuery {
     key: Option<String>,
 }
@@ -164,6 +165,7 @@ async fn get_balance(
 /// the empty key path will be used.
 #[utoipa::path(
     get,
+    params(KvQuery),
     path = "/{address}/kv",
     tag = ACCOUNTS_TAG,
     responses(
@@ -193,6 +195,7 @@ async fn get_kv_value(
 /// the empty key path will be used.
 #[utoipa::path(
     get,
+    params(KvQuery),
     path = "/{address}/kv/subkeys",
     tag = ACCOUNTS_TAG,
     responses(

--- a/crates/jstz_node/stainless.yml
+++ b/crates/jstz_node/stainless.yml
@@ -12,7 +12,7 @@ organization:
 targets:
   node:
     readme_title: Jstz Client
-    package_name: "@jstz-dev/client"
+    package_name: "@jstz-dev/jstz-client"
     production_repo: "jstz-dev/jstz-client"
     publish:
       npm: false


### PR DESCRIPTION
Please go the the `Preview` tab and select the appropriate sub-template:

- [🚧 Web/runtime APIs template](?expand=1&template=api_dev.md)
- [📚 Web/runtime APIs documentation template](?expand=1&template=api_doc.md)
- [⬜️ Blank template](?expand=1&template=default.md)
