### PR TITLE
chore: bump Rust version to 1.82.0

### DIFF
--- a/.github/workflows/cli-npm.yaml
+++ b/.github/workflows/cli-npm.yaml
@@ -51,7 +51,7 @@ jobs:
         run: apk add make musl-dev libcrypto3 openssl-dev clang gcc musl-dev libstdc++ libffi-dev g++ openssl-libs-static bash curl
         # curl and bash are required by dtolnay/rust-toolchain
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.80.0
+      - uses: dtolnay/rust-toolchain@1.82.0
         with:
           targets: wasm32-unknown-unknown
       - name: Build

--- a/crates/jstz_cli/src/jstz.rs
+++ b/crates/jstz_cli/src/jstz.rs
@@ -177,7 +177,7 @@ impl JstzClient {
     pub async fn post_operation(&self, operation: &SignedOperation) -> Result<()> {
         let response = self
             .client
-            .post(&format!("{}/operations", self.endpoint))
+            .post(format!("{}/operations", self.endpoint))
             .json(operation)
             .send()
             .await?;

--- a/crates/jstz_engine/src/script.rs
+++ b/crates/jstz_engine/src/script.rs
@@ -97,6 +97,7 @@ impl<'a, C: Compartment> Script<'a, C> {
         }
     }
 
+    #[allow(dead_code)]
     pub fn compile_and_evaluate<'cx, S>(
         path: &Path,
         src: &str,

--- a/crates/jstz_engine/src/value/conversions.rs
+++ b/crates/jstz_engine/src/value/conversions.rs
@@ -3,6 +3,7 @@ use crate::gc::{compartment::Compartment, ptr::AsRawPtr};
 use super::JsValue;
 
 impl<'a, C: Compartment> JsValue<'a, C> {
+    #[allow(dead_code)]
     pub fn is_undefined(&self) -> bool {
         unsafe { self.as_raw_ptr().is_undefined() }
     }

--- a/crates/jstzd/Dockerfile
+++ b/crates/jstzd/Dockerfile
@@ -3,7 +3,7 @@ FROM tezos/tezos:${OCTEZ_TAG} AS octez
 USER root
 RUN mkdir /octez-bin && mv /usr/local/bin/octez-client /usr/local/bin/octez-node /usr/local/bin/octez-smart-rollup-node /usr/local/bin/octez-baker-* /octez-bin
 
-FROM rust:1.80.0-alpine AS builder
+FROM rust:1.82.0-alpine AS builder
 RUN apk --no-cache add musl-dev libcrypto3 openssl-dev clang make
 ENV OPENSSL_DIR=/usr
 WORKDIR /

--- a/crates/jstzd/tests/jstzd_test.rs
+++ b/crates/jstzd/tests/jstzd_test.rs
@@ -74,7 +74,7 @@ async fn jstzd_test() {
     tokio::spawn(async move {
         sleep(Duration::from_secs(10)).await;
         reqwest::Client::new()
-            .put(&format!("http://localhost:{}/shutdown", jstzd_port))
+            .put(format!("http://localhost:{}/shutdown", jstzd_port))
             .send()
             .await
             .unwrap();

--- a/crates/jstzd/tests/main_test.rs
+++ b/crates/jstzd/tests/main_test.rs
@@ -56,10 +56,7 @@ fn valid_config_file() {
     let client = reqwest::blocking::Client::new();
     for _ in 0..30 {
         thread::sleep(Duration::from_secs(1));
-        if let Ok(r) = client
-            .get(&format!("http://localhost:{port}/health"))
-            .send()
-        {
+        if let Ok(r) = client.get(format!("http://localhost:{port}/health")).send() {
             if r.status().is_success() {
                 break;
             }
@@ -70,7 +67,7 @@ fn valid_config_file() {
     // observe the expected log line above
     thread::sleep(Duration::from_secs(5));
     assert!(client
-        .put(&format!("http://localhost:{port}/shutdown"))
+        .put(format!("http://localhost:{port}/shutdown"))
         .send()
         .unwrap()
         .status()

--- a/flake.lock
+++ b/flake.lock
@@ -179,11 +179,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728461096,
-        "narHash": "sha256-cd0cXB85B3kGpm+iumP9xCnqFErspXL9Z/2X59kQ6c4=",
+        "lastModified": 1739500069,
+        "narHash": "sha256-eCxWMqMsP2KQkleWWhs9KzFvxgd9v0F0iq7Piw6XDAs=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "e310b9bd71fa6c6a9fec0a8cf5af43ce798a0ad6",
+        "rev": "cd3e0a87bf9edadb0f311ba1eb677bbae7a08b81",
         "type": "github"
       },
       "original": {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.80.0"
+channel = "1.82.0"
 profile = "minimal"
 components = ["rustfmt", "clippy", "llvm-tools-preview"]
 targets = ["wasm32-unknown-unknown", "riscv64gc-unknown-hermit"]


### PR DESCRIPTION
# Context

Completes JSTZ-314.
[JSTZ-314](https://linear.app/tezos/issue/JSTZ-314/upgrade-rust-version-to-1820)

On the way to building jstz engine for riscv.

# Description

Bump Rust version to 1.82.0 in order to use the toolchain for `riscv64gc-unknown-linux-musl` ([ref](https://releases.rs/docs/1.82.0/#compiler)).

# Manually testing the PR

CI passes.
