### PR TITLE
feat(jstzd): show bootstrap account alias

### DIFF
--- a/crates/jstzd/src/config.rs
+++ b/crates/jstzd/src/config.rs
@@ -30,28 +30,34 @@ pub const BOOTSTRAP_CONTRACT_NAMES: [(&str, &str); 2] = [
     ("exchanger", EXCHANGER_ADDRESS),
     ("jstz_native_bridge", JSTZ_NATIVE_BRIDGE_ADDRESS),
 ];
-pub(crate) const BOOTSTRAP_ACCOUNTS: [(&str, &str); 6] = [
+pub(crate) const BOOTSTRAP_ACCOUNTS: [(&str, &str, &str); 6] = [
     (
+        "bootstrap0",
         "edpkuSLWfVU1Vq7Jg9FucPyKmma6otcMHac9zG4oU1KMHSTBpJuGQ2",
         "unencrypted:edsk31vznjHSSpGExDMHYASz45VZqXN4DPxvsa4hAyY8dHM28cZzp6",
     ),
     (
+        "bootstrap1",
         "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav",
         "unencrypted:edsk3gUfUPyBSfrS9CCgmCiQsTCHGkviBDusMxDJstFtojtc1zcpsh",
     ),
     (
+        "bootstrap2",
         "edpktzNbDAUjUk697W7gYg2CRuBQjyPxbEg8dLccYYwKSKvkPvjtV9",
         "unencrypted:edsk39qAm1fiMjgmPkw1EgQYkMzkJezLNewd7PLNHTkr6w9XA2zdfo",
     ),
     (
+        "bootstrap3",
         "edpkuTXkJDGcFd5nh6VvMz8phXxU3Bi7h6hqgywNFi1vZTfQNnS1RV",
         "unencrypted:edsk4ArLQgBTLWG5FJmnGnT689VKoqhXwmDPBuGx3z4cvwU9MmrPZZ",
     ),
     (
+        "bootstrap4",
         "edpkuFrRoDSEbJYgxRtLx2ps82UdaYc1WwfS9sE11yhauZt5DgCHbU",
         "unencrypted:edsk2uqQB9AY4FvioK2YMdfmyMrer5R8mGFyuaLLFfSRo8EoyNdht3",
     ),
     (
+        "bootstrap5",
         "edpkv8EUUH68jmo3f7Um5PezmfGrRF24gnfLpH3sVNwJnV5bVCxL2n",
         "unencrypted:edsk4QLrcijEffxV31gGdN2HU7UpyJjA8drFoNcmnB28n89YjPNRFm",
     ),
@@ -229,7 +235,7 @@ async fn build_protocol_params(
         .map(|v| (*v).to_owned())
         .collect::<Vec<BootstrapAccount>>();
     for account in BOOTSTRAP_ACCOUNTS
-        .map(|(pk, _)| BootstrapAccount::new(pk, BOOTSTRAP_ACCOUNT_BALANCE).unwrap())
+        .map(|(_, pk, _)| BootstrapAccount::new(pk, BOOTSTRAP_ACCOUNT_BALANCE).unwrap())
     {
         accounts.push(account);
     }
@@ -274,7 +280,7 @@ mod tests {
     use tezos_crypto_rs::hash::ContractKt1Hash;
     use tokio::io::AsyncReadExt;
 
-    const ACCOUNT_PUBLIC_KEY: &str = super::BOOTSTRAP_ACCOUNTS[0].0;
+    const ACCOUNT_PUBLIC_KEY: &str = super::BOOTSTRAP_ACCOUNTS[0].1;
 
     async fn read_param_file(path: &PathBuf) -> serde_json::Value {
         let mut buf = String::new();
@@ -632,7 +638,7 @@ mod tests {
             .map(|acc| serde_json::from_value::<BootstrapAccount>(acc.clone()).unwrap())
             .collect::<Vec<_>>();
 
-        for (pk, _) in super::BOOTSTRAP_ACCOUNTS {
+        for (_, pk, _) in super::BOOTSTRAP_ACCOUNTS {
             assert!(
                 bootstrap_accounts.contains(
                     &BootstrapAccount::new(pk, super::BOOTSTRAP_ACCOUNT_BALANCE).unwrap()


### PR DESCRIPTION
# Context

Completes JSTZ-311.
[JSTZ-311](https://linear.app/tezos/issue/JSTZ-311/show-bootstrap-account-aliases)

# Description

Display bootstrap account aliases.

Bootstrap accounts defined in the parameter file will still be displayed without aliases, but these accounts cannot be used in transfers as faucets because jstzd does not have their private keys. Users will be puzzled when they try to transfer some fund from the bootstrap accounts they define in their parameter files just to find that jstz cli returns an error saying that the accounts do not exist. I think a good way of resolving this issue is to ask users to specify bootstrap accounts as part of jstzd config with private keys. Jstzd will ignore all bootstrap accounts in the parameter file and inject those retrieved from jstzd config. I'm not dealing with this case here anyway.

# Manually testing the PR

* Unit test: updated the corresponding test.
* Ran jstzd locally
```sh
$ ./jstzd run ./config.json 

           __________
           \  jstz  /
            )______(
            |""""""|_.-._,.---------.,_.-._
            |      | | |               | | ''-.
            |      |_| |_             _| |_..-'
            |______| '-' `'---------'` '-'
            )""""""(
           /________\
           `'------'`
         .------------.
        /______________\

        0.1.0-alpha.0 https://github.com/jstz-dev/jstz

  +---------------------------------------------------+---------------------+
  | Address                                           | XTZ Balance (mutez) |
  +===================================================+=====================+
  | (bootstrap0) tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV | 100000000000        |
  +---------------------------------------------------+---------------------+
  | (bootstrap1) tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx | 100000000000        |
  +---------------------------------------------------+---------------------+
  | (bootstrap2) tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN | 100000000000        |
  +---------------------------------------------------+---------------------+
  | (bootstrap3) tz1faswCTDciRzE4oJ9jn2Vm2dvjeyA9fUzU | 100000000000        |
  +---------------------------------------------------+---------------------+
  | (bootstrap4) tz1b7tUupMgCNw2cCLpKTkSD1NZzB5TkP2sv | 100000000000        |
  +---------------------------------------------------+---------------------+
  | (bootstrap5) tz1ddb9NMYHZi5UzPdzTZMYQQZoMub195zgv | 100000000000        |
  +---------------------------------------------------+---------------------+
```
