### PR TITLE
fix(wpt): properly set location.search for subset tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3114,6 +3114,7 @@ dependencies = [
  "anyhow",
  "clap 4.5.20",
  "ctrlc",
+ "mockito",
  "nix 0.27.1",
  "regex",
  "reqwest",

--- a/crates/jstz_runtime/tests/test_harness_api.js
+++ b/crates/jstz_runtime/tests/test_harness_api.js
@@ -1,9 +1,7 @@
 import { test_result_callback, test_completion_callback } from "ext:core/ops";
 
 Object.defineProperty(globalThis, "location", {
-  value: {
-    search: "?0-5",
-  },
+  value: {},
   enumerable: true,
   configurable: true,
   writable: true,

--- a/crates/jstz_wpt/Cargo.toml
+++ b/crates/jstz_wpt/Cargo.toml
@@ -17,6 +17,7 @@ include = ["config.json", "hosts", "manifest.json", "src"]
 anyhow.workspace = true
 clap.workspace = true
 ctrlc.workspace = true
+mockito.workspace = true
 nix.workspace = true
 regex.workspace = true
 reqwest.workspace = true

--- a/crates/jstz_wpt/src/lib.rs
+++ b/crates/jstz_wpt/src/lib.rs
@@ -201,6 +201,6 @@ impl Wpt {
             }
         }
 
-        WptServe::new(child)
+        WptServe::new("http://localhost:8000", child)
     }
 }


### PR DESCRIPTION
# Context

Part of JSTZ-437.
[JSTZ-437](https://linear.app/tezos/issue/JSTZ-437/calculate-pass-rate-against-deno-test-set)

Deno runs a specific subset of the entire WPT test suites. We want to run the same subset for jstz.

# Description

Correctly set the constraint on subset tests in order to compare the test results with deno's report. The original `?0-5` constraint tells the runner to access the first 5 test cases in each subset test that might contain hundreds of test cases. Deno does not put such a constraint on their runner and we need to remove it if we want to compare our test coverage against their results. However, deno does run subset tests in batches. This uncovers an issue in the way we pack test scripts. Since WPT is designed for a web environment, it expects the runner to be able to handle URL query parameters, in this case setting `location.search` automatically based on the test URL. Since our runner basically downloads scripts and executes them as scripts, we don't really go through this URL processing step. This leads to incorrect search parameters being set. To solve the issue, instead of setting a constant global `location.search` value, we need to inject a code snippet in each test script bundle to manually set the search parameter based on the test URLs. This mimics what a regular web environment does.

Essentially, to match deno's results, we are running more tests cases. The downside is obviously that it will take more time to run. With the current setup, it's not too bad since wpt does not use our own nix github runner and runs in parallel to the regular build job.

# Manually testing the PR

The test result file gets much longer now.
