### PR TITLE
feat(wpt): enable tests for interval and timeout functions

### DIFF
--- a/crates/jstz_api/tests/wpt.rs
+++ b/crates/jstz_api/tests/wpt.rs
@@ -387,6 +387,9 @@ async fn test_wpt() -> Result<()> {
             r"^\/fetch\/api\/response\/response-stream-.+\.any\.html$",
             r"^\/html\/webappapis\/atob\/base64\.any\.html$", // atob, btoa
             r"^\/html\/webappapis\/structured-clone\/structured\-clone\.any\.html$", // structuredClone
+            // set/clearTimeout, set/clearInterval
+            // Some tests show Err because the targeted set/clear functions are not yet defined
+            r"^\/html\/webappapis\/timers\/[^\/]+\.any\.html$",
         ]
         .as_ref(),
     )?;

--- a/crates/jstz_api/tests/wptreport.json
+++ b/crates/jstz_api/tests/wptreport.json
@@ -14138,6 +14138,158 @@
                   }
                 }
               }
+            },
+            "timers": {
+              "Folder": {
+                "clearinterval-from-callback.any.js": {
+                  "Test": {
+                    "variations": [
+                      {
+                        "subtests": [
+                          {
+                            "name": "Clearing an interval from the callback should still clear it.",
+                            "status": "Fail",
+                            "message": "setInterval is not defined"
+                          }
+                        ],
+                        "status": "Ok",
+                        "metrics": {
+                          "passed": 0,
+                          "failed": 1,
+                          "timed_out": 0
+                        }
+                      }
+                    ]
+                  }
+                },
+                "cleartimeout-clearinterval.any.js": {
+                  "Test": {
+                    "variations": [
+                      {
+                        "subtests": [
+                          {
+                            "name": "Clear timeout with clearInterval",
+                            "status": "Fail",
+                            "message": "setTimeout is not defined"
+                          },
+                          {
+                            "name": "Clear interval with clearTimeout",
+                            "status": "Fail",
+                            "message": "setInterval is not defined"
+                          }
+                        ],
+                        "status": "Ok",
+                        "metrics": {
+                          "passed": 0,
+                          "failed": 2,
+                          "timed_out": 0
+                        }
+                      }
+                    ]
+                  }
+                },
+                "evil-spec-example.any.js": {
+                  "Test": {
+                    "variations": [
+                      {
+                        "subtests": [],
+                        "status": "Err",
+                        "metrics": {
+                          "passed": 0,
+                          "failed": 0,
+                          "timed_out": 0
+                        }
+                      }
+                    ]
+                  }
+                },
+                "missing-timeout-setinterval.any.js": {
+                  "Test": {
+                    "variations": [
+                      {
+                        "subtests": [
+                          {
+                            "name": "Calling setInterval with no interval should be the same as if called with 0 interval",
+                            "status": "Fail",
+                            "message": "setInterval is not defined"
+                          },
+                          {
+                            "name": "Calling setInterval with undefined interval should be the same as if called with 0 interval",
+                            "status": "Fail",
+                            "message": "setInterval is not defined"
+                          }
+                        ],
+                        "status": "Ok",
+                        "metrics": {
+                          "passed": 0,
+                          "failed": 2,
+                          "timed_out": 0
+                        }
+                      }
+                    ]
+                  }
+                },
+                "negative-setinterval.any.js": {
+                  "Test": {
+                    "variations": [
+                      {
+                        "subtests": [],
+                        "status": "Err",
+                        "metrics": {
+                          "passed": 0,
+                          "failed": 0,
+                          "timed_out": 0
+                        }
+                      }
+                    ]
+                  }
+                },
+                "negative-settimeout.any.js": {
+                  "Test": {
+                    "variations": [
+                      {
+                        "subtests": [],
+                        "status": "Err",
+                        "metrics": {
+                          "passed": 0,
+                          "failed": 0,
+                          "timed_out": 0
+                        }
+                      }
+                    ]
+                  }
+                },
+                "type-long-setinterval.any.js": {
+                  "Test": {
+                    "variations": [
+                      {
+                        "subtests": [],
+                        "status": "Err",
+                        "metrics": {
+                          "passed": 0,
+                          "failed": 0,
+                          "timed_out": 0
+                        }
+                      }
+                    ]
+                  }
+                },
+                "type-long-settimeout.any.js": {
+                  "Test": {
+                    "variations": [
+                      {
+                        "subtests": [],
+                        "status": "Err",
+                        "metrics": {
+                          "passed": 0,
+                          "failed": 0,
+                          "timed_out": 0
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
# Context

Part of JSTZ-303.
[JSTZ-303](https://linear.app/tezos/issue/JSTZ-303/record-all-relevant-wpt-test-suites)

# Description

Enable test suites for set/clear interval and timeout functions ([interface](https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timers), [implementation](https://nodejs.org/docs/v22.14.0/api/timers.html#scheduling-timers)).

# Manually testing the PR

```sh
cargo test --test wpt
```
