### PR TITLE
fix(examples): fix double-count for get-tez example

### DIFF
--- a/examples/get-tez/index.ts
+++ b/examples/get-tez/index.ts
@@ -12,7 +12,7 @@ const getReceivedTez = (requester: Address): number => {
 };
 
 const setReceivedTez = (requester: Address, received: number): void => {
-  Kv.set(`received/${requester}`, received + 1);
+  Kv.set(`received/${requester}`, received);
 };
 
 const addPoliteMessage = (requester: Address, message: string): void => {


### PR DESCRIPTION
The sample application get-tez double counts how much it sends to an account. When a user requests tez, it adds 2 to the amount that they have requested.