### PR TITLE
fix(nix): fix hash incompatability between CI (linux) and local (MacOS)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -178,10 +178,19 @@
           mozjs = pkgs.callPackage ./nix/mozjs.nix {};
           crates = pkgs.callPackage ./nix/crates.nix {inherit crane rust-toolchain octez mozjs;};
           js-packages = pkgs.callPackage ./nix/js-packages.nix {};
-          riscvV8 = fetchTarball {
-            url = "https://raw.githubusercontent.com/jstz-dev/rusty_v8/130.0.7/librusty_v8.tar.gz";
-            sha256 = "0q7b4f70sczlvx6qsrx11p3gyq6651jj9xjrzrv8j4gn1iqhwpaa";
-          };
+
+          # It is necessary to use fetchurl instead of fetchTarball to
+          # preserve the hash compatability among case (in/)sensitive file systems
+          riscvV8 = with pkgs; let
+            tarball = fetchurl {
+              url = "https://raw.githubusercontent.com/jstz-dev/rusty_v8/130.0.7/librusty_v8.tar.gz";
+              sha256 = "sha256-8cywAe9kofNPxCwdzdkegtlRPwlqqR986m25wvDWbyo=";
+            };
+          in
+            runCommand "fetch-riscv-v8" {} ''
+              mkdir -p $out
+              tar -xzf ${tarball} -C $out --strip-components=1
+            '';
 
           fmt = treefmt.lib.evalModule pkgs {
             projectRootFile = "flake.nix";


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

When entering the nix shell, I get the following error:
```
direnv: loading ~/clients/trilitech/jstz/jstz/.envrc                                                                                                
direnv: using flake -j auto
warning: ignoring untrusted substituter 'https://trilitech-jstz.cachix.org', you are not a trusted user.
Run `man nix.conf` for more information on the `substituters` configuration option.
error:
       … while calling the 'derivationStrict' builtin

         at /builtin/derivation.nix:9:12: (source not available)

       … while evaluating derivation 'nix-shell'
         whose name attribute is located at /nix/store/jk6xpbfh10gz6q5cqw8b2f7xk0pl7hkv-source/pkgs/stdenv/generic/make-derivation.nix:375:7

       … while evaluating attribute 'RISCV_V8_ARCHIVE_DIR' of derivation 'nix-shell'

         at /nix/store/6ljnq0r4yagi223y441xw8pfwbyxyyca-source/flake.nix:255:13:

          254|
          255|             RISCV_V8_ARCHIVE_DIR = "${riscvV8}";
             |             ^
          256|

       error: hash mismatch in file downloaded from 'https://raw.githubusercontent.com/jstz-dev/rusty_v8/130.0.7/librusty_v8.tar.gz':
         specified: sha256:0q7b4f70sczlvx6qsrx11p3gyq6651jj9xjrzrv8j4gn1iqhwpaa
         got:       sha256:04y81fjwdrblhlqsyij2bc37x47x7j5k8qacfi2wby6gz5nwmxrj
```

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

I've not diagnosed the issue with `fetchTarball` but changing the hash to what is suggested produces an error in CI. 
It appears we have a hash incompatibility issue between Linux and MacOS for this archive. 

Issues of these form are usually due to subtle differences in the filesystems between Linux and MacOS
when dealing with folders. Instead, it is simpler for us to use the hash of the _archive_ and then unpack it. 

This PR implements this change (and it works for me locally as well). 

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

```sh
nix develop
```
