### PR TITLE
feat(runtime): add support for module loaders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2852,6 +2852,7 @@ dependencies = [
  "tezos-smart-rollup",
  "tezos-smart-rollup-host",
  "tezos-smart-rollup-mock",
+ "thiserror 1.0.67",
  "tokio",
  "utoipa",
 ]

--- a/crates/jstz_runtime/Cargo.toml
+++ b/crates/jstz_runtime/Cargo.toml
@@ -21,6 +21,8 @@ serde_json.workspace = true
 tezos-smart-rollup.workspace = true
 tezos-smart-rollup-host.workspace = true
 utoipa.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/crates/jstz_runtime/src/error.rs
+++ b/crates/jstz_runtime/src/error.rs
@@ -1,0 +1,26 @@
+use deno_core::{
+    error::{CoreError, JsError},
+    serde_v8, v8,
+};
+
+#[derive(Debug, thiserror::Error)]
+pub enum RuntimeError {
+    #[error(transparent)]
+    DenoCore(#[from] CoreError),
+    #[error(transparent)]
+    SerdeV8(#[from] serde_v8::Error),
+}
+
+impl From<v8::DataError> for RuntimeError {
+    fn from(data_error: v8::DataError) -> Self {
+        Self::DenoCore(data_error.into())
+    }
+}
+
+impl From<JsError> for RuntimeError {
+    fn from(js_error: JsError) -> Self {
+        Self::DenoCore(js_error.into())
+    }
+}
+
+pub type Result<T> = std::result::Result<T, RuntimeError>;

--- a/crates/jstz_runtime/src/lib.rs
+++ b/crates/jstz_runtime/src/lib.rs
@@ -1,9 +1,10 @@
+pub mod error;
 mod jstz_console;
 mod jstz_kv;
 
 pub mod runtime;
 
-pub use runtime::JstzRuntime;
+pub use runtime::{JstzRuntime, JstzRuntimeOptions, Protocol};
 
 #[cfg(test)]
 mod test_utils {
@@ -65,7 +66,9 @@ mod test_utils {
             let mut $tx = jstz_core::kv::Transaction::default();
             $tx.begin();
             #[allow(unused)]
-            let mut $runtime = $crate::JstzRuntime::new(&mut $host, &mut $tx, $address.clone(), None);
+            let protocol  = Some($crate::Protocol::new(&mut $host, &mut $tx, $address.clone()));
+            #[allow(unused)]
+            let mut $runtime = $crate::JstzRuntime::new($crate::JstzRuntimeOptions { protocol, ..Default::default() } );
             #[allow(unused)]
             let $sink = $crate::test_utils::Sink($sink);
         };

--- a/crates/jstz_runtime/tests/wpt.rs
+++ b/crates/jstz_runtime/tests/wpt.rs
@@ -9,7 +9,7 @@ use derive_more::{From, Into};
 use expect_test::expect_file;
 use jstz_core::{host::HostRuntime, kv::Transaction};
 use jstz_crypto::{hash::Hash, smart_function_hash::SmartFunctionHash};
-use jstz_runtime::JstzRuntime;
+use jstz_runtime::{JstzRuntime, JstzRuntimeOptions, Protocol};
 use jstz_wpt::{
     Bundle, BundleItem, TestFilter, TestToRun, Wpt, WptReportTest, WptServe, WptSubtest,
     WptSubtestStatus, WptTestStatus,
@@ -242,7 +242,11 @@ fn init_runtime(host: &mut impl HostRuntime, tx: &mut Transaction) -> JstzRuntim
     options
         .extensions
         .push(test_harness_api::init_ops_and_esm());
-    let mut runtime = JstzRuntime::new(host, tx, address, Some(options));
+    let mut runtime = JstzRuntime::new(JstzRuntimeOptions {
+        protocol: Some(Protocol::new(host, tx, address)),
+        extensions: vec![test_harness_api::init_ops_and_esm()],
+        ..Default::default()
+    });
 
     let op_state = runtime.op_state();
     // Insert a blank report to be filled in by test cases


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
**Related Tasks**: [Implement module loading](https://linear.app/tezos/issue/JSTZ-374/implement-module-loading) 

We need to be able to load ES modules. Why? Smart functions are ES modules. 

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
**Dependencies**: #862, #870 

This PR adds support for module loaders to `JstzRuntime`. Additionally it adds all the functions required for loading, evaluating and calling the default handler.

For now, we do not support passing arguments to the default handler.

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

```sh
cargo nextest run -p jstz_engine
```
