### PR TITLE
fix(wpt): handle utf-16 characters

### DIFF
--- a/crates/jstz_api/tests/wptreport.json
+++ b/crates/jstz_api/tests/wptreport.json
@@ -334,11 +334,497 @@
           "Test": {
             "variations": [
               {
-                "subtests": [],
-                "status": "Err",
+                "subtests": [
+                  {
+                    "name": "encodeInto() into ArrayBuffer with Hi and destination length 0, offset 0, filler 0",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 0 but got (bigint) bigint \"0\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with Hi and destination length 0, offset 0, filler 0",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with Hi and destination length 0, offset 4, filler 0",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 0 but got (bigint) bigint \"2\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with Hi and destination length 0, offset 4, filler 0",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with Hi and destination length 0, offset 0, filler 128",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 0 but got (bigint) bigint \"0\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with Hi and destination length 0, offset 0, filler 128",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with Hi and destination length 0, offset 4, filler 128",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 0 but got (bigint) bigint \"2\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with Hi and destination length 0, offset 4, filler 128",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with Hi and destination length 0, offset 0, filler random",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 0 but got (bigint) bigint \"0\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with Hi and destination length 0, offset 0, filler random",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with Hi and destination length 0, offset 4, filler random",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 0 but got (bigint) bigint \"2\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with Hi and destination length 0, offset 4, filler random",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with A and destination length 10, offset 0, filler 0",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 1 but got (bigint) bigint \"1\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with A and destination length 10, offset 0, filler 0",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with A and destination length 10, offset 4, filler 0",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 1 but got (bigint) bigint \"1\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with A and destination length 10, offset 4, filler 0",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with A and destination length 10, offset 0, filler 128",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 1 but got (bigint) bigint \"1\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with A and destination length 10, offset 0, filler 128",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with A and destination length 10, offset 4, filler 128",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 1 but got (bigint) bigint \"1\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with A and destination length 10, offset 4, filler 128",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with A and destination length 10, offset 0, filler random",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 1 but got (bigint) bigint \"1\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with A and destination length 10, offset 0, filler random",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with A and destination length 10, offset 4, filler random",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 1 but got (bigint) bigint \"1\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with A and destination length 10, offset 4, filler random",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with 𝌆 and destination length 4, offset 0, filler 0",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 2 but got (bigint) bigint \"2\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with 𝌆 and destination length 4, offset 0, filler 0",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with 𝌆 and destination length 4, offset 4, filler 0",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 2 but got (bigint) bigint \"2\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with 𝌆 and destination length 4, offset 4, filler 0",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with 𝌆 and destination length 4, offset 0, filler 128",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 2 but got (bigint) bigint \"2\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with 𝌆 and destination length 4, offset 0, filler 128",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with 𝌆 and destination length 4, offset 4, filler 128",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 2 but got (bigint) bigint \"2\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with 𝌆 and destination length 4, offset 4, filler 128",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with 𝌆 and destination length 4, offset 0, filler random",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 2 but got (bigint) bigint \"2\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with 𝌆 and destination length 4, offset 0, filler random",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with 𝌆 and destination length 4, offset 4, filler random",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 2 but got (bigint) bigint \"2\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with 𝌆 and destination length 4, offset 4, filler random",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with 𝌆A and destination length 3, offset 0, filler 0",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 0 but got (bigint) bigint \"0\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with 𝌆A and destination length 3, offset 0, filler 0",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with 𝌆A and destination length 3, offset 4, filler 0",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 0 but got (bigint) bigint \"3\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with 𝌆A and destination length 3, offset 4, filler 0",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with 𝌆A and destination length 3, offset 0, filler 128",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 0 but got (bigint) bigint \"0\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with 𝌆A and destination length 3, offset 0, filler 128",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with 𝌆A and destination length 3, offset 4, filler 128",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 0 but got (bigint) bigint \"3\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with 𝌆A and destination length 3, offset 4, filler 128",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with 𝌆A and destination length 3, offset 0, filler random",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 0 but got (bigint) bigint \"0\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with 𝌆A and destination length 3, offset 0, filler random",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with 𝌆A and destination length 3, offset 4, filler random",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 0 but got (bigint) bigint \"3\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with 𝌆A and destination length 3, offset 4, filler random",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with A\\uDF06 and destination length 4, offset 0, filler 0",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 2 but got (bigint) bigint \"2\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with A\\uDF06 and destination length 4, offset 0, filler 0",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with A\\uDF06 and destination length 4, offset 4, filler 0",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 2 but got (bigint) bigint \"2\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with A\\uDF06 and destination length 4, offset 4, filler 0",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with A\\uDF06 and destination length 4, offset 0, filler 128",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 2 but got (bigint) bigint \"2\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with A\\uDF06 and destination length 4, offset 0, filler 128",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with A\\uDF06 and destination length 4, offset 4, filler 128",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 2 but got (bigint) bigint \"2\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with A\\uDF06 and destination length 4, offset 4, filler 128",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with A\\uDF06 and destination length 4, offset 0, filler random",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 2 but got (bigint) bigint \"2\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with A\\uDF06 and destination length 4, offset 0, filler random",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with A\\uDF06 and destination length 4, offset 4, filler random",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 2 but got (bigint) bigint \"2\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with A\\uDF06 and destination length 4, offset 4, filler random",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with ¥¥ and destination length 4, offset 0, filler 0",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 2 but got (bigint) bigint \"2\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with ¥¥ and destination length 4, offset 0, filler 0",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with ¥¥ and destination length 4, offset 4, filler 0",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 2 but got (bigint) bigint \"2\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with ¥¥ and destination length 4, offset 4, filler 0",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with ¥¥ and destination length 4, offset 0, filler 128",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 2 but got (bigint) bigint \"2\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with ¥¥ and destination length 4, offset 0, filler 128",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with ¥¥ and destination length 4, offset 4, filler 128",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 2 but got (bigint) bigint \"2\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with ¥¥ and destination length 4, offset 4, filler 128",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with ¥¥ and destination length 4, offset 0, filler random",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 2 but got (bigint) bigint \"2\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with ¥¥ and destination length 4, offset 0, filler random",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "encodeInto() into ArrayBuffer with ¥¥ and destination length 4, offset 4, filler random",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 2 but got (bigint) bigint \"2\""
+                  },
+                  {
+                    "name": "encodeInto() into SharedArrayBuffer with ¥¥ and destination length 4, offset 4, filler random",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "Invalid encodeInto() destination: DataView, backed by: ArrayBuffer",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Invalid encodeInto() destination: DataView, backed by: SharedArrayBuffer",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "Invalid encodeInto() destination: Int8Array, backed by: ArrayBuffer",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Invalid encodeInto() destination: Int8Array, backed by: SharedArrayBuffer",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "Invalid encodeInto() destination: Int16Array, backed by: ArrayBuffer",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Invalid encodeInto() destination: Int16Array, backed by: SharedArrayBuffer",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "Invalid encodeInto() destination: Int32Array, backed by: ArrayBuffer",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Invalid encodeInto() destination: Int32Array, backed by: SharedArrayBuffer",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "Invalid encodeInto() destination: Uint16Array, backed by: ArrayBuffer",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Invalid encodeInto() destination: Uint16Array, backed by: SharedArrayBuffer",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "Invalid encodeInto() destination: Uint32Array, backed by: ArrayBuffer",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Invalid encodeInto() destination: Uint32Array, backed by: SharedArrayBuffer",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "Invalid encodeInto() destination: Uint8ClampedArray, backed by: ArrayBuffer",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Invalid encodeInto() destination: Uint8ClampedArray, backed by: SharedArrayBuffer",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "Invalid encodeInto() destination: BigInt64Array, backed by: ArrayBuffer",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Invalid encodeInto() destination: BigInt64Array, backed by: SharedArrayBuffer",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "Invalid encodeInto() destination: BigUint64Array, backed by: ArrayBuffer",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Invalid encodeInto() destination: BigUint64Array, backed by: SharedArrayBuffer",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "Invalid encodeInto() destination: Float32Array, backed by: ArrayBuffer",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Invalid encodeInto() destination: Float32Array, backed by: SharedArrayBuffer",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "Invalid encodeInto() destination: Float64Array, backed by: ArrayBuffer",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Invalid encodeInto() destination: Float64Array, backed by: SharedArrayBuffer",
+                    "status": "Fail",
+                    "message": "not a constructor"
+                  },
+                  {
+                    "name": "Invalid encodeInto() destination: ArrayBuffer",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "Invalid encodeInto() destination: SharedArrayBuffer",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "encodeInto() and a detached output buffer",
+                    "status": "Fail",
+                    "message": "assert_equals: expected (number) 0 but got (bigint) bigint \"0\""
+                  }
+                ],
+                "status": "Ok",
                 "metrics": {
-                  "passed": 0,
-                  "failed": 0,
+                  "passed": 13,
+                  "failed": 84,
                   "timed_out": 0
                 }
               }


### PR DESCRIPTION
# Context

Closes JSTZ-304.
[JSTZ-304](https://linear.app/tezos/issue/JSTZ-304/handle-utf-16-strings)

# Description

Handle JsStrings with utf-16 characters properly in the test runner. Some test cases involve utf-16 characters, and the implementation of `TryFromJs for String` does not handle those characters properly, specifically the method [`to_std_string`](https://docs.rs/boa_engine/0.19.0/src/boa_engine/value/conversions/try_from_js.rs.html#39-52), which leads to errors like

`could not convert JsString to Rust string: invalid utf-16: lone surrogate found`

and leaves the runner unable to handle some tests.

To fix this, we need to get `JsString` first and then do the proper conversion ourselves.

# Manually testing the PR

```
env UPDATE_EXPECT=1 cargo test --test wpt
```

Test cases showed up for the test suite `encodeInto.any.js` and there is no more error.
