### PR TITLE
feat(jstz_engine): add `handle` and `handle_mut` methods to gcptr wrappers

### DIFF
--- a/crates/jstz_engine/src/gc/mod.rs
+++ b/crates/jstz_engine/src/gc/mod.rs
@@ -85,6 +85,62 @@ macro_rules! gcptr_wrapper {
                     marker: std::marker::PhantomData,
                 }
             }
+
+            /// Retrieves a SpiderMonkey Rooted Handle to the underlying value.
+            ///
+            /// # Safety
+            ///
+            /// This function relies on Rust's borrow checker to ensure that only rooted values
+            /// are used, preventing unrooted accesses at the type level. However, **it is the
+            /// caller's responsibility** to guarantee that:
+            ///
+            /// - The lifetimes of both the context and the value are valid.
+            /// - The `Context` passed to this function is the **same** context in which the value
+            ///   was originally created and rooted.
+            ///
+            /// Failure to uphold these invariants—whether by bypassing the borrow checker
+            /// through `unsafe` code or by using multiple contexts incorrectly—constitutes a
+            /// **programming error** and results in **undefined behavior**.
+            #[allow(unused)]
+            pub(crate) fn handle<'cx, S>(
+                &self,
+                _cx: &'cx mut Context<S>,
+            ) -> $crate::gc::ptr::Handle<<Self as $crate::gc::ptr::AsRawPtr>::Ptr>
+            where
+                S: $crate::context::InCompartment<C> + $crate::context::CanAccess,
+                'cx: 'a,
+            {
+                // SAFETY: self is guaranteed to be rooted due to the lifetimes, therefore it safe to acquire a handle
+                unsafe { $crate::gc::ptr::AsRawHandle::as_raw_handle(self) }
+            }
+
+            /// Retrieves a SpiderMonkey Rooted HandleMut to the underlying value.
+            ///
+            /// # Safety
+            ///
+            /// This function relies on Rust's borrow checker to ensure that only rooted values
+            /// are used, preventing unrooted accesses at the type level. However, **it is the
+            /// caller's responsibility** to guarantee that:
+            ///
+            /// - The lifetimes of both the context and the value are valid.
+            /// - The `Context` passed to this function is the **same** context in which the value
+            ///   was originally created and rooted.
+            ///
+            /// Failure to uphold these invariants—whether by bypassing the borrow checker
+            /// through `unsafe` code or by using multiple contexts incorrectly—constitutes a
+            /// **programming error** and results in **undefined behavior**.
+            #[allow(unused)]
+            pub(crate) fn handle_mut<'cx, S>(
+                &self,
+                _cx: &'cx mut Context<S>,
+            ) -> $crate::gc::ptr::HandleMut<<Self as $crate::gc::ptr::AsRawPtr>::Ptr>
+            where
+                S: $crate::context::InCompartment<C> + $crate::context::CanAccess,
+                'cx: 'a,
+            {
+                // SAFETY: self is guaranteed to be rooted due to lifetimes, therefore it safe to acquire a handle
+                unsafe { $crate::gc::ptr::AsRawHandleMut::as_raw_handle_mut(self) }
+            }
         }
 
         unsafe impl<'a, 'b, C: $crate::gc::Compartment> $crate::gc::Prolong<'a>


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
**Related Tasks**: [Add safe `.handle()` and `.handle_mut()` to gcptr types](https://linear.app/tezos/issue/JSTZ-308/add-safe-handle-and-handle-mut-to-gcptr-types)

Consider the following function (part of #740):
```rust
  pub fn concat<'cx, 'b, S>(
        &self,
        other: &JsString<'b, C>,
        cx: &'cx mut Context<S>,
    ) -> JsString<'cx, C>
    where
        S: InCompartment<C> + CanAlloc,
        'cx: 'a,
        'cx: 'b
  {
      // SAFETY: Root both self and other to obtain handles
      //        (since `JS_ConcatStrings` will allocate and maybe GC)
      letroot!(rooted_self = self.clone(); [cx]);
      letroot!(rooted_other = other.clone(); [cx]);

      unsafe {
          JsString::from_raw(JS_ConcatStrings(
              cx.as_raw_ptr(),
              rooted_self.handle(),
              rooted_other.handle(),
          ))
     }
 }
```

Note that we need to explicitly root `self` and `other`. However, from the lifetime information and the 
'proof' of a mutable context `cx`, we know that the lifetimes of `self` (`'a`) and `other` (`'b`) must be 
produced via rooting, otherwise we would not be able to call `self.concat(other, cx)`. 

This implies the rooting of `self` and `other` is unnecessary. Thus requiring an explicit `letroot!` here is an
anti-pattern. 

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
**Dependencies**: #745 

This PR adds `.handle` and `.handle_mut` methods to gcptr types which allows one
to obtain a rooted handle using the existence of a context `cx` as 'proof' that the value 
is rooted. 

This is sound provided:
- The lifetimes of `cx` and the gcptr type are 'valid' (i.e. haven't been coerced using `mem::transmute` or some other unsafe function)
- The context `cx` is the one that created (and rooted) the gcptr type

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

Testing to be covered by subsequent PRs that make use of `.handle` and `.handle_mut`
