### PR TITLE
fix(proto): remove `Operation.source` and fix `Operation::verify_nonce`

### DIFF
--- a/crates/jstz_cli/src/deploy.rs
+++ b/crates/jstz_cli/src/deploy.rs
@@ -71,7 +71,7 @@ pub async fn exec(
         .map_err(|err: JsError| user_error!("{err}"))?;
 
     let op = Operation {
-        source: user.address.clone(),
+        public_key: user.public_key.clone(),
         nonce,
         content: Content::DeployFunction(DeployFunction {
             function_code: code,
@@ -85,8 +85,7 @@ pub async fn exec(
 
     debug!("Operation hash: {}", hash.to_string());
 
-    let signed_op =
-        SignedOperation::new(user.public_key.clone(), user.secret_key.sign(&hash)?, op);
+    let signed_op = SignedOperation::new(user.secret_key.sign(&hash)?, op);
 
     debug!("Signed operation: {:?}", signed_op);
 

--- a/crates/jstz_cli/src/run.rs
+++ b/crates/jstz_cli/src/run.rs
@@ -212,7 +212,7 @@ pub async fn exec(args: RunArgs) -> Result<()> {
     }
 
     let op = Operation {
-        source: user.address.clone(),
+        public_key: user.public_key.clone(),
         nonce,
         content: OperationContent::RunFunction(RunFunction {
             uri: url,
@@ -232,8 +232,7 @@ pub async fn exec(args: RunArgs) -> Result<()> {
 
     debug!("Operation hash: {}", hash.to_string());
 
-    let signed_op =
-        SignedOperation::new(user.public_key.clone(), user.secret_key.sign(&hash)?, op);
+    let signed_op = SignedOperation::new(user.secret_key.sign(&hash)?, op);
 
     debug!("Signed operation: {:?}", signed_op);
 

--- a/crates/jstz_mock/src/lib.rs
+++ b/crates/jstz_mock/src/lib.rs
@@ -1,4 +1,7 @@
-use jstz_crypto::{hash::Hash, smart_function_hash::SmartFunctionHash};
+use jstz_crypto::{
+    hash::Hash, public_key::PublicKey, public_key_hash::PublicKeyHash,
+    secret_key::SecretKey, smart_function_hash::SmartFunctionHash,
+};
 use tezos_crypto_rs::hash::ContractKt1Hash;
 use tezos_smart_rollup::{
     michelson::{
@@ -24,6 +27,35 @@ pub fn parse_ticket(
     Ticket::new(Contract::Originated(ticketer), ticket_content, amount).unwrap()
 }
 
+pub fn sk1() -> SecretKey {
+    SecretKey::from_base58("edsk3M1HxYgWowRxyQQJTp3Zz9QwpSawRmzdvu7fKzxEgwTmggiRb3")
+        .unwrap()
+}
+
+pub fn pk1() -> PublicKey {
+    PublicKey::from_base58("edpkuifh2JiPVYfEM4LuGBcPjhHR1GS88bc4ciNUqg15UcWM5zjFmn")
+        .unwrap()
+}
+
+pub fn pkh1() -> PublicKeyHash {
+    PublicKeyHash::from_base58("tz1SfjqKLQC2pUTduhSoa8HkcAsuTPgh1fVU").unwrap()
+}
+
+pub fn sk2() -> SecretKey {
+    SecretKey::from_base58("edsk3tf3TGZEpf7TRZZPVxiWtN7dYwa2zRecme3UCWEDVvzBZEY4go")
+        .unwrap()
+}
+
+pub fn pk2() -> PublicKey {
+    PublicKey::from_base58("edpkuaLhZbGU3noeP82aXejhPJFMYtEWouK2ZEc5i1PraC3t2KjZ2W")
+        .unwrap()
+}
+
+pub fn pkh2() -> PublicKeyHash {
+    PublicKeyHash::from_base58("tz1MX7cSM75S8zvcy2UuUWoWtwZQ5chaGyAh").unwrap()
+}
+
+// TODO(): Replace account1 and account2 usage with pk1 and pk2
 pub fn account1() -> jstz_crypto::public_key_hash::PublicKeyHash {
     jstz_crypto::public_key_hash::PublicKeyHash::from_base58(
         "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx",

--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -741,19 +741,22 @@
       "Operation": {
         "type": "object",
         "required": [
-          "source",
+          "public_key",
           "nonce",
           "content"
         ],
         "properties": {
           "content": {
-            "$ref": "#/components/schemas/Content"
+            "$ref": "#/components/schemas/Content",
+            "description": "The content of the operation"
           },
           "nonce": {
-            "$ref": "#/components/schemas/Nonce"
+            "$ref": "#/components/schemas/Nonce",
+            "description": "Nonce is used to avoid replay attacks."
           },
-          "source": {
-            "$ref": "#/components/schemas/PublicKeyHash"
+          "public_key": {
+            "$ref": "#/components/schemas/PublicKey",
+            "description": "The public key of the account which was used to sign the operation"
           }
         }
       },
@@ -1082,16 +1085,12 @@
       "SignedOperation": {
         "type": "object",
         "required": [
-          "public_key",
           "signature",
           "inner"
         ],
         "properties": {
           "inner": {
             "$ref": "#/components/schemas/Operation"
-          },
-          "public_key": {
-            "$ref": "#/components/schemas/PublicKey"
           },
           "signature": {
             "$ref": "#/components/schemas/Signature"

--- a/crates/jstz_tps_bench/src/bench/generate.rs
+++ b/crates/jstz_tps_bench/src/bench/generate.rs
@@ -10,8 +10,7 @@ use http::{HeaderMap, Method, Uri};
 use jstz_crypto::hash::Hash;
 use jstz_crypto::smart_function_hash::SmartFunctionHash;
 use jstz_crypto::{
-    keypair_from_passphrase, public_key::PublicKey, public_key_hash::PublicKeyHash,
-    secret_key::SecretKey,
+    keypair_from_passphrase, public_key::PublicKey, secret_key::SecretKey,
 };
 use jstz_proto::context::account::{Address, Addressable, Nonce, ParsedCode};
 use jstz_proto::operation::{
@@ -285,13 +284,13 @@ impl Account {
         content: Content,
     ) -> Result<Message> {
         let op = Operation {
-            source: PublicKeyHash::from_base58(&self.address.to_base58())?,
+            public_key: self.pk.clone(),
             nonce: self.nonce,
             content,
         };
 
         let hash = op.hash();
-        let signed_op = SignedOperation::new(self.pk.clone(), self.sk.sign(hash)?, op);
+        let signed_op = SignedOperation::new(self.sk.sign(hash)?, op);
 
         let bytes = bincode::encode_to_vec(&signed_op, bincode::config::legacy())?;
         let mut external = Vec::with_capacity(bytes.len() + EXTERNAL_FRAME_SIZE);


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
**Related Issues**: [Operations can be signed with any key pair](https://linear.app/tezos/issue/JSTZ-396/operations-can-be-signed-with-any-key-pair) 

This PR fixes the security vuln described in the linear issue. 

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

This PR removes `source` from `Operation`, adding `public_key` in its place. 
Additionally, we can now remove `public_key` from `SignedOperation`. 

This means `public_key` is the single source of truth (in the protocol) about the signer's identity. 
Which was the issue that led to the vuln. 

This PR additionally adds some tests around `Operation::verify_nonce` and `SignedOperation::verify`

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

```
cargo nextest run -p jstz_proto
```