### PR TITLE
chore(octez): remove disable-slow-pvm

### DIFF
--- a/crates/jstzd/Cargo.toml
+++ b/crates/jstzd/Cargo.toml
@@ -51,7 +51,7 @@ tezos_crypto_rs.workspace = true
 
 [features]
 skip-rollup-tests = []
-build-image = ["octez/disable-alpha", "octez/disable-slow-pvm"]
+build-image = ["octez/disable-alpha"]
 
 [[bin]]
 name = "jstzd"

--- a/crates/octez/Cargo.toml
+++ b/crates/octez/Cargo.toml
@@ -32,4 +32,3 @@ tokio.workspace = true
 
 [features]
 disable-alpha = []
-disable-slow-pvm = []

--- a/crates/octez/src/async/rollup.rs
+++ b/crates/octez/src/async/rollup.rs
@@ -221,7 +221,6 @@ impl OctezRollup {
             &self.rpc_endpoint.port().to_string(),
             "--acl-override",
             "allow-all",
-            #[cfg(feature = "disable-slow-pvm")]
             "--unsafe-disable-wasm-kernel-checks",
         ]);
         if let Some(boot_sector_file) = boot_sector_file {


### PR DESCRIPTION
# Context

`disable-slow-pvm` was created when the old octez version whose rollup node did not have the flag was still in use by nix. Now we no longer need it.

# Description

Removing this feature.

# Manually testing the PR

Everything should still build.
