### PR TITLE
feat(runtime): add JstzRuntime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,12 +304,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base32"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
-
-[[package]]
 name = "base58"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,16 +640,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "boxed_error"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17d4f95e880cfd28c4ca5a006cf7f6af52b4bcb7b5866f573b2faa126fb7affb"
-dependencies = [
- "quote",
- "syn 2.0.87",
-]
-
-[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,26 +720,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58ec49028cb308564429cd8fac4ef21290067a0afe8f5955330a8d487d0d790c"
 dependencies = [
  "itoa",
-]
-
-[[package]]
-name = "capacity_builder"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f2d24a6dcf0cd402a21b65d35340f3a49ff3475dc5fdac91d22d2733e6641c6"
-dependencies = [
- "capacity_builder_macros",
- "itoa",
-]
-
-[[package]]
-name = "capacity_builder_macros"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4a6cae9efc04cc6cbb8faf338d2c497c165c83e74509cf4dbedea948bbf6e5"
-dependencies = [
- "quote",
- "syn 2.0.87",
 ]
 
 [[package]]
@@ -1002,25 +966,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1237,7 +1182,7 @@ dependencies = [
  "bit-set",
  "bit-vec",
  "bytes",
- "capacity_builder 0.1.3",
+ "capacity_builder",
  "cooked-waker",
  "deno_core_icudata",
  "deno_error",
@@ -1296,56 +1241,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deno_fs"
-version = "0.100.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82f79b71403b93b248727a89746026104b3a5ac1d82e79a02af6fa8e8487666"
-dependencies = [
- "async-trait",
- "base32",
- "boxed_error",
- "deno_core",
- "deno_error",
- "deno_io",
- "deno_path_util",
- "deno_permissions",
- "filetime",
- "junction",
- "libc",
- "nix 0.27.1",
- "rand 0.8.5",
- "rayon",
- "serde",
- "thiserror 2.0.12",
- "winapi",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "deno_io"
-version = "0.100.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e72489fe0dcada08047611d1ab92db1baebf7b606ab7c78790f622ecb30e22b"
-dependencies = [
- "async-trait",
- "deno_core",
- "deno_error",
- "filetime",
- "fs3",
- "libc",
- "log",
- "once_cell",
- "os_pipe",
- "parking_lot",
- "pin-project",
- "rand 0.8.5",
- "tokio",
- "uuid",
- "winapi",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "deno_ops"
 version = "0.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1373,38 +1268,6 @@ dependencies = [
  "sys_traits",
  "thiserror 2.0.12",
  "url",
-]
-
-[[package]]
-name = "deno_permissions"
-version = "0.49.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf879dff0b3de4dbcb78d6dda3a55e711369d5b9f479270a82853ef106c4176"
-dependencies = [
- "capacity_builder 0.5.0",
- "deno_core",
- "deno_error",
- "deno_path_util",
- "deno_terminal",
- "fqdn",
- "libc",
- "log",
- "once_cell",
- "percent-encoding",
- "serde",
- "thiserror 2.0.12",
- "which 6.0.3",
- "winapi",
-]
-
-[[package]]
-name = "deno_terminal"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daef12499e89ee99e51ad6000a91f600d3937fb028ad4918af76810c5bc9e0d5"
-dependencies = [
- "once_cell",
- "termcolor",
 ]
 
 [[package]]
@@ -1960,23 +1823,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fqdn"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb540cf7bc4fe6df9d8f7f0c974cfd0dce8ed4e9e8884e73433b503ee78b4e7d"
-
-[[package]]
-name = "fs3"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb17cf6ed704f72485332f6ab65257460c4f9f3083934cf402bf9f5b3b600a90"
-dependencies = [
- "libc",
- "rustc_version 0.2.3",
- "winapi",
 ]
 
 [[package]]
@@ -3363,7 +3209,11 @@ name = "jstz_runtime"
 version = "0.1.0-alpha.0"
 dependencies = [
  "deno_core",
- "deno_fs",
+ "jstz_core",
+ "jstz_crypto",
+ "tezos-smart-rollup",
+ "tezos-smart-rollup-host",
+ "tezos-smart-rollup-mock",
 ]
 
 [[package]]
@@ -3451,16 +3301,6 @@ dependencies = [
  "tezos-smart-rollup-installer-config",
  "tezos_crypto_rs 0.6.0",
  "tokio",
-]
-
-[[package]]
-name = "junction"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72bbdfd737a243da3dfc1f99ee8d6e166480f17ab4ac84d7c34aacd73fc7bd16"
-dependencies = [
- "scopeguard",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4013,16 +3853,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "os_pipe"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57119c3b893986491ec9aa85056780d3a0f3cf4da7cc09dd3650dbd6c6738fb9"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "os_str_bytes"
@@ -4602,26 +4432,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6928fa44c097620b706542d428957635951bade7143269085389d42c8a4927e"
 dependencies = [
  "bitflags 2.6.0",
-]
-
-[[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]

--- a/crates/jstz_core/src/host.rs
+++ b/crates/jstz_core/src/host.rs
@@ -1,14 +1,13 @@
 use derive_more::Display;
+pub use tezos_smart_rollup_host::runtime::{
+    Runtime as HostRuntime, RuntimeError as HostError,
+};
 use tezos_smart_rollup_host::{
     dal_parameters::RollupDalParameters,
     input,
     metadata::RollupMetadata,
     path::{self, Path},
-    runtime::{Runtime, ValueType},
-};
-
-pub use tezos_smart_rollup_host::runtime::{
-    Runtime as HostRuntime, RuntimeError as HostError,
+    runtime::ValueType,
 };
 
 mod erased_runtime {
@@ -435,7 +434,7 @@ pub struct JsHostRuntime<'a> {
 }
 
 impl<'a> JsHostRuntime<'a> {
-    pub fn new<R: Runtime>(rt: &'a mut R) -> JsHostRuntime<'static> {
+    pub fn new<R: HostRuntime>(rt: &'a mut R) -> JsHostRuntime<'static> {
         let rt_ptr: *mut dyn erased_runtime::Runtime = rt;
 
         // SAFETY

--- a/crates/jstz_proto/Cargo.toml
+++ b/crates/jstz_proto/Cargo.toml
@@ -33,3 +33,4 @@ utoipa.workspace = true
 jstz_mock = { path = "../jstz_mock" }
 tezos-smart-rollup-mock.workspace = true
 bincode.workspace = true
+

--- a/crates/jstz_runtime/Cargo.toml
+++ b/crates/jstz_runtime/Cargo.toml
@@ -12,4 +12,12 @@ description = "Javascript runtime for Jstz"
 
 [dependencies]
 deno_core.workspace = true
-deno_fs.workspace = true
+
+jstz_core = { path = "../jstz_core" }
+jstz_crypto = { path = "../jstz_crypto" }
+
+tezos-smart-rollup.workspace = true
+tezos-smart-rollup-host.workspace = true
+
+[dev-dependencies]
+tezos-smart-rollup-mock.workspace = true

--- a/crates/jstz_runtime/src/lib.rs
+++ b/crates/jstz_runtime/src/lib.rs
@@ -1,1 +1,23 @@
+pub mod runtime;
 
+pub use runtime::JstzRuntime;
+
+#[cfg(test)]
+mod test_utils {
+
+    use tezos_smart_rollup_mock::MockHost;
+
+    #[allow(unused)]
+    #[allow(clippy::box_collection)]
+    pub fn init_mock_host() -> (Box<Vec<u8>>, MockHost) {
+        let mut sink: Box<Vec<u8>> = Box::default();
+        let mut host = MockHost::default();
+        host.set_debug_handler(unsafe {
+            std::mem::transmute::<&mut std::vec::Vec<u8>, &'static mut Vec<u8>>(
+                sink.as_mut(),
+            )
+        });
+
+        (sink, host)
+    }
+}

--- a/crates/jstz_runtime/src/runtime.rs
+++ b/crates/jstz_runtime/src/runtime.rs
@@ -1,0 +1,118 @@
+use deno_core::*;
+use jstz_core::host::HostRuntime;
+use jstz_core::host::JsHostRuntime;
+use jstz_core::kv::Transaction;
+use jstz_crypto::smart_function_hash::SmartFunctionHash;
+use serde::Deserialize;
+use std::ops::Deref;
+use std::ops::DerefMut;
+
+fn init_extenions() -> Vec<Extension> {
+    vec![]
+}
+
+/// [`JstzRuntime`] manages the [`JsRuntime`] state. It is also
+/// provides [`JsRuntime`] with the instiatiated [`HostRuntime`]
+/// and protocol capabilities
+pub struct JstzRuntime {
+    runtime: JsRuntime,
+}
+
+impl JstzRuntime {
+    /// Returns the default [`RuntimeOptions`] configured
+    /// with custom extensions
+    pub fn options() -> RuntimeOptions {
+        let extensions = init_extenions();
+        RuntimeOptions {
+            extensions,
+            ..Default::default()
+        }
+    }
+
+    /// Creates a new [`JstzRuntime`] with protocol extensions registered
+    /// and an instance of Protocol exposed in the [`OpState`]
+    pub fn init(
+        hrt: &mut impl HostRuntime,
+        tx: &mut Transaction,
+        address: SmartFunctionHash,
+    ) -> Self {
+        let protocol = Protocol::new(hrt, tx, address);
+
+        let mut runtime = JsRuntime::new(RuntimeOptions {
+            extensions: init_extenions(),
+            ..Default::default()
+        });
+
+        let op_state = runtime.op_state();
+        op_state.borrow_mut().put(protocol);
+
+        Self { runtime }
+    }
+
+    /// Executes traditional, non-ECMAScript-module JavaScript code, ignoring
+    /// its result
+    pub fn execute(mut self, code: &str) -> Option<()> {
+        self.execute_script("jstz://run", code.to_string()).ok()?;
+        Some(())
+    }
+
+    /// Executes traditional, non-ECMAScript-module JavaScript code, parsing
+    /// its result ot a Rust type T
+    pub fn execute_with_result<'de, T: Deserialize<'de>>(
+        &mut self,
+        code: &str,
+    ) -> Option<T> {
+        let value = self.execute_script("jstz://run", code.to_string()).unwrap();
+        let scope = &mut self.handle_scope();
+        let local = v8::Local::new(scope, value);
+        serde_v8::from_v8::<T>(scope, local).ok()
+    }
+}
+
+impl Deref for JstzRuntime {
+    type Target = JsRuntime;
+
+    fn deref(&self) -> &Self::Target {
+        &self.runtime
+    }
+}
+
+impl DerefMut for JstzRuntime {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.runtime
+    }
+}
+
+pub struct Protocol {
+    pub host: JsHostRuntime<'static>,
+    pub tx: &'static mut Transaction,
+    pub address: SmartFunctionHash,
+}
+
+impl Protocol {
+    pub fn new(
+        hrt: &mut impl HostRuntime,
+        tx: &mut Transaction,
+        address: SmartFunctionHash,
+    ) -> Self {
+        let host = JsHostRuntime::new(hrt);
+
+        // Safety: Since we synchronisely execute Operatios, the tx will not be dropped before
+        // the runtime, so this is safe
+        // TODO: Replace with Arc<Mutex<Transaction>>
+        // https://linear.app/tezos/issue/JSTZ-375/replace-andmut-transaction-with-arcmutextransaction
+        let tx = unsafe {
+            std::mem::transmute::<&mut Transaction, &'static mut Transaction>(tx)
+        };
+        Protocol { host, tx, address }
+    }
+}
+
+#[macro_export]
+macro_rules! init_ops_and_esm_extensions  {
+    ($($ext:ident),*) => {
+        vec![
+            $($ext::init_ops_and_esm()),*
+        ]
+    };
+}


### PR DESCRIPTION
# Context
Adds `JstzRuntime`, the top level struct that will manage the `JsRuntime` state. 
This PR sets up for the implementation of runtime APIs. Check out https://github.com/jstz-dev/jstz/pull/863, https://github.com/jstz-dev/jstz/pull/868/filesfor an example.

# Description
*  For `JstzRuntime` to interact with protocol state, we pre-seed the initialization with a `Protocol` that allows us to expose instances of `HostRuntime` and `Transaction` to extension logic. 
* ~`deno_core` exposes the ability to take snapshots of the running instance which we can use to quickly create isolated, sandboxed environments for each Smart Function evaluation but I couldn't got that to work yet 😞 ~ Removed snapshot function
* Currently, `JstzRuntime` can only execute plain, non ECMAScript module Javascript. Supporting default handler will be done in a follow up PR. See [JSTZ-366](https://linear.app/tezos/issue/JSTZ-366/load-init-and-run-default-handler) 
* Introduces `init_mock_host()` util which initializes the MockHost and sets & exposes a vec buffer for the debug msg sink. This allows us to inspect` debug_msg` without reading from stdout. e 
* The runtime fns return `Option`s for now. Refactoring to a proper error type can be done later


# Manually testing the PR
Will be tested in subsequent PRs that make use of the structure
<!-- Describe how reviewers and approvers can test this PR. -->
