### PR TITLE
feat(wpt): calculate pass rate against deno test set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3071,6 +3071,7 @@ dependencies = [
  "tezos-smart-rollup-mock",
  "thiserror 1.0.67",
  "tokio",
+ "url",
  "utoipa",
 ]
 

--- a/crates/jstz_runtime/.gitignore
+++ b/crates/jstz_runtime/.gitignore
@@ -1,1 +1,1 @@
-tests/deno_results.json
+tests/deno_report.json

--- a/crates/jstz_runtime/Cargo.toml
+++ b/crates/jstz_runtime/Cargo.toml
@@ -43,6 +43,7 @@ regex.workspace = true
 serde_json.workspace = true
 tezos-smart-rollup-mock.workspace = true
 tokio.workspace = true
+url.workspace = true
 
 [features]
 skip-wpt = []


### PR DESCRIPTION
# Context

Completes JSTZ-437.
[JSTZ-437](https://linear.app/tezos/issue/JSTZ-437/calculate-pass-rate-against-deno-test-set)

Deno runs a specific subset of the entire WPT test suites. We want to run the same subset for jstz and compare the results.

# Description

Extract stats from deno's WPT report and calculate our pass rate accordingly.

A deno report looks like this:
```
{
  "results": [
    {"test": "/WebCryptoAPI/algorithm-discards-context.https.window.html", "subtests": [...], "status": ... },
    {...}
  ]
}
```
where each entry in `results` is the report of a test suite. We can extract the number of test cases in each test suite by inspecting its status and subtests. Based on the status and other information of a subtest, we know which test cases work with deno. Therefore, after iterating through the entire report, we can get the total amount of runnable/discoverable test cases and the amount of tests that work with deno. This is the baseline for our WPT runner. The pass rate of our test runner is then `#tests passed reported / #tests runnable according to deno`.

# Manually testing the PR

Numbers in the [test summary](https://github.com/jstz-dev/jstz/actions/runs/14405780792/attempts/1#summary-40401833880) match those in [deno's report](https://wpt.fyi/results/?run_id=5104565471150080): 99681 / 117168
