### PR TITLE
fix(crypto): remove keypair_from_passphrase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2913,6 +2913,7 @@ version = "0.1.0-alpha.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.0-rc.3",
+ "bip39",
  "boa_gc",
  "derive_more",
  "hex",
@@ -3091,6 +3092,7 @@ version = "0.1.0-alpha.0"
 dependencies = [
  "base64 0.21.7",
  "bincode 2.0.0-rc.3",
+ "bip39",
  "boa_gc",
  "clap 4.5.20",
  "hex",

--- a/crates/jstz_cli/src/account.rs
+++ b/crates/jstz_cli/src/account.rs
@@ -4,7 +4,7 @@ use bip39::{Language, Mnemonic};
 use clap::Subcommand;
 use dialoguer::{Confirm, Input};
 use jstz_crypto::smart_function_hash::SmartFunctionHash;
-use jstz_crypto::{keypair_from_passphrase, public_key_hash::PublicKeyHash};
+use jstz_crypto::{keypair_from_mnemonic, public_key_hash::PublicKeyHash};
 use log::{debug, info, warn};
 
 use crate::utils::MUTEZ_PER_TEZ;
@@ -24,7 +24,7 @@ fn generate_passphrase() -> String {
 
 impl User {
     pub fn from_passphrase(passphrase: String) -> Result<Self> {
-        let (sk, pk) = keypair_from_passphrase(passphrase.as_str())?;
+        let (sk, pk) = keypair_from_mnemonic(passphrase.as_str(), "")?;
 
         let address = PublicKeyHash::from(&pk);
 
@@ -357,11 +357,22 @@ pub async fn exec(command: Command) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use crate::config::User;
+
     #[test]
     fn generate_passphrase() {
         // Just to make sure that generate_passphrase works with the current version of Mnemonic.
         // If anything changes in the library and fails our logic, the unwrap call will lead to
         // a panic and we can capture that issue here.
         assert_ne!(super::generate_passphrase(), super::generate_passphrase());
+    }
+
+    #[test]
+    fn user_from_passphrase() {
+        let user = User::from_passphrase("author crumble medal dose ribbon permit ankle sport final hood shadow vessel horn hawk enter zebra prefer devote captain during fly found despair business".to_owned()).expect("should instantiate user");
+        assert_eq!(
+            user.address.to_string(),
+            "tz1ia78UBMgdmVf8b2vu5y8Rd148p9e2yn2h"
+        );
     }
 }

--- a/crates/jstz_crypto/Cargo.toml
+++ b/crates/jstz_crypto/Cargo.toml
@@ -13,6 +13,7 @@ description.workspace = true
 [dependencies]
 anyhow.workspace = true
 bincode.workspace = true
+bip39.workspace = true
 boa_gc.workspace = true
 derive_more.workspace = true
 hex.workspace = true

--- a/crates/jstz_crypto/src/lib.rs
+++ b/crates/jstz_crypto/src/lib.rs
@@ -8,13 +8,20 @@ pub mod secret_key;
 pub mod signature;
 pub mod smart_function_hash;
 
-use tezos_crypto_rs::hash::SeedEd25519;
+use crate::{public_key::PublicKey, secret_key::SecretKey};
+use bip39::{Language, Mnemonic};
+use tezos_crypto_rs::{hash::SeedEd25519, CryptoError};
 
-use crate::{hash::Blake2b, public_key::PublicKey, secret_key::SecretKey};
-
-pub fn keypair_from_passphrase(passphrase: &str) -> Result<(SecretKey, PublicKey)> {
-    let ikm = Blake2b::from(passphrase.as_bytes()).as_array().to_vec();
-    let seed = SeedEd25519::try_from(ikm)?;
+pub fn keypair_from_mnemonic(
+    mnemonic: &str,
+    passphrase: &str,
+) -> Result<(SecretKey, PublicKey)> {
+    let m = Mnemonic::parse_in(Language::English, mnemonic).map_err(|e| {
+        CryptoError::InvalidKey {
+            reason: format!("failed to parse mnemonic: {e}"),
+        }
+    })?;
+    let seed = SeedEd25519::try_from(m.to_seed(passphrase)[0..32].to_vec())?;
     let (pk, sk) = seed.keypair()?;
     Ok((SecretKey::Ed25519(sk), PublicKey::Ed25519(pk.into())))
 }
@@ -48,13 +55,33 @@ macro_rules! impl_bincode_for_hash {
 
 #[cfg(test)]
 mod tests {
-    use super::keypair_from_passphrase;
+    use super::keypair_from_mnemonic;
     use proptest::prelude::*;
+
+    #[test]
+    fn keypair_from_mnemonic_should_align_with_octez_client() {
+        let mnemonic = "author crumble medal dose ribbon permit ankle sport final hood shadow vessel horn hawk enter zebra prefer devote captain during fly found despair business";
+        let (_, pk) = keypair_from_mnemonic(mnemonic, "").unwrap();
+        // This address is acquired from octez-client with the mnemonic above and an empty passphrase:
+        // echo $'author crumble medal dose ribbon permit ankle sport final hood shadow vessel horn hawk enter zebra prefer devote captain during fly found despair business\n' | octez-client import keys from mnemonic test --force
+        assert_eq!(pk.hash(), "tz1ia78UBMgdmVf8b2vu5y8Rd148p9e2yn2h");
+
+        let (_, pk) = keypair_from_mnemonic(mnemonic, "foobar").unwrap();
+        // This address is acquired from octez-client with the mnemonic above and passphrase 'foobar':
+        // echo $'author crumble medal dose ribbon permit ankle sport final hood shadow vessel horn hawk enter zebra prefer devote captain during fly found despair business\nfoobar\n' | octez-client import keys from mnemonic test --force
+        assert_eq!(pk.hash(), "tz1W8rEphWEjMcD1HsxEhsBFocfMeGsW7Qxg");
+    }
+
+    #[test]
+    fn keypair_from_mnemonic_failed() {
+        assert_eq!(keypair_from_mnemonic("a", "").unwrap_err().to_string(), "Invalid crypto key, reason: failed to parse mnemonic: mnemonic has an invalid word count: 1. Word count must be 12, 15, 18, 21, or 24");
+    }
 
     proptest! {
         #[test]
         fn test_keygen_verify(passphrase in any::<String>(), message in any::<Vec<u8>>()) {
-            let (sk, pk) = keypair_from_passphrase(&passphrase).unwrap();
+            let mnemonic = "author crumble medal dose ribbon permit ankle sport final hood shadow vessel horn hawk enter zebra prefer devote captain during fly found despair business";
+            let (sk, pk) = keypair_from_mnemonic(mnemonic, &passphrase).unwrap();
             let sig = sk.sign(&message).unwrap();
             assert!(sig.verify(&pk, &message).is_ok());
         }

--- a/crates/jstz_tps_bench/Cargo.toml
+++ b/crates/jstz_tps_bench/Cargo.toml
@@ -15,6 +15,7 @@ base64.workspace = true
 boa_gc.workspace = true
 http.workspace = true
 bincode.workspace = true
+bip39.workspace = true
 regex.workspace = true
 serde_json.workspace = true
 jstz_kernel = { path = "../jstz_kernel" }

--- a/crates/jstz_tps_bench/src/bench/generate.rs
+++ b/crates/jstz_tps_bench/src/bench/generate.rs
@@ -6,12 +6,11 @@ use std::error::Error;
 use std::path::Path;
 
 use base64::{engine::general_purpose::URL_SAFE, Engine};
+use bip39::{Language, Mnemonic};
 use http::{HeaderMap, Method, Uri};
 use jstz_crypto::hash::Hash;
 use jstz_crypto::smart_function_hash::SmartFunctionHash;
-use jstz_crypto::{
-    keypair_from_passphrase, public_key::PublicKey, secret_key::SecretKey,
-};
+use jstz_crypto::{keypair_from_mnemonic, public_key::PublicKey, secret_key::SecretKey};
 use jstz_proto::context::account::{Address, Addressable, Nonce, ParsedCode};
 use jstz_proto::operation::{
     Content, DeployFunction, Operation, RunFunction, SignedOperation,
@@ -256,8 +255,11 @@ fn deploy_fa2(
 fn gen_keys(num: usize) -> Result<Vec<Account>> {
     let mut res = Vec::with_capacity(num);
 
-    for i in 0..num {
-        let (sk, pk) = keypair_from_passphrase(&i.to_string())?;
+    for _ in 0..num {
+        let mnemonic = Mnemonic::generate_in(Language::English, 12)
+            .expect("generate_in should generate mnemonics")
+            .to_string();
+        let (sk, pk) = keypair_from_mnemonic(&mnemonic, "")?;
         let account = Account {
             address: Address::from_base58(&pk.hash())?,
             sk,


### PR DESCRIPTION
# Context

Part of JSTZ-484.
[JSTZ-484](https://linear.app/tezos/issue/JSTZ-484/update-account-creation)

In jstz, the term `passphrase` has always been what is referred to as mnemonic in other tools like octez-client and L1 wallets. This is misleading and the way CLI derives keys from passphrases is also problematic.

# Description

Replace `keypair_from_passphrase` with `keypair_from_mnemonic` to align key derivation with octez-client.

# Manually testing the PR

Added unit tests.
