### PR TITLE
fix(jstz_engine): introduce generative compartment `Id`s

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,2 +1,6 @@
 [profile.default]
 slow-timeout = { period = "60s", terminate-after = 1 }
+
+[[profile.default.overrides]]
+filter = 'package(jstz_engine) and test(ui)'
+slow-timeout = { period = "3m", terminate-after = 1 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2856,6 +2856,7 @@ version = "0.1.0-alpha.0"
 dependencies = [
  "anyhow",
  "mozjs",
+ "trybuild",
 ]
 
 [[package]]
@@ -4558,6 +4559,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4995,6 +5005,12 @@ dependencies = [
  "libc",
  "xattr",
 ]
+
+[[package]]
+name = "target-triple"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
 
 [[package]]
 name = "tempfile"
@@ -5493,10 +5509,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -5505,6 +5536,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap 2.6.0",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -5576,6 +5609,21 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trybuild"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b812699e0c4f813b872b373a4471717d9eb550da14b311058a4d9cf4173cbca6"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml",
+]
 
 [[package]]
 name = "typeid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ tokio = { version = "1.36.0", features = ["full"] }
 tokio-stream = "0.1.14"
 tokio-util = "0.7.10"
 tower-http = { version = "0.6.1", features = ["cors"] }
+trybuild = "1.0.103"
 url = "2.4.1"
 urlpattern = "0.2.0"
 utoipa = { version = "5.1.3", features = ["axum_extras", "url"] }

--- a/crates/jstz_engine/Cargo.toml
+++ b/crates/jstz_engine/Cargo.toml
@@ -15,3 +15,6 @@ description = "A memory-safe JavaScript engine API in Rust"
 [dependencies]
 anyhow.workspace = true
 mozjs.workspace = true
+
+[dev-dependencies]
+trybuild.workspace = true

--- a/crates/jstz_engine/src/compartment.rs
+++ b/crates/jstz_engine/src/compartment.rs
@@ -17,7 +17,7 @@ use std::{fmt::Debug, hash::Hash, marker::PhantomData};
 ///
 /// The lifetime of the compartment id is guaranteed to be unique among all
 /// other compartments. This will ensure that when creating a compartment,
-/// a different compartment will produce a new lifetime that cannot be unified
+/// a different compartment will produce a new lifetime that cannot be coerced
 /// with an existing compartment.
 ///
 /// `Id` is [invariant](https://doc.rust-lang.org/nomicon/subtyping.html#variance) over the
