### PR TITLE
Add auth for proto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4782,9 +4782,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
 dependencies = [
  "serde_derive",
 ]
@@ -4811,9 +4811,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/jstz_kernel/src/lib.rs
+++ b/crates/jstz_kernel/src/lib.rs
@@ -1,5 +1,5 @@
 use jstz_core::kv::{Storage, Transaction};
-use jstz_crypto::smart_function_hash::SmartFunctionHash;
+use jstz_crypto::{public_key::PublicKey, smart_function_hash::SmartFunctionHash};
 use jstz_proto::{executor, Result};
 use tezos_crypto_rs::hash::ContractKt1Hash;
 use tezos_smart_rollup::{
@@ -13,9 +13,14 @@ pub mod inbox;
 pub mod parsing;
 
 pub const TICKETER: RefPath = RefPath::assert_from(b"/ticketer");
+pub const INJECTOR: RefPath = RefPath::assert_from(b"/injector");
 
 fn read_ticketer(rt: &impl Runtime) -> Option<SmartFunctionHash> {
     Storage::get(rt, &TICKETER).ok()?
+}
+
+fn read_injector(rt: &impl Runtime) -> Option<PublicKey> {
+    Storage::get(rt, &INJECTOR).ok()?
 }
 
 fn handle_message(
@@ -23,6 +28,7 @@ fn handle_message(
     message: Message,
     ticketer: &ContractKt1Hash,
     tx: &mut Transaction,
+    injector: &PublicKey,
 ) -> Result<()> {
     match message {
         Message::Internal(external_operation) => {
@@ -32,8 +38,13 @@ fn handle_message(
         }
         Message::External(signed_operation) => {
             debug_msg!(hrt, "External operation: {signed_operation:?}\n");
-            let receipt =
-                executor::execute_operation(hrt, tx, signed_operation, ticketer);
+            let receipt = executor::execute_operation(
+                hrt,
+                tx,
+                signed_operation,
+                ticketer,
+                injector,
+            );
             debug_msg!(hrt, "Receipt: {receipt:?}\n");
             receipt.write(hrt, tx)?
         }
@@ -44,11 +55,14 @@ fn handle_message(
 // kernel entry
 #[entrypoint::main]
 pub fn entry(rt: &mut impl Runtime) {
+    // TODO: we should organize protocol consts into a struct
+    // https://linear.app/tezos/issue/JSTZ-459/organize-protocol-consts-into-a-struct
     let ticketer = read_ticketer(rt).expect("Ticketer not found");
+    let injector = read_injector(rt).expect("Revealer not found");
     let mut tx = Transaction::default();
     tx.begin();
     if let Some(message) = read_message(rt, &ticketer) {
-        handle_message(rt, message, &ticketer, &mut tx)
+        handle_message(rt, message, &ticketer, &mut tx, &injector)
             .unwrap_or_else(|err| debug_msg!(rt, "[🔴] {err:?}\n"));
     }
     if let Err(commit_error) = tx.commit(rt) {

--- a/crates/jstz_mock/src/host.rs
+++ b/crates/jstz_mock/src/host.rs
@@ -4,7 +4,7 @@ use jstz_core::{host::HostRuntime, kv::Storage};
 
 use crate::message::MockInternalMessage;
 use derive_more::{Deref, DerefMut};
-use jstz_crypto::smart_function_hash::SmartFunctionHash;
+use jstz_crypto::{public_key::PublicKey, smart_function_hash::SmartFunctionHash};
 use tezos_crypto_rs::hash::ContractKt1Hash;
 use tezos_smart_rollup::{
     michelson::{
@@ -34,6 +34,7 @@ pub const MOCK_PROXY_FUNCTION: &str = r#"
 pub const MOCK_TICKETER: &str = "KT1H28iie4mW9LmmJeYLjH6zkC8wwSmfHf5P";
 
 pub const TICKETER_PATH: RefPath = RefPath::assert_from(b"/ticketer");
+pub const INJECTOR_PATH: RefPath = RefPath::assert_from(b"/injector");
 pub type RollupType = MichelsonOr<
     MichelsonPair<MichelsonContract, FA2_1Ticket>,
     MichelsonPair<
@@ -88,6 +89,12 @@ impl Default for JstzMockHost {
                 .unwrap()
                 .into();
         Storage::insert(&mut mock_host, &TICKETER_PATH, &ticketer)
+            .expect("Could not insert ticketer");
+        let injector: PublicKey = PublicKey::from_base58(
+            "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav",
+        )
+        .unwrap();
+        Storage::insert(&mut mock_host, &INJECTOR_PATH, &injector)
             .expect("Could not insert ticketer");
         mock_host.set_debug_handler(empty());
         Self(mock_host)

--- a/crates/jstz_proto/src/error.rs
+++ b/crates/jstz_proto/src/error.rs
@@ -45,6 +45,7 @@ pub enum Error {
     AccountExists,
     RevealTypeMismatch,
     RevealNotSupported,
+    InvalidInjector,
 }
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -125,6 +126,9 @@ impl From<Error> for JsError {
             Error::RevealNotSupported => JsNativeError::eval()
                 .with_message("RevealNotSupported")
                 .into(),
+            Error::InvalidInjector => {
+                JsNativeError::eval().with_message("InvalidInjector").into()
+            }
         }
     }
 }

--- a/crates/jstz_tps_bench/src/kernel/main.rs
+++ b/crates/jstz_tps_bench/src/kernel/main.rs
@@ -2,8 +2,8 @@
 
 use std::sync::Once;
 
-use jstz_crypto::hash::Hash;
 use jstz_crypto::smart_function_hash::SmartFunctionHash;
+use jstz_crypto::{hash::Hash, public_key::PublicKey};
 use tezos_smart_rollup::{entrypoint, storage::path::RefPath};
 use tezos_smart_rollup_core::smart_rollup_core::SmartRollupCore;
 use tezos_smart_rollup_host::runtime::Runtime;
@@ -27,6 +27,18 @@ pub fn entry(host: &mut impl Runtime) {
             host.store_write(
                 &TICKETER,
                 &bincode::encode_to_vec(&ticketer, bincode::config::legacy()).unwrap(),
+                0,
+            )
+            .unwrap();
+
+            let injector = PublicKey::from_base58(
+                "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav",
+            )
+            .unwrap();
+            const INJECTOR: RefPath = RefPath::assert_from(b"/injector");
+            host.store_write(
+                &INJECTOR,
+                &bincode::encode_to_vec(&injector, bincode::config::legacy()).unwrap(),
                 0,
             )
             .unwrap();

--- a/crates/jstzd/build.rs
+++ b/crates/jstzd/build.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use jstz_crypto::smart_function_hash::SmartFunctionHash;
-use jstz_kernel::TICKETER;
+use jstz_crypto::{public_key::PublicKey, smart_function_hash::SmartFunctionHash};
+use jstz_kernel::{INJECTOR, TICKETER};
 use std::{
     env, fs,
     path::{Path, PathBuf},
@@ -127,6 +127,14 @@ fn make_kernel_installer(kernel_file: &Path, preimages_dir: &Path) -> Result<Str
                 bincode::config::legacy(),
             )?),
             OwnedPath::from(TICKETER),
+        ),
+        // 3. Set `jstz` injector as the `jstz_node` account
+        OwnedConfigInstruction::set_instr(
+            OwnedBytes(bincode::encode_to_vec(
+                PublicKey::from_base58(INJECTOR_PK)?,
+                bincode::config::legacy(),
+            )?),
+            OwnedPath::from(INJECTOR),
         ),
     ]);
     let installer = installer::with_config_program(installer_program);

--- a/crates/jstzd/build_config.rs
+++ b/crates/jstzd/build_config.rs
@@ -1,1 +1,5 @@
 pub const EXCHANGER_ADDRESS: &str = "KT1F3MuqvT9Yz57TgCS3EkDcKNZe9HpiavUJ";
+
+/// jstz node's injector used (bootstrap1) to sign `RevealLargePayload` operation.
+/// make sure to update jstzd/src/config.rs if you change this.
+pub const INJECTOR_PK: &str = "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav";


### PR DESCRIPTION
# Context

[task link](https://linear.app/tezos/issue/JSTZ-363/add-authentication)

# Description

* Add auth to the protocol to check that reveal large payload comes from `bootstrap1` 
* created a task to organize protocol constants in one place. Will leave it for now as we only have ticketer and injector .

# Manually testing the PR

add unit test.
```
cargo test -p jstz_proto
```
