### PR TITLE
feat(nix): add support for riscv sandbox

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -173,6 +173,22 @@
             else pkgs.clang;
 
           rust-toolchain = pkgs.callPackage ./nix/rust-toolchain.nix {};
+
+          riscvSandbox = with pkgs;
+            rustPlatform.buildRustPackage {
+              name = "riscv-sandbox";
+              src = builtins.fetchGit {
+                url = "https://gitlab.com/tezos/tezos.git";
+                ref = "master";
+                rev = "03eccd0c9bddbe225730ef1e8ece67a3e3005fd3";
+              };
+              cargoRoot = "src/riscv";
+              buildAndTestSubdir = "src/riscv/sandbox";
+              useFetchCargoVendor = true;
+              cargoHash = "sha256-ZhvEguaALAbxo/Icf3SIA6ROc5eq7GhNA/ZIfWoT5oc=";
+              cargoBuildFeatures = ["supervisor"];
+            };
+
           llvmPackages = pkgs.llvmPackages_16;
 
           crates = pkgs.callPackage ./nix/crates.nix {inherit crane rust-toolchain octez;};
@@ -323,6 +339,7 @@
                 python39 # for running web-platform tests
 
                 riscv64MuslPkgs.pkgsStatic.stdenv.cc
+                riscvSandbox
               ]
               ++ lib.optionals stdenv.isLinux [pkg-config openssl.dev];
           };


### PR DESCRIPTION
# Context
Brings `riscv-sandbox` into our nix environment for testing Jstz using the RISCV PVM supervisor
<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
* Uses pkgs.rustPlatform.buildRustPackage to fetch and build the `sandbox` workspace member of the `tezos/tezos` riscv project
* `useFetchCargoVendor` is set to true to ensure dependencies are vendored for the CI environment
<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
`riscv-sandbox --help`
<!-- Describe how reviewers and approvers can test this PR. -->
