### PR TITLE
feat(wpt): display metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,10 @@ jobs:
           ln -s /usr/bin/python3.11 /usr/bin/python3
           cd crates/jstz_wpt/wpt && python3 wpt make-hosts-file >> /etc/hosts
           python3 wpt serve &
-          cd ../../jstz_runtime && cargo test --test wpt
+          cd ../../jstz_runtime && STATS_PATH=$(pwd)/out.txt cargo test --test wpt
+          while read line; do
+            echo "$line" >> $GITHUB_STEP_SUMMARY
+          done < $(pwd)/out.txt
 
   build-docs:
     name: Build Documentation


### PR DESCRIPTION
# Context

Completes JSTZ-333.
[JSTZ-333](https://linear.app/tezos/issue/JSTZ-332/collect-test-metrics)

# Description

The test runner now dumps test stats as a markdown file to a specified destination when the environment variable `STATS_PATH` is present. This file is picked up in the CI workflow and displayed in the run summary.

# Manually testing the PR

[Test summary](https://github.com/jstz-dev/jstz/actions/runs/14105298959/attempts/1#summary-39510379280)
