### PR TITLE
ci: update codecov action to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Coverage
         run: nix --accept-flake-config --log-format raw -L build .#checks.x86_64-linux.cargo-llvm-cov
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4.2.0
+        uses: codecov/codecov-action@v5
         with:
           files: result
           fail_ci_if_error: true


### PR DESCRIPTION
# Context

Completes JSTZ-310.
[JSTZ-310](https://linear.app/tezos/issue/JSTZ-310)

# Description

Upgrade codecov-action to v5 to fix the token issue. This ensures that contributions in the future don't run into this problem.

# Manually testing the PR

Before: this [test commit](https://github.com/jstz-dev/jstz/pull/815/commits/ac8f95404c9804dc2dc6772a907bb79fbde2e820) shows that it did not work with my forked repo.

After: codecov works in this PR 