### PR TITLE
fix(examples): handle zero messages in show-tez example

### DIFF
--- a/examples/show-tez/src/index.ts
+++ b/examples/show-tez/src/index.ts
@@ -68,9 +68,14 @@ async function main() {
     try {
       if (input.toLocaleLowerCase() === "show") {
         const length: number = Number.parseInt(
-          await jstzClient.accounts.getKv(contractAddress, {
-            key: `messages/${address}/length`,
-          }),
+          await jstzClient.accounts
+            .getKv(contractAddress, {
+              key: `messages/${address}/length`,
+            })
+            .catch(() => {
+              console.log("No messages yet.");
+              return "0";
+            }),
         );
         for (let index = 0; index < length; index++) {
           const message = await jstzClient.accounts.getKv(contractAddress, {


### PR DESCRIPTION
# Description

if you run the `show-tez` example and run the command `show` before sending any messages, you get a 404 error in the console. This change handles that error.

# Manual testing

1. Start the sandbox.
2. Build and deploy the get-tez example
3. Build and run the show-tez example
4. Send the command `show`

The show-tez example should return the message "No messages yet." instead of a 404 error.
