### PR TITLE
feat(jstz_api): implement todo to return JsError

### DIFF
--- a/crates/jstz_api/src/todo.rs
+++ b/crates/jstz_api/src/todo.rs
@@ -10,25 +10,54 @@ pub enum Todo {
 
 impl Finalize for Todo {
     fn finalize(&self) {
-        todo!()
+        std::todo!()
     }
 }
 
 #[allow(unused_variables)]
 unsafe impl Trace for Todo {
-    custom_trace!(this, mark, todo!());
+    custom_trace!(this, mark, std::todo!());
 }
 
 #[allow(unused_variables)]
 impl IntoJs for Todo {
     fn into_js(self, context: &mut Context) -> JsValue {
-        todo!()
+        std::todo!()
     }
 }
 
 #[allow(unused_variables)]
 impl TryFromJs for Todo {
     fn try_from_js(value: &JsValue, context: &mut Context) -> JsResult<Self> {
-        todo!()
+        std::todo!()
+    }
+}
+
+#[allow(unused_macros)]
+macro_rules! todo {
+    ($msg:literal) => {
+        return boa_engine::JsResult::Err(
+            boa_engine::JsNativeError::error()
+                .with_message(format!("todo: {}", String::from($msg)))
+                .into(),
+        )
+    };
+}
+#[allow(unused_imports)]
+pub(crate) use todo;
+
+#[cfg(test)]
+mod tests {
+    use boa_engine::{JsNativeError, JsResult};
+
+    #[test]
+    fn todo() {
+        fn test() -> JsResult<()> {
+            super::todo!("foobar");
+        }
+        assert_eq!(
+            test().unwrap_err(),
+            JsNativeError::error().with_message("todo: foobar").into()
+        );
     }
 }


### PR DESCRIPTION
# Context

Part of JSTZ-303.
[JSTZ-303](https://linear.app/tezos/issue/JSTZ-303/record-all-relevant-wpt-test-suites)

# Description

Implement `todo!` to return JsError for methods that are not yet implemented.

When methods calling `std::todo!` get hit, they simply panic, and this breaks wpt. To ensure that tests fail gracefully, these methods need to return JsError with some error messages. I think overall todos in this crate should return errors anyway rather than panicking since panicking means users will never be able to catch and report such errors.

# Manually testing the PR

```sh
$ cd crates/jstz_api && cargo test todo
running 1 test
test todo::tests::todo ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```
