### PR TITLE
feat(wpt): enable tests for queuing strategies

### DIFF
--- a/crates/jstz_api/src/lib.rs
+++ b/crates/jstz_api/src/lib.rs
@@ -12,3 +12,4 @@ pub mod urlpattern;
 
 pub use console::ConsoleApi;
 pub use random::RandomApi;
+pub(crate) use todo::todo;

--- a/crates/jstz_api/src/stream/queuing_strategy/size.rs
+++ b/crates/jstz_api/src/stream/queuing_strategy/size.rs
@@ -70,7 +70,7 @@ impl JsCallableWithoutThis<(Chunk,), idl::UnrestrictedDouble>
     ) -> JsResult<idl::UnrestrictedDouble> {
         match self {
             ByteLengthQueuingStrategySizeAlgorithm::ReturnByteLengthOfChunk => {
-                todo!("ReturnByteLengthOfChunk.call_without_this()")
+                crate::todo!("ReturnByteLengthOfChunk.call_without_this()");
             }
         }
     }
@@ -153,5 +153,25 @@ impl ExtractSizeAlgorithm for Option<QueuingStrategy> {
         self.as_ref()
             .map(|v| v.extract_size_algorithm())
             .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ByteLengthQueuingStrategySizeAlgorithm;
+    use crate::stream::Chunk;
+    use boa_engine::{Context, JsNativeError};
+    use jstz_core::js_fn::JsCallableWithoutThis;
+
+    #[test]
+    fn byte_length_queuing_call_without_this() {
+        assert_eq!(
+            ByteLengthQueuingStrategySizeAlgorithm::ReturnByteLengthOfChunk
+                .call_without_this((Chunk::null(),), &mut Context::default())
+                .unwrap_err(),
+            JsNativeError::error()
+                .with_message("todo: ReturnByteLengthOfChunk.call_without_this()")
+                .into()
+        );
     }
 }

--- a/crates/jstz_api/src/todo.rs
+++ b/crates/jstz_api/src/todo.rs
@@ -33,7 +33,6 @@ impl TryFromJs for Todo {
     }
 }
 
-#[allow(unused_macros)]
 macro_rules! todo {
     ($msg:literal) => {
         return boa_engine::JsResult::Err(
@@ -43,7 +42,6 @@ macro_rules! todo {
         )
     };
 }
-#[allow(unused_imports)]
 pub(crate) use todo;
 
 #[cfg(test)]

--- a/crates/jstz_api/tests/wpt.rs
+++ b/crates/jstz_api/tests/wpt.rs
@@ -252,6 +252,7 @@ pub fn register_apis(context: &mut Context) {
     jstz_api::http::header::HeadersApi.init(context);
     jstz_api::encoding::EncodingApi.init(context);
     jstz_api::file::FileApi.init(context);
+    jstz_api::stream::StreamApi.init(context);
 }
 
 fn insert_global_properties(rt: &mut Runtime) {
@@ -362,6 +363,9 @@ async fn test_wpt() -> Result<()> {
             r"^\/encoding\/[^\/]+\.any\.html$",
             r"^\/fetch\/api\/headers\/[^\/]+\.any\.html$",
             r"^\/FileAPI\/blob\/[^\/]+\.any\.html$", // Blob
+            r"^\/streams\/queuing\-strategies\.any\.html$", // CountQueuingStrategy, ByteLengthQueuingStrategy
+            r"^\/streams\/writable\-streams\/byte\-length\-queuing\-strategy\.any\.html$", // ByteLengthQueuingStrategy
+            r"^\/streams\/writable\-streams\/count\-queuing\-strategy\.any\.html$", // CountQueuingStrategy
         ]
         .as_ref(),
     )?;

--- a/crates/jstz_api/tests/wptreport.json
+++ b/crates/jstz_api/tests/wptreport.json
@@ -5857,6 +5857,182 @@
           }
         }
       }