@@ -54,12 +54,16 @@ impl<'a> Drop for Region<'a> {
     #[inline(always)]
     fn drop(&mut self) {
         // Purposefully blank -- this ensures `Region` has drop glue, ensuring this is dropped at
-        // the end of the scope. Importantly, this ensures the compiler considers `'a` live at the
-        // point this region is dropped.
+        // the end of the scope. Without it it, the compiler will optimize region away as it contains
+        // only PhamtomData, consequently ignoring the lifetime check. Importantly, this ensures the
+        // compiler considers `'a` live at the point this region is dropped.
     }
 }
 
 impl<'a> Region<'a> {
+    /// # Safety
+    ///
+    /// DO NOT USE. Used by [`alloc_compartment!`].
     pub unsafe fn new(_: &'a Id<'a>) -> Self {
         Self(PhantomData)
     }
@@ -78,6 +82,9 @@ pub struct Ref<'a>(Id<'a>);
 impl<'a> Compartment for Ref<'a> {}
 
 impl<'a> Ref<'a> {
+    /// # Safety
+    ///
+    /// DO NOT USE. Used by [`alloc_compartment!`].
     pub unsafe fn new(id: Id<'a>) -> Self {
         Self(id)
     }

--- a/crates/jstz_engine/src/compartment.rs
+++ b/crates/jstz_engine/src/compartment.rs
@@ -13,7 +13,59 @@
 
 use std::{fmt::Debug, hash::Hash, marker::PhantomData};
 
-pub trait Compartment: Copy + Debug + Eq + Hash {}
+/// A compartment id that is alive for a given lifetime
+///
+/// The lifetime of the compartment id is guaranteed to be unique among all
+/// other compartments. This will ensure that when creating a compartment,
+/// a different compartment will produce a new lifetime that cannot be unified
+/// with an existing compartment.
+///
+/// `Id` is [invariant](https://doc.rust-lang.org/nomicon/subtyping.html#variance) over the
+/// lifetime parameter.
+///
+/// Any `Id` lifetime can be trusted, so long as they are known to be allocated using
+/// [`alloc_compartment!`] and haven't been derived from some unsafe code.  
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct Id<'a>(
+    /// To achieve lifetime invariance, we use `fn(&'a ()) -> &'a ()`. This works
+    /// because `fn(T) -> T` is contravariant over `T` and covariant over `T`, which
+    /// combines to invariance over `T`.
+    PhantomData<fn(&'a ()) -> &'a ()>,
+);
+
+impl<'a> Id<'a> {
+    /// Construct a new compartment with an unbounded lifetime.
+    ///
+    /// You should not need to use this function; use [`alloc_compartment!`] instead.
+    ///
+    /// # Safety
+    ///
+    /// `Id` holds an invariant lifetime that must be generative. Using this function directly
+    /// cannot guarentee that `'a` is generative.
+    pub unsafe fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+/// DO NOT USE. Used by [`alloc_compartment!`].
+pub struct Region<'a>(PhantomData<&'a Id<'a>>);
+
+impl<'a> Drop for Region<'a> {
+    #[inline(always)]
+    fn drop(&mut self) {
+        // Purposefully blank -- this ensures `Region` has drop glue, ensuring this is dropped at
+        // the end of the scope. Importantly, this ensures the compiler considers `'a` live at the
+        // point this region is dropped.
+    }
+}
+
+impl<'a> Region<'a> {
+    pub unsafe fn new(_: &'a Id<'a>) -> Self {
+        Self(PhantomData)
+    }
+}
+
+pub trait Compartment: Debug + Eq + Hash {}
 
 /// A wildcard compartment with an erased lifetime
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -21,6 +73,41 @@ pub struct Any;
 impl Compartment for Any {}
 
 /// A compartment that is alive for a given lifetime
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Ref<'a>(PhantomData<&'a mut ()>);
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct Ref<'a>(Id<'a>);
 impl<'a> Compartment for Ref<'a> {}
+
+impl<'a> Ref<'a> {
+    pub unsafe fn new(id: Id<'a>) -> Self {
+        Self(id)
+    }
+}
+
+#[macro_export]
+macro_rules! alloc_compartment {
+    ($name:ident) => {
+        let compartment_id = unsafe { $crate::compartment::Id::new() };
+        #[allow(unused)]
+        let compartment_region =
+            unsafe { $crate::compartment::Region::new(&compartment_id) };
+        let $name = unsafe { $crate::compartment::Ref::new(compartment_id) };
+    };
+}
+
+#[cfg(test)]
+mod test {
+
+    #[test]
+    fn allow_unify_with_self() {
+        alloc_compartment!(a);
+        alloc_compartment!(b);
+        assert_eq!(a, a);
+        assert_eq!(b, b);
+    }
+
+    #[test]
+    fn ui() {
+        let t = trybuild::TestCases::new();
+        t.compile_fail("tests/ui/compartments_are_generative.rs");
+    }
+}

--- a/crates/jstz_engine/src/gc/ptr.rs
+++ b/crates/jstz_engine/src/gc/ptr.rs
@@ -21,6 +21,10 @@ pub trait AsRawPtr {
     type Ptr;
 
     /// Get the raw pointer to the underlying object.
+    ///
+    /// # Safety
+    ///
+    /// Callers are responsible for handling the raw pointer safely
     unsafe fn as_raw_ptr(&self) -> Self::Ptr;
 }
 

