### PR TITLE
fix(docs): correct instance methods for Request object

### DIFF
--- a/docs/api/request.md
+++ b/docs/api/request.md
@@ -71,14 +71,14 @@ A string property for the URL of the request.
 
 ## Instance Methods
 
-### `Response.arrayBuffer(): Promise<ArrayBuffer>`
+### `Request.arrayBuffer(): Promise<ArrayBuffer>`
 
 Returns a promise that resolves with an `ArrayBuffer`.
 
-### `Response.json(): Promise<any>`
+### `Request.json(): Promise<any>`
 
 Returns a promise that resolves with the result of parsing the body text as JSON.
 
-### `Response.text(): Promise<string>`
+### `Request.text(): Promise<string>`
 
 Returns a promise that resolves with a UTF-16 `string`.


### PR DESCRIPTION
The docs page for the Request object refers to the Response object in error.