### PR TITLE
feat(jstz_core): implement reveal data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3046,14 +3046,17 @@ dependencies = [
  "erased-serde",
  "expect-test",
  "getrandom",
+ "hex",
  "jstz_crypto",
  "nom",
  "serde",
+ "serde-big-array",
  "tezos-smart-rollup",
  "tezos-smart-rollup-host",
  "tezos-smart-rollup-mock",
  "tezos_crypto_rs 0.6.0",
  "tezos_data_encoding 0.6.0",
+ "thiserror 1.0.67",
  "tokio",
 ]
 
@@ -4857,6 +4860,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ reqwest-eventsource = "0.5.0"
 rust-embed = { version = "8.5.0", features = ["interpolate-folder-path", "include-exclude"] }
 rustyline = "14.0.0"
 serde = { version = "1.0.196", features = ["derive", "rc"] }
+serde-big-array = "0.5.1"
 serde-wasm-bindgen = "0.6.5"
 serde_json = "1.0.107"
 serde_with = { version = "3.6.1", features = ["macros"] }

--- a/crates/jstz_core/Cargo.toml
+++ b/crates/jstz_core/Cargo.toml
@@ -21,10 +21,13 @@ getrandom.workspace = true
 jstz_crypto = { path = "../jstz_crypto" }
 nom.workspace = true
 serde.workspace = true
+serde-big-array.workspace = true
 tezos_crypto_rs.workspace = true
 tezos_data_encoding.workspace = true
 tezos-smart-rollup-host.workspace = true
 tezos-smart-rollup.workspace = true
+thiserror.workspace = true
+hex.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true 

--- a/crates/jstz_core/src/error.rs
+++ b/crates/jstz_core/src/error.rs
@@ -1,6 +1,10 @@
 use boa_engine::{JsError, JsNativeError};
 use derive_more::{Display, Error, From};
 
+use crate::host;
+use crate::kv;
+use crate::reveal_data;
+
 #[derive(Display, Debug, Error, From)]
 pub enum KvError {
     DowncastFailed,
@@ -14,7 +18,7 @@ pub enum Error {
         source: KvError,
     },
     HostError {
-        source: crate::host::HostError,
+        source: host::HostError,
     },
     PathError {
         source: tezos_smart_rollup_host::path::PathError,
@@ -26,7 +30,10 @@ pub enum Error {
         description: String,
     },
     OutboxError {
-        source: crate::kv::outbox::OutboxError,
+        source: kv::outbox::OutboxError,
+    },
+    RevealDataError {
+        source: reveal_data::Error,
     },
 }
 
@@ -51,6 +58,9 @@ impl From<Error> for JsError {
                 .into(),
             Error::OutboxError { source } => JsNativeError::eval()
                 .with_message(format!("OutboxError: {}", source))
+                .into(),
+            Error::RevealDataError { source } => JsNativeError::eval()
+                .with_message(format!("RevealDataError: {}", source))
                 .into(),
         }
     }

--- a/crates/jstz_core/src/lib.rs
+++ b/crates/jstz_core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod js_fn;
 pub mod kv;
 pub mod native;
 pub mod realm;
+pub mod reveal_data;
 pub mod runtime;
 pub mod value;
 

