### PR TITLE
refactor(cli): check sandbox status through jstzd

### DIFF
--- a/crates/jstz_cli/src/deploy.rs
+++ b/crates/jstz_cli/src/deploy.rs
@@ -10,6 +10,7 @@ use crate::{
     account,
     config::{Config, NetworkName, SmartFunction},
     error::{anyhow, bail, bail_user_error, user_error, Result},
+    sandbox::{assert_sandbox_running, JSTZD_SERVER_BASE_URL},
     term::styles,
     utils::{read_file_or_input_or_piped, MUTEZ_PER_TEZ},
 };
@@ -25,11 +26,8 @@ pub async fn exec(
 
     let mut cfg = Config::load().await?;
     // Load sandbox if the selected network is Dev and sandbox is not already loaded
-    if cfg.network_name(&network)? == NetworkName::Dev && cfg.sandbox.is_none() {
-        bail_user_error!(
-            "No sandbox is currently running. Please run {}.",
-            styles::command("jstz sandbox start")
-        );
+    if cfg.network_name(&network)? == NetworkName::Dev {
+        assert_sandbox_running(JSTZD_SERVER_BASE_URL).await?;
     }
 
     // Get the current user and check if we are logged in

--- a/crates/jstz_cli/src/sandbox/jstzd.rs
+++ b/crates/jstz_cli/src/sandbox/jstzd.rs
@@ -25,7 +25,7 @@ where
     false
 }
 
-async fn is_jstzd_running(jstzd_server_base_url: &str) -> Result<bool> {
+pub(crate) async fn is_jstzd_running(jstzd_server_base_url: &str) -> Result<bool> {
     match reqwest::get(format!("{jstzd_server_base_url}/health")).await {
         Err(e) => {
             // ignore connection error because this is what is returned when the server


### PR DESCRIPTION
# Context

Part of JSTZ-421.
[JSTZ-421](https://linear.app/tezos/issue/JSTZ-421/clean-up-sandbox-config)
Sandbox config is not really necessary after jstzd is integrated into CLI.

# Description

Make CLI check sandbox status through jstzd instead of by checking the sandbox config. Since jstzd server always listens on port 54321, it's sufficient to check if the sandbox is running properly through the health check endpoint.

# Manually testing the PR

* Manual testing: tested the sandbox locally
* Unit testing: added some test cases for the new helper function.
