### PR TITLE
Jstz cli: transfer

### DIFF
--- a/crates/jstz_cli/src/bridge/withdraw.rs
+++ b/crates/jstz_cli/src/bridge/withdraw.rs
@@ -2,7 +2,7 @@ use crate::{
     bridge::convert_tez_to_mutez,
     config::{Config, NetworkName},
     error::{bail_user_error, Result},
-    run,
+    run::{self, RunArgs},
     term::styles,
     utils::AddressOrAlias,
 };
@@ -33,14 +33,6 @@ pub async fn exec(
     let gas_limit = 10; // TODO: set proper gas limit
     let withdraw = jstz_proto::executor::withdraw::Withdrawal { amount, receiver };
     let json_data = serde_json::to_string(&withdraw)?;
-    run::exec(
-        url,
-        http_method,
-        gas_limit,
-        Some(json_data),
-        network,
-        false,
-        false,
-    )
-    .await
+    let args = RunArgs::new(url, http_method, gas_limit);
+    run::exec(args.set_json_data(Some(json_data)).set_network(network)).await
 }

--- a/crates/jstz_core/src/reveal_data.rs
+++ b/crates/jstz_core/src/reveal_data.rs
@@ -1,0 +1,106 @@
+use crate::{host::HostRuntime, BinEncodable};
+use bincode::{Decode, Encode};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use tezos_smart_rollup::{
+    core_unsafe::PREIMAGE_HASH_SIZE,
+    dac::{self, PreimageHash, PreimageHashError, V0SliceContentPage},
+};
+
+pub struct RevealData<'a, H: HostRuntime> {
+    host: &'a mut H,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PageHash(pub [u8; PREIMAGE_HASH_SIZE]);
+
+impl Serialize for PageHash {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for PageHash {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Deserialize as bytes first
+        let bytes = Vec::<u8>::deserialize(deserializer)?;
+        // Then use bincode's decode
+        Ok(PageHash(bytes.try_into().unwrap()))
+    }
+}
+
+impl Default for PageHash {
+    fn default() -> Self {
+        PageHash([0; PREIMAGE_HASH_SIZE])
+    }
+}
+
+impl AsRef<[u8; PREIMAGE_HASH_SIZE]> for PageHash {
+    fn as_ref(&self) -> &[u8; PREIMAGE_HASH_SIZE] {
+        &self.0
+    }
+}
+
+impl From<[u8; PREIMAGE_HASH_SIZE]> for PageHash {
+    fn from(hash: [u8; PREIMAGE_HASH_SIZE]) -> Self {
+        PageHash(hash)
+    }
+}
+
+impl<'a, H: HostRuntime> RevealData<'a, H> {
+    pub fn new(host: &'a mut H) -> Self {
+        RevealData { host }
+    }
+
+    pub fn reveal<F>(
+        &mut self,
+        root_hash: &PageHash,
+        save_content: &mut F,
+    ) -> Result<(), &'static str>
+    where
+        F: FnMut(&mut H, V0SliceContentPage) -> Result<(), &'static str>,
+    {
+        let mut buffer = [0u8; 4096]; // Buffer for reading preimages
+        dac::reveal_loop(
+            self.host,
+            0,
+            root_hash.as_ref(),
+            &mut buffer,
+            3,
+            save_content,
+        )
+    }
+
+    pub fn reveal_and_decode<T>(
+        &mut self,
+        root_hash: &PageHash,
+    ) -> Result<T, &'static str>
+    where
+        T: BinEncodable,
+    {
+        let content = [0u8; 4096];
+        /// use reveal function to fill content and decode it into T
+        // self.reveal(root_hash, |_, page| {
+        //     content.copy_from_slice(page.as_ref());
+        //     Ok(())
+        // })?;
+        T::decode(&mut &content[..]).map_err(|_| "Failed to decode")
+    }
+
+    pub fn encode_into_preimage_pages<T, F>(
+        value: &T,
+        save_content: &mut F,
+    ) -> Result<PreimageHash, PreimageHashError>
+    where
+        T: BinEncodable,
+        F: FnMut(PreimageHash, Vec<u8>),
+    {
+        let v = T::encode(value).unwrap();
+        dac::prepare_preimages(&v, save_content)
+    }
+}


### PR DESCRIPTION
# Context

[task link](https://linear.app/tezos/issue/JSTZ-301/add-transfer-cli)

# Description

* add support for transfer
```
Usage: jstz transfer [OPTIONS] <AMOUNT> <ADDRESS|ALIAS>

Arguments:
  <AMOUNT>         The amount in XTZ to transfer
  <ADDRESS|ALIAS>  

Options:
  -g, --gas-limit <GAS_LIMIT>  The maximum amount of gas to be used [default: 550000]
  -i, --include                Include response headers in the output
  -n, --network <NETWORK>      Specifies the network from the config file, defaulting to the configured default network. Use `dev` for the local sandbox
```
* introduce `RunArgs` as the number of arguments were getting bigger and linting complaning

# Manually testing the PR

```
cargo run --bin jstz -- transfer 1 KT1AyfEg3c1ZkW4CATmzSoo5MiNkTP16qpb7 -n dev
Transferred 1 XTZ to KT1AyfEg3c1ZkW4CATmzSoo5MiNkTP16qpb7
cargo run --bin jstz -- transfer 1 tz1bzweZEmcZJqDVESsEi5q4q98EoBw7tR5P -n dev
Transferred 1 XTZ to tz1bzweZEmcZJqDVESsEi5q4q98EoBw7tR5P
cargo run --bin jstz -- account balance -a test --network dev 
3ꜩ
cargo run --bin jstz -- account balance -a tz1bzweZEmcZJqDVESsEi5q4q98EoBw7tR5P --network dev
1ꜩ
cargo run --bin jstz -- account balance -a KT1AyfEg3c1ZkW4CATmzSoo5MiNkTP16qpb7 --network dev
6ꜩ
```