+    },
+    "streams": {
+      "Folder": {
+        "queuing-strategies.any.js": {
+          "Test": {
+            "variations": [
+              {
+                "subtests": [
+                  {
+                    "name": "CountQueuingStrategy: Can construct a with a valid high water mark",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "CountQueuingStrategy: Constructor behaves as expected with strange arguments",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "CountQueuingStrategy: highWaterMark constructor values are converted per the unrestricted double rules",
+                    "status": "Fail",
+                    "message": "cannot convert value to a f64"
+                  },
+                  {
+                    "name": "CountQueuingStrategy: size is the same function across all instances",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "CountQueuingStrategy: size should have the right name",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "CountQueuingStrategy: subclassing should work correctly",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "CountQueuingStrategy: size should not have a prototype property",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "ByteLengthQueuingStrategy: Can construct a with a valid high water mark",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "ByteLengthQueuingStrategy: Constructor behaves as expected with strange arguments",
+                    "status": "Fail",
+                    "message": "Failed to convert js value into Rust type `CountQueuingStrategy`"
+                  },
+                  {
+                    "name": "ByteLengthQueuingStrategy: highWaterMark constructor values are converted per the unrestricted double rules",
+                    "status": "Fail",
+                    "message": "Failed to convert js value into Rust type `CountQueuingStrategy`"
+                  },
+                  {
+                    "name": "ByteLengthQueuingStrategy: size is the same function across all instances",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "ByteLengthQueuingStrategy: size should have the right name",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "ByteLengthQueuingStrategy: subclassing should work correctly",
+                    "status": "Fail",
+                    "message": "Failed to convert js value into Rust type `CountQueuingStrategy`"
+                  },
+                  {
+                    "name": "ByteLengthQueuingStrategy: size should not have a prototype property",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "CountQueuingStrategy: size should not be a constructor",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "ByteLengthQueuingStrategy: size should not be a constructor",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "CountQueuingStrategy: size should have the right length",
+                    "status": "Fail",
+                    "message": "assert_equals: expected 0 but got 1"
+                  },
+                  {
+                    "name": "ByteLengthQueuingStrategy: size should have the right length",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "CountQueuingStrategy: size behaves as expected with strange arguments",
+                    "status": "Pass",
+                    "message": null
+                  },
+                  {
+                    "name": "ByteLengthQueuingStrategy: size behaves as expected with strange arguments",
+                    "status": "Fail",
+                    "message": "assert_throws_js: size fails with undefined function \"function () { [native code] }\" threw object \"Error: todo: ReturnByteLengthOfChunk.call_without_this()\" (\"Error\") expected instance of function \"function TypeError() { [native code] }\" (\"TypeError\")"
+                  }
+                ],
+                "status": "Ok",
+                "metrics": {
+                  "passed": 14,
+                  "failed": 6,
+                  "timed_out": 0
+                }
+              }
+            ]
+          }
+        },
+        "writable-streams": {
+          "Folder": {
+            "byte-length-queuing-strategy.any.js": {
+              "Test": {
+                "variations": [
+                  {
+                    "subtests": [
+                      {
+                        "name": "Closing a writable stream with in-flight writes below the high water mark delays the close call properly",
+                        "status": "Fail",
+                        "message": "WritableStream is not defined"
+                      }
+                    ],
+                    "status": "Ok",
+                    "metrics": {
+                      "passed": 0,
+                      "failed": 1,
+                      "timed_out": 0
+                    }
+                  }
+                ]
+              }
+            },
+            "count-queuing-strategy.any.js": {
+              "Test": {
+                "variations": [
+                  {
+                    "subtests": [
+                      {
+                        "name": "Can construct a writable stream with a valid CountQueuingStrategy",
+                        "status": "Fail",
+                        "message": "WritableStream is not defined"
+                      },
+                      {
+                        "name": "Correctly governs the value of a WritableStream's state property (HWM = 0)",
+                        "status": "Fail",
+                        "message": "WritableStream is not defined"
+                      },
+                      {
+                        "name": "Correctly governs the value of a WritableStream's state property (HWM = 4)",
+                        "status": "Fail",
+                        "message": "WritableStream is not defined"
+                      }
+                    ],
+                    "status": "Ok",
+                    "metrics": {
+                      "passed": 0,
+                      "failed": 3,
+                      "timed_out": 0
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
# Context

Part of JSTZ-303.
[JSTZ-303](https://linear.app/tezos/issue/JSTZ-303/record-all-relevant-wpt-test-suites)

# Description

Enable test suites for `CountQueuingStrategy` ([interface](https://streams.spec.whatwg.org/#countqueuingstrategy), [class](https://nodejs.org/docs/v22.13.1/api/globals.html#class-countqueuingstrategy)) and `ByteLengthQueuingStrategy` ([interface](https://streams.spec.whatwg.org/#bytelengthqueuingstrategy), [class](https://nodejs.org/docs/v22.13.1/api/globals.html#class-bytelengthqueuingstrategy)).

# Manually testing the PR

```sh
env UPDATE_EXPECT=1 cargo test --test wpt
```
