### PR TITLE
ci: build static x64 cli binary

### DIFF
--- a/.github/workflows/cli-npm.yaml
+++ b/.github/workflows/cli-npm.yaml
@@ -17,13 +17,30 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
   linux-amd64:
     name: Build CLI for Linux AMD64
-    runs-on: [x86_64, linux, nix]
+    runs-on: ubuntu-24.04
+    # need to build in an alpine container so that cargo can build with musl
+    # target: x86_64-unknown-linux-musl
+    container:
+      image: alpine:3.21
     steps:
-      - uses: jstz-dev/jstz/.github/actions/build-cli@main
+      - name: Install dependencies
+        shell: sh
+        run: apk add make musl-dev libcrypto3 openssl-dev clang gcc musl-dev libstdc++ libffi-dev g++ openssl-libs-static bash curl
+        # curl and bash are required by dtolnay/rust-toolchain
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.82.0
         with:
-          platform: linux
-          arch: x64 # To match the arch name in Node.js. This will be referenced by the npm package
+          targets: wasm32-unknown-unknown
+      - name: Build
+        shell: sh
+        run: make build-cli
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/release/jstz
+          asset_name: jstz_linux_x64
+          tag: ${{ github.ref_name }}
   linux-arm64:
     # cannot easily build with nix on arm64 because mozjs does not have prebuilds for linux arm64
     # so we need to use make build-cli here
@@ -31,7 +48,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     # need to build in an alpine container so that cargo can build with musl
     container:
-      image: alpine
+      image: alpine:3.21
       volumes:
         - /:/host
     steps:


### PR DESCRIPTION
# Context

Completes JSTZ-345.
[JSTZ-345](https://linear.app/tezos/issue/JSTZ-345/build-static-cli-binary-for-x86-64)

# Description

Build CLI for `x86_64-unknown-linux-musl` in order to get static x64 cli binaries.

I tried to use `pkgsMusl` in nix, but nix tried to rebuild a whole bunch of irrelevant packages for musl, which took hours, and in the end there were some error in those in irrelevant packages, and again mozjs does not have a prebuilt for `x86_64-unknown-linux-musl`, so I'm building this as how it's done for aarch64-linux.

# Manually testing the PR

[Test workflow run](https://github.com/jstz-dev/jstz/actions/runs/13699721004/job/38310216001)

Also tested the built binary in a clean x64 environment.
