### PR TITLE
ci: skip wpt but keep test coverage for jstz_api

### DIFF
--- a/crates/jstz_api/Cargo.toml
+++ b/crates/jstz_api/Cargo.toml
@@ -36,3 +36,6 @@ expect-test.workspace = true
 jstz_wpt = { path = "../jstz_wpt" }
 tezos-smart-rollup-mock.workspace = true
 tokio.workspace = true
+
+[features]
+skip-wpt = []

--- a/crates/jstz_api/tests/wpt.rs
+++ b/crates/jstz_api/tests/wpt.rs
@@ -354,6 +354,7 @@ fn run_wpt_test(
     }
 }
 
+#[cfg_attr(feature = "skip-wpt", ignore)]
 #[tokio::test]
 async fn test_wpt() -> Result<()> {
     let filter = TestFilter::try_from(

--- a/nix/crates.nix
+++ b/nix/crates.nix
@@ -160,7 +160,7 @@ in {
         # Use nextest for test harness (instead of `cargo test`)
         cargoLlvmCovCommand = "nextest";
         # Generate coverage reports for codecov
-        cargoLlvmCovExtraArgs = "--workspace --exclude-from-test \"jstz_api\" --codecov --output-path $out --features \"skip-rollup-tests\" --config-file ${src}/.config/nextest.toml";
+        cargoLlvmCovExtraArgs = "--codecov --output-path $out --features \"skip-rollup-tests\" --features \"skip-wpt\" --config-file ${src}/.config/nextest.toml";
       });
 
     cargo-clippy = craneLib.cargoClippy (commonWorkspace


### PR DESCRIPTION
# Context

Part of JSTZ-303.
[JSTZ-303](https://linear.app/tezos/issue/JSTZ-303/record-all-relevant-wpt-test-suites)

# Description

Skip wpt in CI in a different way so that test coverage for jstz_api can still be calculated properly.

I'm making some code changes to jstz_api in #808, but codecov complains that the test coverage is 0 even if I created a test for the changed lines. The problem lies in this `--exclude-from-test` flag. Since the goal is to prevent llvm-cov from running wpt, I replaced that flag with a feature flag in jstz_api that ignores wpt so that other tests in the crate can contribute to test coverage.

# Manually testing the PR

CI runs properly.

Test coverage indeed changed with the [test commit](https://app.codecov.io/github/jstz-dev/jstz/commit/4fc0af07209047e5e7afc5b650fffc8dde71d702/indirect-changes).