--- a/crates/jstz_engine/src/lib.rs
+++ b/crates/jstz_engine/src/lib.rs
@@ -1,9 +1,9 @@
-mod compartment;
-mod context;
-mod gc;
-mod realm;
-mod script;
-mod value;
+pub mod compartment;
+pub mod context;
+pub mod gc;
+pub mod realm;
+pub mod script;
+pub mod value;
 
 #[cfg(test)]
 mod test {

--- a/crates/jstz_engine/src/lib.rs
+++ b/crates/jstz_engine/src/lib.rs
@@ -1,9 +1,9 @@
 pub mod compartment;
-pub mod context;
-pub mod gc;
-pub mod realm;
-pub mod script;
-pub mod value;
+mod context;
+mod gc;
+mod realm;
+mod script;
+mod value;
 
 #[cfg(test)]
 mod test {

--- a/crates/jstz_engine/src/realm.rs
+++ b/crates/jstz_engine/src/realm.rs
@@ -57,6 +57,10 @@ impl<'a, C: Compartment> Clone for Realm<'a, C> {
 }
 
 impl<'a, C: Compartment> Realm<'a, C> {
+    // Creates a new Realm in compartment C in the context of cx.
+    // The unused [_compartment] argument is potentially a witness for the lifetime
+    // of Self in C because C can be Ref<'b>. If so, then the returned Realm will be
+    // bounded by two lifetimes - the lifetime of cx ('a) and of _compartment ('b)
     pub fn new<S>(_compartment: C, cx: &'a mut Context<S>) -> Option<Self>
     where
         S: CanAlloc + CanAccess,

--- a/crates/jstz_engine/src/realm.rs
+++ b/crates/jstz_engine/src/realm.rs
@@ -30,7 +30,7 @@ use mozjs::{
 };
 
 use crate::{
-    compartment::{self, Compartment},
+    compartment::Compartment,
     context::{CanAccess, CanAlloc, Context, InCompartment},
     custom_trace,
     gc::{
@@ -56,8 +56,8 @@ impl<'a, C: Compartment> Clone for Realm<'a, C> {
     }
 }
 
-impl<'a> Realm<'a, compartment::Ref<'a>> {
-    pub fn new<S>(cx: &'a mut Context<S>) -> Option<Self>
+impl<'a, C: Compartment> Realm<'a, C> {
+    pub fn new<S>(_compartment: C, cx: &'a mut Context<S>) -> Option<Self>
     where
         S: CanAlloc + CanAccess,
     {

--- a/crates/jstz_engine/src/script.rs
+++ b/crates/jstz_engine/src/script.rs
@@ -139,7 +139,9 @@ mod test {
 
     use mozjs::rust::{JSEngine, Runtime};
 
-    use crate::{context::Context, gc::ptr::AsRawPtr, letroot, script::Script};
+    use crate::{
+        alloc_compartment, context::Context, gc::ptr::AsRawPtr, letroot, script::Script,
+    };
 
     #[test]
     fn test_compile_and_evaluate() {
@@ -149,7 +151,8 @@ mod test {
         let rt_cx = &mut Context::from_runtime(&rt);
 
         // Enter a new realm to evaluate the script in.
-        let mut cx = rt_cx.new_realm().unwrap();
+        alloc_compartment!(c);
+        let mut cx = rt_cx.new_realm(c).unwrap();
 
         // Some example source in a string.
         let filename = PathBuf::from("inline.js");

--- a/crates/jstz_engine/src/value/conversions.rs
+++ b/crates/jstz_engine/src/value/conversions.rs
@@ -12,14 +12,15 @@ impl<'a, C: Compartment> JsValue<'a, C> {
 mod test {
     use mozjs::rust::{JSEngine, Runtime};
 
-    use crate::{context::Context, value::JsValue};
+    use crate::{alloc_compartment, context::Context, value::JsValue};
 
     #[test]
     fn test_is_undefined() {
         let engine = JSEngine::init().unwrap();
         let rt = Runtime::new(engine.handle());
         let rt_cx = &mut Context::from_runtime(&rt);
-        let mut cx = rt_cx.new_realm().unwrap();
+        alloc_compartment!(c);
+        let mut cx = rt_cx.new_realm(c).unwrap();
         let val = JsValue::undefined(&mut cx);
         assert!(val.is_undefined());
     }

--- a/crates/jstz_engine/src/value/mod.rs
+++ b/crates/jstz_engine/src/value/mod.rs
@@ -78,7 +78,7 @@ unsafe impl<'a, C: Compartment> Trace for JsValue<'a, C> {
 mod test {
     use mozjs::rust::{JSEngine, Runtime};
 
-    use crate::context::Context;
+    use crate::{alloc_compartment, context::Context};
 
     use super::JsValue;
 
@@ -88,7 +88,8 @@ mod test {
         let engine = JSEngine::init().unwrap();
         let rt = Runtime::new(engine.handle());
         let rt_cx = &mut Context::from_runtime(&rt);
-        let mut cx = rt_cx.new_realm().unwrap();
+        alloc_compartment!(c);
+        let mut cx = rt_cx.new_realm(c).unwrap();
         let val = JsValue::undefined(&mut cx);
         assert!(val.is_undefined())
     }

--- a/crates/jstz_engine/tests/ui/compartments_are_generative.rs
+++ b/crates/jstz_engine/tests/ui/compartments_are_generative.rs
@@ -1,0 +1,7 @@
+use jstz_engine::alloc_compartment;
+
+fn main() {
+    alloc_compartment!(a);
+    alloc_compartment!(b);
+    assert_eq!(a, b);
+}

--- a/crates/jstz_engine/tests/ui/compartments_are_generative.stderr
+++ b/crates/jstz_engine/tests/ui/compartments_are_generative.stderr
@@ -1,0 +1,17 @@
+error[E0597]: `compartment_id` does not live long enough
+ --> tests/ui/compartments_are_generative.rs:5:5
+  |
+5 |     alloc_compartment!(b);
+  |     ^^^^^^^^^^^^^^^^^^^^^
+  |     |
+  |     borrowed value does not live long enough
+  |     binding `compartment_id` declared here
+6 |     assert_eq!(a, b);
+7 | }
+  | -
+  | |
+  | `compartment_id` dropped here while still borrowed
+  | borrow might be used here, when `compartment_region` is dropped and runs the `Drop` code for type `Region`
+  |
+  = note: values in a scope are dropped in the opposite order they are defined
+  = note: this error originates in the macro `alloc_compartment` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
 **Related Tasks**: [jstz-298](https://linear.app/tezos/issue/JSTZ-298/fix-generative-of-lifetime-parameters-for-compartments) 

While playing around with unrooting this morning, Ryan and I observed the following bug -- namely the following snippet compiles:
```rust
// Initialize JS engine
let engine = JSEngine::init().unwrap();
let rt = Runtime::new(engine.handle());

let rt_cx1 = Runtime::new(engine.handle());
let cx1 = rt_cx1.new_realm().unwrap();

let rt_cx2 = Runtime::new(engine.handle());
let cx2 = rt_cx2.new_realm().unwrap();

// This line shouldn't compile
let foo = vec![cx1, cx2];
```

Morally speaking, each `new_realm` should allocate a 'generative' lifetime parameter -- this parameter is generative in the sense that no other lifetime should unify with it apart from itself. 

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

The fix is the following:
1. Make the `'a` parameter of `compartment::Ref` invariant -- meaning that it is never valid to substitute or `Ref<'a>` into `Ref<'b>`, for *any* concrete `'a` or `'b`. 
2. Add a `Region<'a>` as a compiler witness that `'a` is live until `Region` is dropped
3. Add a macro `alloc_compartment` which allocates a fresh compartment reference in a fresh region -- APIs that use this compartment reference (as a value) should use the reference as an owned value. 

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

Added some tests to check the generativity of compartment ids
```
cargo nextest run --package jstz_engine
```
