### PR TITLE
chore: use `nix fmt` for fmt and fmt-check targets in Makefile

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -13,4 +13,6 @@
 # Lock files
 **/*.lock
 
+# Ignore generated files:
 crates/jstz_node/openapi.json
+crates/jstz_tps_bench/fa2.js

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,2 +1,4 @@
 max_width = 90
 newline_style = "Unix"
+
+ignore = []

--- a/Makefile
+++ b/Makefile
@@ -93,35 +93,13 @@ clean:
 	@rm -f result
 	@rm -rf logs
 
-.PHONY: fmt-nix-check
-fmt-nix-check:
-	@alejandra check ./
-
-.PHONY: fmt-nix
-fmt-nix:
-	@alejandra ./
-
-.PHONY: fmt-rust-check
-fmt-rust-check:
-	@cargo fmt --check
-
-.PHONY: fmt-rust
-fmt-rust:
-	@cargo fmt
-
-.PHONY: fmt-js-check
-fmt-js-check:
-	npm run check:format
-
-.PHONY: fmt-js
-fmt-js:
-	npm run format
-
 .PHONY: fmt
-fmt: fmt-nix fmt-rust fmt-js
+fmt:
+	nix fmt
 
 .PHONY: fmt-check
-fmt-check: fmt-nix-check fmt-rust-check fmt-js-check
+fmt-check:
+	nix fmt -- --fail-on-change
 
 .PHONY: lint
 lint:

--- a/flake.nix
+++ b/flake.nix
@@ -193,7 +193,19 @@
 
             # TODO(https://linear.app/tezos/issue/JSTZ-63)
             # Configure formatter for LIGO contracts
-            settings.global.excludes = ["target" "result" "node_modules/**" ".github" ".direnv" "contracts/**" "Dockerfile" "*.toml" "crates/jstz_tps_bench/fa2.js"];
+
+            # NOTE: For language specific ignores, use the specific ignore files:
+            #   rustfmt: use .rustfmt.toml
+            #   prettier: use .prettierignore
+            settings.global.excludes =
+              # Build/install directories (ignored by all formatters)
+              ["target" "result" "node_modules/**" "**/dist"]
+              ++
+              # Dot files
+              [".direnv"]
+              ++
+              # Unsupported languages (LIGO, Docker)
+              ["contracts/**" "Dockerfile"];
           };
 
           mkFrameworkFlags = frameworks:


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

Following #837, the pre-commit hook fails (since `fa2.js` is not formatted). 

There are two issues here:
1. The configured ignore `crates/jstz_tps_bench/fa2.js` should be `.prettierignore` instead of the global ignores (for treefmt)
2. The `make fmt` targets don't use Nix

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

This PR updates `make fmt` and `make fmt-check` to use `nix fmt`. 
Additionally it moves the ignore for `crates/jstz_tps_bench/fa2.js` to `.prettierignore` 
(and a comment instructing that future changes should be made in `.rustfmt.toml`/`.prettierignore`
 for language-specific ignores)

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

Test your pre-commit hook works by committing something :) 
