### PR TITLE
Fix Operation hash for large payload operation

### DIFF
--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -1006,15 +1006,22 @@
         "description": "An operation to reveal an operation with a large payload of type `RevealType`. The root hash is the hash of the SignedOperation and the data is assumed to be available.",
         "required": [
           "root_hash",
-          "reveal_type"
+          "reveal_type",
+          "original_op_hash"
         ],
         "properties": {
+          "original_op_hash": {
+            "$ref": "#/components/schemas/Blake2b",
+            "description": "The original operation hash that is being revealed."
+          },
           "reveal_type": {
             "type": "string",
+            "description": "The type of operation being revealed.",
             "example": "DeployFunction"
           },
           "root_hash": {
-            "type": "string"
+            "type": "string",
+            "description": "The root hash of the preimage of the operation used to reveal the operation data."
           }
         }
       },

--- a/crates/jstz_proto/src/executor/mod.rs
+++ b/crates/jstz_proto/src/executor/mod.rs
@@ -1,5 +1,7 @@
 use crate::{
-    operation::{self, ExternalOperation, Operation, OperationHash, SignedOperation},
+    operation::{
+        self, Content, ExternalOperation, Operation, OperationHash, SignedOperation,
+    },
     receipt::{self, Receipt},
     Error, Result,
 };
@@ -12,17 +14,6 @@ pub mod fa_withdraw;
 pub mod smart_function;
 pub mod withdraw;
 pub const JSTZ_HOST: &str = "jstz";
