### PR TITLE
feat(cli): support XDG_CONFIG_HOME for config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2808,6 +2808,7 @@ version = "0.1.0-alpha.0"
 dependencies = [
  "ansi_term",
  "anyhow",
+ "assert_cmd",
  "bip39",
  "boa_engine",
  "boa_gc",
@@ -2840,6 +2841,7 @@ dependencies = [
  "mockito",
  "nix 0.27.1",
  "octez",
+ "predicates",
  "prettytable",
  "rand 0.8.5",
  "regex",

--- a/crates/jstz_cli/Cargo.toml
+++ b/crates/jstz_cli/Cargo.toml
@@ -73,7 +73,9 @@ tokio.workspace = true
 url.workspace = true
 
 [dev-dependencies]
+assert_cmd.workspace = true
 mockito.workspace = true
+predicates.workspace = true
 
 [[bin]]
 name = "jstz"

--- a/crates/jstz_cli/src/config.rs
+++ b/crates/jstz_cli/src/config.rs
@@ -25,16 +25,14 @@ use crate::{
     utils::AddressOrAlias,
 };
 
-// hardcoding it here instead of importing from jstzd simply to avoid adding jstzd
-// as a new depedency of jstz_cli just for this so that build time remains the same
 #[cfg(not(test))]
 pub fn jstz_home_dir() -> PathBuf {
-    if let Ok(value) = std::env::var("JSTZ_HOME") {
+    if let Ok(value) = std::env::var("XDG_CONFIG_HOME") {
         PathBuf::from(value)
     } else {
         dirs::home_dir()
             .expect("Could not find home directory")
-            .join(".jstz")
+            .join(".config/jstz")
     }
 }
 

--- a/crates/jstz_cli/tests/config.rs
+++ b/crates/jstz_cli/tests/config.rs
@@ -1,0 +1,85 @@
+use assert_cmd::prelude::{CommandCargoExt, OutputAssertExt};
+use std::{
+    fs::{create_dir_all, File},
+    process::Command,
+};
+use tempfile::TempDir;
+
+fn config() -> serde_json::Value {
+    serde_json::json!({
+        "current_alias": "foo",
+        "accounts": {
+            "foo": {
+                "User": {
+                    "address": "tz1ficxJFv7MUtsCimF8bmT9SYPDok52ySg6",
+                    "secret_key": "edsk3a3gq6ocr51rGDqqSb8sxxV46v77GZYmhyKyjqWjckhVTJXYCf",
+                    "public_key": "edpktpcAZ3d8Yy1EZUF1yX4xFgLq5sJ7cL9aVhp7aV12y89RXThE3N"
+                }
+            },
+        }
+    })
+}
+
+#[test]
+fn jstz_home_dir() {
+    let tmp_dir = TempDir::new().unwrap();
+    let path = tmp_dir.path().join(".config/jstz/config.json");
+    create_dir_all(path.parent().expect("should find parent dir"))
+        .expect("should create dir");
+    let file = File::create(&path).expect("should create file");
+    serde_json::to_writer(file, &config()).expect("should write config file");
+
+    Command::cargo_bin("jstz")
+        .unwrap()
+        .env("HOME", tmp_dir.path().to_string_lossy().to_string())
+        .arg("whoami")
+        .assert()
+        .stderr(predicates::str::contains(
+            "Logged in to account foo with address tz1ficxJFv7MUtsCimF8bmT9SYPDok52ySg6",
+        ))
+        .success();
+
+    let another_dir = TempDir::new().unwrap();
+    // config file does not exist in this new directory
+    Command::cargo_bin("jstz")
+        .unwrap()
+        .env("HOME", another_dir.path().to_string_lossy().to_string())
+        .arg("whoami")
+        .assert()
+        .stderr(predicates::str::contains("You are not logged in"))
+        .failure();
+}
+
+#[test]
+fn xdg_config_home() {
+    let tmp_dir = TempDir::new().unwrap();
+    let path = tmp_dir.path().join("config.json");
+    let file = File::create(&path).expect("should create file");
+    serde_json::to_writer(file, &config()).expect("should write config file");
+
+    Command::cargo_bin("jstz")
+        .unwrap()
+        .env(
+            "XDG_CONFIG_HOME",
+            tmp_dir.path().to_string_lossy().to_string(),
+        )
+        .arg("whoami")
+        .assert()
+        .stderr(predicates::str::contains(
+            "Logged in to account foo with address tz1ficxJFv7MUtsCimF8bmT9SYPDok52ySg6",
+        ))
+        .success();
+
+    let another_dir = TempDir::new().unwrap();
+    // config file does not exist in this new directory
+    Command::cargo_bin("jstz")
+        .unwrap()
+        .env(
+            "XDG_CONFIG_HOME",
+            another_dir.path().to_string_lossy().to_string(),
+        )
+        .arg("whoami")
+        .assert()
+        .stderr(predicates::str::contains("You are not logged in"))
+        .failure();
+}


### PR DESCRIPTION
# Context

Completes JSTZ-461.
[JSTZ-461](https://linear.app/tezos/issue/JSTZ-461/support-xdg-compatibility)

Closes #892.

# Description

Support `XDG_CONFIG_HOME` for config. Following the [guideline](https://specifications.freedesktop.org/basedir-spec/latest/#variables),
* when `XDG_CONFIG_HOME` is set, the path to the config file is `$XDG_CONFIG_HOME/config.json`.
* when `XDG_CONFIG_HOME` is not set, the path to the config file is changed to `$HOME/.config/jstz/config.json`.

Configuring config directory with `JSTZ_HOME` is replaced by `XDG_CONFIG_HOME`.

# Manually testing the PR

* Integration test: added one test