--- a/crates/jstz_core/src/reveal_data.rs
+++ b/crates/jstz_core/src/reveal_data.rs
@@ -1,0 +1,194 @@
+use crate::error::Result;
+use crate::{host::HostRuntime, BinEncodable};
+use derive_more::From;
+use serde::{Deserialize, Serialize};
+use serde_big_array::BigArray;
+use std::fmt;
+use tezos_smart_rollup::{
+    core_unsafe::PREIMAGE_HASH_SIZE,
+    dac::{
+        self, PreimageHash as DacPreimageHash, PreimageHashError, V0SliceContentPage,
+        MAX_PAGE_SIZE,
+    },
+};
+use thiserror::Error;
+
+// Maximum number of DAC levels to support, can reveal up to 59MB of data.
+const MAX_DAC_LEVELS: usize = 3;
+// Support `MAX_DAC_LEVELS` levels of hashes pages, + the bottom layer of content.
+const MAX_REVEAL_BUFFER_SIZE: usize = MAX_PAGE_SIZE * (MAX_DAC_LEVELS + 1);
+/// maximum size of the reveal data in bytes (10MB)
+pub const MAX_REVEAL_SIZE: usize = 10 * 1024 * 1024;
+
+/// A 33-byte hash corresponding to a preimage
+type RawPreimageHash = [u8; PREIMAGE_HASH_SIZE];
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct PreimageHash(#[serde(with = "BigArray")] pub RawPreimageHash);
+
+impl Default for PreimageHash {
+    fn default() -> Self {
+        PreimageHash([0; PREIMAGE_HASH_SIZE])
+    }
+}
+
+impl AsRef<RawPreimageHash> for PreimageHash {
+    fn as_ref(&self) -> &[u8; PREIMAGE_HASH_SIZE] {
+        &self.0
+    }
+}
+
+impl From<RawPreimageHash> for PreimageHash {
+    fn from(hash: [u8; PREIMAGE_HASH_SIZE]) -> Self {
+        PreimageHash(hash)
+    }
+}
+
+impl From<DacPreimageHash> for PreimageHash {
+    fn from(hash: DacPreimageHash) -> Self {
+        PreimageHash(*hash.as_ref())
+    }
+}
+
+impl From<PreimageHash> for DacPreimageHash {
+    fn from(hash: PreimageHash) -> Self {
+        DacPreimageHash::from(hash.as_ref())
+    }
+}
+
+impl fmt::Display for PreimageHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(self.as_ref()))
+    }
+}
+
+#[derive(Debug, Error, From)]
+pub enum Error {
+    #[error("Errors encountered while revealing data: {description}")]
+    RevealDataError { description: String },
+    #[error("Errors encountered while constructing a preimage hash.")]
+    PreimageHashConstructionError(PreimageHashError),
+    #[error("Reveal data size exceeds the maximum limit.")]
+    RevealDataSizeExceedsMaximumLimit,
+}
+
+// TODO: optimize the api and performance
+// https://linear.app/tezos/issue/JSTZ-359/optimize-reveal-data
+pub struct RevealData;
+
+impl RevealData {
+    fn reveal<H, F>(
+        hrt: &mut H,
+        root_hash: &PreimageHash,
+        save_content: &mut F,
+    ) -> Result<()>
+    where
+        H: HostRuntime,
+        F: FnMut(&mut H, V0SliceContentPage) -> std::result::Result<(), &'static str>,
+    {
+        let mut reveal_buffer = [0; MAX_REVEAL_BUFFER_SIZE];
+        dac::reveal_loop(
+            hrt,
+            0,
+            root_hash.as_ref(),
+            &mut reveal_buffer,
+            MAX_DAC_LEVELS,
+            save_content,
+        )
+        .map_err(|e| e.to_owned().into())
+    }
+
+    /// Reveal the data and decode it into the given type.
+    pub fn reveal_and_decode<H, T>(hrt: &mut H, root_hash: &PreimageHash) -> Result<T>
+    where
+        H: HostRuntime,
+        T: BinEncodable,
+    {
+        // TODO: include the size of the data in the operation to avoid the allocation of a large buffer
+        // https://linear.app/tezos/issue/JSTZ-359/optimize-reveal-data
+        let mut content = Vec::with_capacity(10 * MAX_PAGE_SIZE);
+        Self::reveal(
+            hrt,
+            root_hash,
+            &mut |_: &mut H, page: V0SliceContentPage| {
+                content.extend_from_slice(page.as_ref());
+                Ok(())
+            },
+        )?;
+        T::decode(&content[..])
+    }
+
+    /// Encode the data, prepare the preimages and return the root preimage hash.
+    pub fn encode_and_prepare_preimages<T, F>(
+        value: &T,
+        mut handle: F,
+    ) -> Result<PreimageHash>
+    where
+        T: BinEncodable,
+        F: FnMut(PreimageHash, Vec<u8>),
+    {
+        let encoded = T::encode(value)?;
+        if encoded.len() > MAX_REVEAL_SIZE {
+            return Err(Error::RevealDataSizeExceedsMaximumLimit.into());
+        }
+        let hash =
+            dac::prepare_preimages(&encoded, |hash: DacPreimageHash, data: Vec<u8>| {
+                let hash = PreimageHash::from(hash);
+                handle(hash, data);
+            })
+            .map_err(Error::PreimageHashConstructionError)?;
+        Ok(hash.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::Error;
+    use crate::BinEncodable;
+    use bincode::{Decode, Encode};
+    use tezos_smart_rollup_mock::MockHost;
+
+    #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
+    pub struct TestData(pub Vec<u8>);
+
+    #[test]
+    fn encode_and_prepare_preimages_fails_if_size_exceeds() {
+        let preimage = TestData(vec![0; MAX_REVEAL_SIZE + 1]);
+        let err = RevealData::encode_and_prepare_preimages(&preimage, |_, _| {})
+            .expect_err("should fail");
+        assert!(matches!(err, Error::RevealDataError { .. }));
+    }
+
+    #[test]
+    fn test_encode_and_decode_with_rdc() {
+        let data = TestData(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        encode_and_decode_data_with_rdc(data);
+    }
+
+    #[test]
+    fn test_encode_and_decode_with_rdc_large_data() {
+        let sample: Vec<u8> = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let large_data = vec![sample.clone(); MAX_REVEAL_SIZE / sample.len()]
+            .into_iter()
+            .flatten()
+            .collect::<Vec<u8>>();
+        let large_data = TestData(large_data);
+        encode_and_decode_data_with_rdc(large_data);
+    }
+
+    fn encode_and_decode_data_with_rdc<T>(data: T)
+    where
+        T: BinEncodable + Clone + PartialEq + Eq + std::fmt::Debug,
+    {
+        let mut host = MockHost::default();
+        let preimage_hash = RevealData::encode_and_prepare_preimages(&data, |_, page| {
+            host.set_preimage(page);
+        })
+        .expect("should prepare preimages");
+
+        let decoded =
+            RevealData::reveal_and_decode::<_, T>(&mut host, &preimage_hash).unwrap();
+        assert_eq!(decoded, data);
+    }
+}


### PR DESCRIPTION
# Context

Part of [adding support for large smart function](https://linear.app/tezos/project/large-smart-function-deployment-e1f8c66e4e03/overview)

[task url](https://linear.app/tezos/issue/JSTZ-358/implement-reveal-data)


# Description

Added `RevealData` struct that introduces apis to
1. reveal data greater than 4KB via the reveal data channel.
2. help encode the data and chunk them into preimages of size 4KB. 

The max size of data supported is now 10MB.


# Manually testing the PR

Added uni tests:
```
cargo test --package jstz_core   
```
