### PR TITLE
fix(cli): allow empty input for passphrase

### DIFF
--- a/crates/jstz_cli/src/account.rs
+++ b/crates/jstz_cli/src/account.rs
@@ -133,6 +133,7 @@ pub async fn login(alias: String) -> Result<()> {
 
             let passphrase: String = Input::new()
                 .with_prompt("Enter the passphrase for the new account (or leave empty to generate a random one)")
+                .allow_empty(true)
                 .interact()?;
 
             let passphrase = if passphrase.is_empty() {


### PR DESCRIPTION
# Context

Closes JSTZ-283.
[JSTZ-283](https://linear.app/tezos/issue/JSTZ-283/enter-passphrase-does-not-accept-empty-input)

# Description

Allow empty input when users are prompted to enter the passphrase when they create new accounts.

# Manually testing the PR

Tested manually by trying to create a new account locally:
```sh
$ ./jstz deploy index.js --name example --network dev
You are not logged in. Please type the account name that you want to log into or create as new: e
Account not found. Do you want to create it? yes
Enter the passphrase for the new account (or leave empty to generate a random one):        
Generated passphrase: pond elevator nation final menu cliff license boring donate badge side bullet
Logged in to account e with address tz1frMYLkuPzdkcthRv79qyvL6eBaR8KUKcA
```
