### PR TITLE
fix(riscv-sandbox): properly enable supervisor build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -186,7 +186,7 @@
               buildAndTestSubdir = "src/riscv/sandbox";
               useFetchCargoVendor = true;
               cargoHash = "sha256-ZhvEguaALAbxo/Icf3SIA6ROc5eq7GhNA/ZIfWoT5oc=";
-              cargoBuildFeatures = ["supervisor"];
+              buildFeatures = ["supervisor"];
             };
 
           llvmPackages = pkgs.llvmPackages_16;


### PR DESCRIPTION
# Context
Fixes the issues with `riscv-sandbox` not building with supervisor feature
<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Manually testing the PR
`nm $(which riscv-sandbox) | grep linux` should not be empty
<!-- Describe how reviewers and approvers can test this PR. -->
