### PR TITLE
chore(deps): replace tiny-bip39 with bip39

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "bip39"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33415e24172c1b7d6066f6d999545375ab8e1d95421d6784bdfff9496f292387"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+ "serde",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +427,22 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
+dependencies = [
+ "bitcoin-internals",
+ "hex-conservative",
+]
 
 [[package]]
 name = "bitflags"
@@ -1368,7 +1397,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -1475,7 +1503,7 @@ checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
 dependencies = [
  "der",
  "elliptic-curve",
- "hmac 0.11.0",
+ "hmac",
  "signature 1.3.2",
 ]
 
@@ -1893,6 +1921,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
@@ -2090,6 +2129,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-conservative"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
+
+[[package]]
 name = "hmac"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2097,15 +2142,6 @@ checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac",
  "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -2635,6 +2671,7 @@ version = "0.1.0-alpha.0"
 dependencies = [
  "ansi_term",
  "anyhow",
+ "bip39",
  "boa_engine",
  "boa_gc",
  "bollard",
@@ -2685,7 +2722,6 @@ dependencies = [
  "tezos-smart-rollup",
  "tezos-smart-rollup-mock",
  "tezos_crypto_rs 0.6.0",
- "tiny-bip39",
  "tokio",
  "tokio-util",
  "url",
@@ -3561,15 +3597,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "pbkdf2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
 name = "pear"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3991,6 +4018,8 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
+ "getrandom 0.1.16",
+ "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc",
@@ -4053,6 +4082,9 @@ name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
+]
 
 [[package]]
 name = "rand_core"
@@ -5514,25 +5546,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny-bip39"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62cc94d358b5a1e84a5cb9109f559aa3c4d634d2b1b4de3d0fa4adc7c78e2861"
-dependencies = [
- "anyhow",
- "hmac 0.12.1",
- "once_cell",
- "pbkdf2",
- "rand 0.8.5",
- "rustc-hash 1.1.0",
- "sha2 0.10.8",
- "thiserror 1.0.67",
- "unicode-normalization",
- "wasm-bindgen",
- "zeroize",
-]
-
-[[package]]
 name = "tinystr"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5793,9 +5806,9 @@ checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.24"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
@@ -6023,6 +6036,12 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -6554,20 +6573,6 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.87",
-]
 
 [[package]]
 name = "zerovec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ async-trait = "0.1.82"
 axum = "0.7.7"
 base64 = "0.21.7"
 bincode = { version = "2.0.0-rc.3", features = ["derive", "serde"] }
+bip39 = { version = "2.1.0", features = ["rand"] }
 boa_engine = { version = "0.19.0", features = ["fuzz"] }
 boa_gc = "0.19.0"
 bollard = "0.16.1"
@@ -106,7 +107,6 @@ syntect = "5.2.0"
 tempfile = "3.10.0"
 tezos_data_encoding = "0.6.0"
 thiserror = "1.0.56"
-tiny-bip39 = "1.0.0"
 tl = "0.7.7"
 tokio = { version = "1.36.0", features = ["full"] }
 tokio-stream = "0.1.14"

--- a/crates/jstz_cli/Cargo.toml
+++ b/crates/jstz_cli/Cargo.toml
@@ -17,6 +17,7 @@ default-run = "jstz"
 [dependencies]
 ansi_term.workspace = true
 anyhow.workspace = true
+bip39.workspace = true
 boa_engine.workspace = true
 boa_gc.workspace = true
 bollard.workspace = true
@@ -66,7 +67,6 @@ tempfile.workspace = true
 tezos-smart-rollup-mock.workspace = true
 tezos-smart-rollup.workspace = true
 tezos_crypto_rs.workspace = true
-tiny-bip39.workspace = true
 tokio-util.workspace = true
 tokio.workspace = true
 url.workspace = true

--- a/crates/jstz_cli/src/account.rs
+++ b/crates/jstz_cli/src/account.rs
@@ -1,6 +1,6 @@
 use std::collections::hash_map::Entry;
 
-use bip39::{Language, Mnemonic, MnemonicType};
+use bip39::{Language, Mnemonic};
 use clap::Subcommand;
 use dialoguer::{Confirm, Input};
 use jstz_crypto::smart_function_hash::SmartFunctionHash;
@@ -15,7 +15,10 @@ use crate::{
 };
 
 fn generate_passphrase() -> String {
-    let mnemonic = Mnemonic::new(MnemonicType::Words12, Language::English);
+    // unwrap is okay here because we are using a fixed value for word count and it's always
+    // valid unless the library stops supporting word count 12
+    let mnemonic = Mnemonic::generate_in(Language::English, 12)
+        .expect("generate_in should generate mnemonics");
     mnemonic.to_string()
 }
 
@@ -349,5 +352,16 @@ pub async fn exec(command: Command) -> Result<()> {
         Command::List { long } => list_accounts(long).await,
         Command::Code { account, network } => get_code(account, network).await,
         Command::Balance { account, network } => get_balance(account, network).await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn generate_passphrase() {
+        // Just to make sure that generate_passphrase works with the current version of Mnemonic.
+        // If anything changes in the library and fails our logic, the unwrap call will lead to
+        // a panic and we can capture that issue here.
+        assert_ne!(super::generate_passphrase(), super::generate_passphrase());
     }
 }


### PR DESCRIPTION
# Context

Part of JSTZ-403.
[JSTZ-403](https://linear.app/tezos/issue/JSTZ-403/passphrases-and-tz1-generation-are-different-to-umami-and-octez-cli)

# Description

The version of `tiny-bip39` in this repo is out of date and `tiny-bip39` itself lacks some features. Replacing it with `bip39` allows us to do more things easily. It seems that there used to be some issues with `bip39` and `tiny-bip39` was created as a fork to address those issues. It's been a while since `tiny-bip39` was created and added to this repo and I assume that now `bip39` is fine with the upgrades.

# Manually testing the PR

* Manual testing: CLI still works
* Unit testing: added one test to monitor bip39 API