-
-fn verify_signed_op(
-    hrt: &mut impl HostRuntime,
-    tx: &mut Transaction,
-    signed_op: SignedOperation,
-) -> Result<Operation> {
-    signed_op.verify().and_then(|op| {
-        op.verify_nonce(hrt, tx)?;
-        Ok(op)
-    })
-}
 
 fn execute_operation_inner(
     hrt: &mut impl HostRuntime,
@@ -57,8 +48,9 @@ fn execute_operation_inner(
             let revealed_op = RevealData::reveal_and_decode::<_, SignedOperation>(
                 hrt,
                 &reveal.root_hash,
-            )?;
-            let revealed_op = verify_signed_op(hrt, tx, revealed_op)?;
+            )?
+            .verify()?;
+            revealed_op.verify_nonce(hrt, tx)?;
             if reveal.reveal_type == revealed_op.content().try_into()? {
                 return execute_operation_inner(hrt, tx, revealed_op, ticketer, injector);
             }
@@ -87,13 +79,25 @@ pub fn execute_operation(
     ticketer: &ContractKt1Hash,
     injector: &PublicKey,
 ) -> Receipt {
-    let operation_hash = signed_operation.hash();
-    let result = verify_signed_op(hrt, tx, signed_operation)
-        .and_then(|op| execute_operation_inner(hrt, tx, op, ticketer, injector));
-    match result {
-        Ok((hash, content)) => Receipt::new(hash, Ok(content)),
-        Err(e) => Receipt::new(operation_hash, Err(e)),
-    }
+    let op_hash = signed_operation.hash();
+    let op: std::result::Result<Operation, Error> = signed_operation.verify();
+    let op_hash = match &op {
+        // If the operation is a reveal large payload operation, use the original operation hash
+        Ok(Operation {
+            content: Content::RevealLargePayload(reveal),
+            ..
+        }) => reveal.original_op_hash.clone(),
+        _ => op_hash,
+    };
+
+    op.and_then(|op| {
+        op.verify_nonce(hrt, tx)?;
+        execute_operation_inner(hrt, tx, op, ticketer, injector)
+    })
+    .map_or_else(
+        |e| Receipt::new(op_hash, Err(e)),
+        |(hash, content)| Receipt::new(hash, Ok(content)),
+    )
 }
 
 #[cfg(test)]
@@ -182,10 +186,12 @@ mod tests {
         root_hash: PreimageHash,
         pk: PublicKey,
         sk: SecretKey,
+        original_op_hash: OperationHash,
     ) -> SignedOperation {
         let rdc_op = RevealLargePayload {
             root_hash,
             reveal_type: RevealType::DeployFunction,
+            original_op_hash,
         };
         let rdc_op_content = rdc_op;
         let rdc_op: Operation = Operation {
@@ -214,8 +220,8 @@ mod tests {
         let (_, pk1, sk1) = bootstrap1();
         let (_, pk2, sk2) = bootstrap2();
         let deploy_op = make_signed_op(deploy_function_content(), pk2, sk2);
-        let root_hash = make_data_available(&mut host, deploy_op);
-        let rdc_op = signed_rdc_op(root_hash, pk1.clone(), sk1);
+        let root_hash = make_data_available(&mut host, deploy_op.clone());
+        let rdc_op = signed_rdc_op(root_hash, pk1.clone(), sk1, deploy_op.hash());
         let ticketer = ContractKt1Hash::try_from_bytes(&[0; 20]).unwrap();
         let receipt = execute_operation(&mut host, &mut tx, rdc_op, &ticketer, &pk1);
         assert!(matches!(receipt.result, ReceiptResult::Success(_)));
@@ -228,8 +234,8 @@ mod tests {
         let (_, pk1, sk1) = bootstrap1();
         let (_, pk2, sk2) = bootstrap2();
         let run_op = make_signed_op(run_function_content(), pk2.clone(), sk2.clone());
-        let root_hash = make_data_available(&mut host, run_op);
-        let rdc_op = signed_rdc_op(root_hash, pk1.clone(), sk1.clone());
+        let root_hash = make_data_available(&mut host, run_op.clone());
+        let rdc_op = signed_rdc_op(root_hash, pk1.clone(), sk1.clone(), run_op.hash());
         let ticketer = ContractKt1Hash::try_from_bytes(&[0; 20]).unwrap();
         let receipt = execute_operation(&mut host, &mut tx, rdc_op, &ticketer, &pk1);
         println!("receipt: {:?}", receipt);
@@ -264,12 +270,14 @@ mod tests {
         let (_, pk1, sk1) = bootstrap1();
         let (_, pk2, sk2) = bootstrap2();
         let deploy_op = make_signed_op(deploy_function_content(), pk1.clone(), sk1);
-        let root_hash = make_data_available(&mut host, deploy_op);
-        let rdc_op = signed_rdc_op(root_hash, pk2.clone(), sk2);
+        let root_hash = make_data_available(&mut host, deploy_op.clone());
+        let rdc_op = signed_rdc_op(root_hash, pk2.clone(), sk2, deploy_op.hash());
         let ticketer = ContractKt1Hash::try_from_bytes(&[0; 20]).unwrap();
-        let receipt = execute_operation(&mut host, &mut tx, rdc_op, &ticketer, &pk1);
+        let receipt =
+            execute_operation(&mut host, &mut tx, rdc_op.clone(), &ticketer, &pk1);
         assert!(
-            matches!(receipt.result, ReceiptResult::Failed(e) if e.contains("InvalidInjector"))
+            matches!(receipt.clone().result, ReceiptResult::Failed(e) if e.contains("InvalidInjector"))
         );
+        assert_eq!(receipt.hash().to_string(), deploy_op.hash().to_string());
     }
 }


### PR DESCRIPTION
# Context
[link](https://linear.app/tezos/issue/JSTZ-458/store-recipt-in-the-original-hash)
Before this fix, when handling RLP operation in the protocol, the protocol used  the RLP operation hash. it should be linked to the orignal operation hash instead as RLP operation is an `intermediate opertion`

# Description

* Extended the RLP operation to include the hash of the original operation
* Modified the protocol to use the orginal operation hash instead of the RLP hash

# Manually testing the PR

add unit test.
```
cargo test -p jstz_proto
```
