### PR TITLE
feat(runtime): patch deno_fetch with jstz fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
  "tokio",
- "tower",
+ "tower 0.5.1",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1060,9 +1060,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.11.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
 dependencies = [
  "generic-array",
  "subtle",
@@ -1281,6 +1281,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
+]
+
+[[package]]
+name = "deno_fetch_base"
+version = "0.202.0"
+source = "git+https://github.com/jstz-dev/deno?branch=ryan/patch-deno-fetch#519316508427077e246c6fe593e39d371f31a6f0"
+dependencies = [
+ "bytes",
+ "deno_core",
+ "deno_error",
+ "serde",
 ]
 
 [[package]]
@@ -2401,9 +2412,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2414,6 +2425,7 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio",
+ "tower 0.4.13",
  "tower-service",
  "tracing",
 ]
@@ -2988,6 +3000,7 @@ dependencies = [
  "deno_console",
  "deno_core",
  "deno_error",
+ "deno_fetch_base",
  "deno_url",
  "deno_web",
  "deno_webidl",
@@ -3118,7 +3131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5061,9 +5074,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -5750,6 +5763,21 @@ dependencies = [
  "indexmap 2.6.0",
  "toml_datetime",
  "winnow",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/crates/jstz_runtime/Cargo.toml
+++ b/crates/jstz_runtime/Cargo.toml
@@ -29,6 +29,12 @@ deno_web.workspace = true
 deno_url.workspace = true
 deno_error.workspace = true
 
+[dependencies.deno_fetch_base]
+git = "https://github.com/jstz-dev/deno"
+branch = "ryan/patch-deno-fetch"
+features = ["sandbox"]
+default-features = false
+
 [dev-dependencies]
 anyhow.workspace = true
 derive_more.workspace = true


### PR DESCRIPTION
# Context
Patch `deno_fetch` with our `deno_fetch` fork - https://github.com/jstz-dev/deno/tree/ryan/patch-deno-fetch . The fork exposes `deno_fetch_base` crates which exposes the fetch ops as traits that we can implement in our code going forward.  

The set of changes made by the fork can be found at https://github.com/jstz-dev/deno/pull/1 

Closes: [JSTZ-419](https://linear.app/tezos/issue/JSTZ-419/fork-deno-fetch), [JSTZ-420](https://linear.app/tezos/issue/JSTZ-420/removetraitify-non-compliant-functionality-from-deno-fetch)


# Description
Dangerous and non-blockchain compliant features from `deno_fetch` need to be removed or traitfied. This allows us to alter the behaviour of fetch dependning no the environment that we're running in (blockchain sandbox and wpt). Isolating changes allows to potentially upstream them in the future

# Manually testing the PR
Code compiles - `make build`
