### PR TITLE
ci: run wpt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,24 @@ jobs:
             echo "Base branch (${{ github.event.pull_request.base.ref }}): ${{ steps.bench_base.outputs.result }}"
           fi
 
+  wpt:
+    name: Web Platform Test
+    runs-on: ubuntu-latest
+    container:
+      image: rust:1.82-slim
+    steps:
+      - name: Setup
+        run: apt update && apt install -y git curl python3.11 pkg-config libssl-dev
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Run
+        run: |
+          ln -s /usr/bin/python3.11 /usr/bin/python3
+          cd crates/jstz_wpt/wpt && python3 wpt make-hosts-file >> /etc/hosts
+          python3 wpt serve &
+          cd ../../jstz_runtime && cargo test --test wpt
+
   build-docs:
     name: Build Documentation
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Context

Completes JSTZ-339.
[JSTZ-339](https://linear.app/tezos/issue/JSTZ-339/run-web-platform-tests-as-part-of-ci)

# Description

Runs wpt as part of CI.

I decided not to add wpt as a nix flake package because
* it's troublesome.
* adding wpt means the submodule needs to be pulled into the source as well, and wpt is a huge code repository, meaning a non-trivial increase in the amount of data cached / size of derivation.
* running wpt in parallel means we can save some time for each CI run.

Note:
* Using a rust base image is much simpler than using a python base image because there is no need to set up CC and relevant libraries for rust with a rust base image.
* Soft-linking `python3.11` to `python3` is necessary because our wpt runner looks for `python3`.
* wpt has some problem with python 3.12 and above, so 3.11 is the latest suitable version.

# Manually testing the PR

[A successful run](https://github.com/jstz-dev/jstz/actions/runs/13718157860/job/38367385624)
