### PR TITLE
fix(crypto): check length of smart function addresses

### DIFF
--- a/crates/jstz_crypto/src/smart_function_hash.rs
+++ b/crates/jstz_crypto/src/smart_function_hash.rs
@@ -57,6 +57,9 @@ impl<'a> Hash<'a> for SmartFunctionHash {
     }
 
     fn from_base58(data: &str) -> Result<Self> {
+        if data.len() < 3 {
+            return Err(Error::InvalidSmartFunctionHash);
+        }
         match &data[..3] {
             "KT1" => Ok(SmartFunctionHash(ContractKt1Hash::from_base58_check(data)?)),
             _ => Err(Error::InvalidSmartFunctionHash),
@@ -113,6 +116,8 @@ mod test {
 
         // Test with completely invalid format
         assert!(SmartFunctionHash::from_str("invalid").is_err());
+
+        assert!(SmartFunctionHash::from_str("a").is_err());
     }
 
     #[test]


### PR DESCRIPTION
# Context

Part of JSTZ-338.
[JSTZ-338](https://linear.app/tezos/issue/JSTZ-338/jstz-account-alias-panics-when-address-is-too-short)

# Description

Check the length of input strings in `from_base58` to avoid panics.

This bug leads to something like this:
```
$ jstz account alias a b                      
thread 'main' panicked at crates/jstz_crypto/src/smart_function_hash.rs:60:20:
byte index 3 is out of bounds of b
```

# Manually testing the PR

Updated the corresponding unit test.
