### PR TITLE
chore: update rollup sdk version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5101,10 +5101,11 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 [[package]]
 name = "tezos-smart-rollup"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#d38a26e33e89271a4aac74fb5675ede23828b055"
+source = "git+https://gitlab.com/tezos/tezos.git?rev=9642a3e9b8e8bc3c71cbcd6f513616d4310f7552#9642a3e9b8e8bc3c71cbcd6f513616d4310f7552"
 dependencies = [
  "hermit",
  "hex",
+ "tezos-smart-rollup-build-utils",
  "tezos-smart-rollup-core",
  "tezos-smart-rollup-debug",
  "tezos-smart-rollup-encoding",
@@ -5118,22 +5119,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "tezos-smart-rollup-build-utils"
+version = "0.2.2"
+source = "git+https://gitlab.com/tezos/tezos.git?rev=9642a3e9b8e8bc3c71cbcd6f513616d4310f7552#9642a3e9b8e8bc3c71cbcd6f513616d4310f7552"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+]
+
+[[package]]
 name = "tezos-smart-rollup-constants"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#d38a26e33e89271a4aac74fb5675ede23828b055"
+source = "git+https://gitlab.com/tezos/tezos.git?rev=9642a3e9b8e8bc3c71cbcd6f513616d4310f7552#9642a3e9b8e8bc3c71cbcd6f513616d4310f7552"
 
 [[package]]
 name = "tezos-smart-rollup-core"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#d38a26e33e89271a4aac74fb5675ede23828b055"
+source = "git+https://gitlab.com/tezos/tezos.git?rev=9642a3e9b8e8bc3c71cbcd6f513616d4310f7552#9642a3e9b8e8bc3c71cbcd6f513616d4310f7552"
 dependencies = [
+ "tezos-smart-rollup-build-utils",
  "tezos-smart-rollup-constants",
 ]
 
 [[package]]
 name = "tezos-smart-rollup-debug"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#d38a26e33e89271a4aac74fb5675ede23828b055"
