### PR TITLE
ci: benchmark after build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,33 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  benchmark:
+    name: Benchmark
+    runs-on: [x86_64, linux, nix]
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run benchmark
+        id: bench_head
+        run: |
+          result=$(nix --accept-flake-config --log-format raw -L run .#tps_bench)
+          echo "result=$result" >> $GITHUB_OUTPUT || true
+      - uses: actions/checkout@v4
+        if: github.event_name == 'pull_request'
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+      - name: Run benchmark with base
+        id: bench_base
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "result=$(nix --accept-flake-config --log-format raw -L run .#tps_bench)" >> $GITHUB_OUTPUT || true
+      - name: Display result
+        run: |
+          echo "Current branch: ${{ steps.bench_head.outputs.result }}"
+          if [ -n "${{ steps.bench_base.outputs.result }}" ]; then
+            echo "Base branch (${{ github.event.pull_request.base.ref }}): ${{ steps.bench_base.outputs.result }}"
+          fi
+
   build-docs:
     name: Build Documentation
     runs-on: ubuntu-latest

--- a/crates/jstz_tps_bench/src/kernel/main.rs
+++ b/crates/jstz_tps_bench/src/kernel/main.rs
@@ -6,14 +6,13 @@ use jstz_crypto::hash::Hash;
 use jstz_crypto::smart_function_hash::SmartFunctionHash;
 use tezos_smart_rollup::prelude::Runtime;
 use tezos_smart_rollup::{entrypoint, storage::path::RefPath};
-use tezos_smart_rollup_core::smart_rollup_core::SmartRollupCore;
 
 #[entrypoint::main]
 #[cfg_attr(
     feature = "static-inbox",
     entrypoint::runtime(static_inbox = "./inbox.json")
 )]
-pub fn entry(host: &mut (impl Runtime + SmartRollupCore)) {
+pub fn entry(host: &mut impl Runtime) {
     // We need to setup the ticketer (bridge address that funds Jstz) for Jstz to not panic.
     {
         static ONCE: Once = Once::new();

--- a/flake.nix
+++ b/flake.nix
@@ -249,6 +249,7 @@
               default = self.packages.${system}.jstz_kernel;
             };
           checks = crates.checks // {formatting = fmt.config.build.check self;};
+          apps = crates.apps;
 
           formatter = fmt.config.build.wrapper;
 


### PR DESCRIPTION
# Context

Part of JSTZ-31.
[JSTZ-31](https://linear.app/tezos/issue/JSTZ-31)

# Description

Runs benchmarking as part of each build. If a build is for a PR, benchmarking will be run against the base branch as well for comparison. If benchmarking does not work in the base branch, it will be skipped. Of course it's possible to cache the result somewhere so that we don't need to run it for the base branch every time, but since it requires setting up a database and nix cache should help avoid building the base branch from scratch, I think it's okay to leave it like this. This result display can be further extended to something like attaching a comment to a PR so that people are easily aware of changes that lead to performance regression.

`jstz_bench` in flake.nix looks a bit awkward because of how the benchmark program needs to be built. I want to keep parameters, e.g. number of smart function calls, all in the same place. With this implementation, everything is wrapped inside `run.sh` and that looks better to me.

Note that [github-action-benchmark](https://github.com/benchmark-action/github-action-benchmark) is not used here because it's not supposed to be used for PRs. We can use that for the main branch, but that's not the point of this PR.

# Manually testing the PR

The [workflow run](https://github.com/jstz-dev/jstz/actions/runs/13628594079/job/38091300947?pr=842) succeeded.
```
Current branch: 10 FA2 transfers took 49.467928ms @ 202.151 TPS
```