+source = "git+https://gitlab.com/tezos/tezos.git?rev=9642a3e9b8e8bc3c71cbcd6f513616d4310f7552#9642a3e9b8e8bc3c71cbcd6f513616d4310f7552"
 dependencies = [
  "tezos-smart-rollup-core",
  "tezos-smart-rollup-host",
@@ -5142,7 +5154,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-encoding"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#d38a26e33e89271a4aac74fb5675ede23828b055"
+source = "git+https://gitlab.com/tezos/tezos.git?rev=9642a3e9b8e8bc3c71cbcd6f513616d4310f7552#9642a3e9b8e8bc3c71cbcd6f513616d4310f7552"
 dependencies = [
  "hex",
  "nom",
@@ -5161,10 +5173,11 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-entrypoint"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#d38a26e33e89271a4aac74fb5675ede23828b055"
+source = "git+https://gitlab.com/tezos/tezos.git?rev=9642a3e9b8e8bc3c71cbcd6f513616d4310f7552#9642a3e9b8e8bc3c71cbcd6f513616d4310f7552"
 dependencies = [
  "cfg-if",
  "dlmalloc",
+ "tezos-smart-rollup-build-utils",
  "tezos-smart-rollup-core",
  "tezos-smart-rollup-debug",
  "tezos-smart-rollup-host",
@@ -5176,8 +5189,9 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-host"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#d38a26e33e89271a4aac74fb5675ede23828b055"
+source = "git+https://gitlab.com/tezos/tezos.git?rev=9642a3e9b8e8bc3c71cbcd6f513616d4310f7552#9642a3e9b8e8bc3c71cbcd6f513616d4310f7552"
 dependencies = [
+ "tezos-smart-rollup-build-utils",
  "tezos-smart-rollup-core",
  "tezos_crypto_rs 0.6.0",
  "tezos_data_encoding 0.6.0",
@@ -5222,18 +5236,19 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-macros"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#d38a26e33e89271a4aac74fb5675ede23828b055"
+source = "git+https://gitlab.com/tezos/tezos.git?rev=9642a3e9b8e8bc3c71cbcd6f513616d4310f7552#9642a3e9b8e8bc3c71cbcd6f513616d4310f7552"
 dependencies = [
  "proc-macro-error2",
  "quote",
  "shellexpand",
  "syn 2.0.87",
+ "tezos-smart-rollup-build-utils",
 ]
 
 [[package]]
 name = "tezos-smart-rollup-mock"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#d38a26e33e89271a4aac74fb5675ede23828b055"
+source = "git+https://gitlab.com/tezos/tezos.git?rev=9642a3e9b8e8bc3c71cbcd6f513616d4310f7552#9642a3e9b8e8bc3c71cbcd6f513616d4310f7552"
 dependencies = [
  "hex",
  "tezos-smart-rollup-core",
@@ -5246,16 +5261,17 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-panic-hook"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#d38a26e33e89271a4aac74fb5675ede23828b055"
+source = "git+https://gitlab.com/tezos/tezos.git?rev=9642a3e9b8e8bc3c71cbcd6f513616d4310f7552#9642a3e9b8e8bc3c71cbcd6f513616d4310f7552"
 dependencies = [
  "rustversion",
+ "tezos-smart-rollup-build-utils",
  "tezos-smart-rollup-core",
 ]
 
 [[package]]
 name = "tezos-smart-rollup-storage"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#d38a26e33e89271a4aac74fb5675ede23828b055"
+source = "git+https://gitlab.com/tezos/tezos.git?rev=9642a3e9b8e8bc3c71cbcd6f513616d4310f7552#9642a3e9b8e8bc3c71cbcd6f513616d4310f7552"
 dependencies = [
  "tezos-smart-rollup-core",
  "tezos-smart-rollup-debug",
@@ -5267,13 +5283,14 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-utils"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#d38a26e33e89271a4aac74fb5675ede23828b055"
+source = "git+https://gitlab.com/tezos/tezos.git?rev=9642a3e9b8e8bc3c71cbcd6f513616d4310f7552#9642a3e9b8e8bc3c71cbcd6f513616d4310f7552"
 dependencies = [
  "clap 4.5.20",
  "hex",
  "quanta",
  "serde",
  "serde_json",
+ "tezos-smart-rollup-build-utils",
  "tezos-smart-rollup-encoding",
  "tezos-smart-rollup-mock",
  "tezos_crypto_rs 0.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,15 +165,15 @@ default-features = false
 [patch.crates-io]
 # NOTE: When updating `tag`, also update the `tag` in the `mozjs_archive` derivation in `nix/crates.nix`
 mozjs = { git = "https://github.com/servo/mozjs.git", tag = "mozjs-sys-v0.128.3-0" }
-tezos-smart-rollup = { git = "https://gitlab.com/tezos/tezos.git" }
-tezos-smart-rollup-host = { git = "https://gitlab.com/tezos/tezos.git" }
-tezos-smart-rollup-core = { git = "https://gitlab.com/tezos/tezos.git" }
-tezos-smart-rollup-mock = { git = "https://gitlab.com/tezos/tezos.git" }
-tezos-smart-rollup-encoding = { git = "https://gitlab.com/tezos/tezos.git" }
-tezos-smart-rollup-entrypoint = { git = "https://gitlab.com/tezos/tezos.git" }
-tezos-smart-rollup-debug = { git = "https://gitlab.com/tezos/tezos.git" }
-tezos-smart-rollup-panic-hook = { git = "https://gitlab.com/tezos/tezos.git" }
-tezos-smart-rollup-storage = { git = "https://gitlab.com/tezos/tezos.git" }
+tezos-smart-rollup = { git = "https://gitlab.com/tezos/tezos.git", rev = "9642a3e9b8e8bc3c71cbcd6f513616d4310f7552" }
+tezos-smart-rollup-host = { git = "https://gitlab.com/tezos/tezos.git", rev = "9642a3e9b8e8bc3c71cbcd6f513616d4310f7552" }
+tezos-smart-rollup-core = { git = "https://gitlab.com/tezos/tezos.git", rev = "9642a3e9b8e8bc3c71cbcd6f513616d4310f7552" }
+tezos-smart-rollup-mock = { git = "https://gitlab.com/tezos/tezos.git", rev = "9642a3e9b8e8bc3c71cbcd6f513616d4310f7552" }
+tezos-smart-rollup-encoding = { git = "https://gitlab.com/tezos/tezos.git", rev = "9642a3e9b8e8bc3c71cbcd6f513616d4310f7552" }
+tezos-smart-rollup-entrypoint = { git = "https://gitlab.com/tezos/tezos.git", rev = "9642a3e9b8e8bc3c71cbcd6f513616d4310f7552" }
+tezos-smart-rollup-debug = { git = "https://gitlab.com/tezos/tezos.git", rev = "9642a3e9b8e8bc3c71cbcd6f513616d4310f7552" }
+tezos-smart-rollup-panic-hook = { git = "https://gitlab.com/tezos/tezos.git", rev = "9642a3e9b8e8bc3c71cbcd6f513616d4310f7552" }
+tezos-smart-rollup-storage = { git = "https://gitlab.com/tezos/tezos.git", rev = "9642a3e9b8e8bc3c71cbcd6f513616d4310f7552" }
 boa_ast = { git = "https://github.com/trilitech/boa.git", branch = "ajob410@fix/remove-wasm-bindgen-from-time" }
 boa_engine = { git = "https://github.com/trilitech/boa.git", branch = "ajob410@fix/remove-wasm-bindgen-from-time" }
 boa_gc = { git = "https://github.com/trilitech/boa.git", branch = "ajob410@fix/remove-wasm-bindgen-from-time" }


### PR DESCRIPTION
# Context

Closes JSTZ-313.
[JSTZ-313](https://linear.app/tezos/issue/JSTZ-313/upgrade-tezos-version)

In preparation for #707.

# Description

Upgrades the rollup sdk so that jstz_engine can be built for target `riscv64gc-unknown-linux-musl`.

# Manually testing the PR

CI should continue to work.

To test building into riscv, spin up a container with this image:

`ghcr.io/huancheng-trili/cross-riscv64gc-unknown-linux-musl:5f9a19d`

```sh
# in host environment
docker run -it --rm --entrypoint bash ghcr.io/huancheng-trili/cross-riscv64gc-unknown-linux-musl:5f9a19d
# inside the container
git clone https://github.com/jstz-dev/jstz.git --branch huanchengchang-jstz-313
# download the prebuilt mozjs archive
wget -O a.tar.gz https://github.com/huancheng-trili/test-mozjs/releases/download/mozjs-sys-v0.128.3-0/libmozjs-riscv64gc-unknown-linux-musl.tar.gz
# set up rust toolchain
curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
. "$HOME/.cargo/env"
rustup toolchain install 1.82.0
rustup target add --toolchain 1.82.0 riscv64gc-unknown-linux-musl
# build jstz_engine test binary
cd jstz/
env RUSTFLAGS='-latomic' PATH=$PATH:/tmp/riscv64-linux-musl-cross/bin CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_MUSL_RUNNER="/usr/bin/qemu-riscv64-static" CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_MUSL_LINKER="riscv64-linux-musl-gcc" CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_MUSL_AR="riscv64-linux-musl-ar" MOZJS_ARCHIVE=/a.tar.gz cargo +1.82.0 build -p jstz_engine --release --features "native-kernel" --target riscv64gc-unknown-linux-musl
# run the built jstz_engine test binary
QEMU_LD_PREFIX=/tmp/riscv64-linux-musl-cross/riscv64-linux-musl/ ./target/riscv64gc-unknown-linux-musl/release/jstz_engine
```