### PR TITLE
chore(proto): use camelCase in json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ test-int:
 # --test only runs a specified integration test (a test in /tests).
 #        the glob pattern is used to match all integration tests
 # --exclude excludes the jstz_api wpt test
-	@cargo nextest run --test "*" --workspace --exclude "jstz_api"
+	@cargo nextest run --test "*" --workspace --exclude "jstz_api" --features skip-wpt,skip-rollup-tests
 
 .PHONY: cov 
 cov:

--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -636,15 +636,15 @@
       "DeployFunction": {
         "type": "object",
         "required": [
-          "function_code",
-          "account_credit"
+          "functionCode",
+          "accountCredit"
         ],
         "properties": {
-          "account_credit": {
+          "accountCredit": {
             "$ref": "#/components/schemas/u64",
             "description": "Amount of tez to credit to the smart function account, debited from the sender"
           },
-          "function_code": {
+          "functionCode": {
             "$ref": "#/components/schemas/ParsedCode",
             "description": "Smart function code"
           }
@@ -665,13 +665,13 @@
         "type": "object",
         "required": [
           "account",
-          "updated_balance"
+          "updatedBalance"
         ],
         "properties": {
           "account": {
             "$ref": "#/components/schemas/Address"
           },
-          "updated_balance": {
+          "updatedBalance": {
             "type": "integer",
             "format": "int64",
             "minimum": 0
@@ -682,13 +682,13 @@
         "type": "object",
         "required": [
           "receiver",
-          "ticket_balance"
+          "ticketBalance"
         ],
         "properties": {
           "receiver": {
             "$ref": "#/components/schemas/Address"
           },
-          "run_function": {
+          "runFunction": {
             "oneOf": [
               {
                 "type": "null"
@@ -698,7 +698,7 @@
               }
             ]
           },
-          "ticket_balance": {
+          "ticketBalance": {
             "$ref": "#/components/schemas/u64"
           }
         }
@@ -707,17 +707,17 @@
         "type": "object",
         "required": [
           "amount",
-          "routing_info",
-          "ticket_info"
+          "routingInfo",
+          "ticketInfo"
         ],
         "properties": {
           "amount": {
             "$ref": "#/components/schemas/u64"
           },
-          "routing_info": {
+          "routingInfo": {
             "$ref": "#/components/schemas/RoutingInfo"
           },
-          "ticket_info": {
+          "ticketInfo": {
             "$ref": "#/components/schemas/TicketInfo"
           }
         }
@@ -763,7 +763,7 @@
         "type": "object",
         "required": [
           "address",
-          "request_id",
+          "requestId",
           "level",
           "text"
         ],
@@ -774,7 +774,7 @@
           "level": {
             "$ref": "#/components/schemas/LogLevel"
           },
-          "request_id": {
+          "requestId": {
             "type": "string"
           },
           "text": {
@@ -790,7 +790,7 @@
       "Operation": {
         "type": "object",
         "required": [
-          "public_key",
+          "publicKey",
           "nonce",
           "content"
         ],
@@ -803,7 +803,7 @@
             "$ref": "#/components/schemas/Nonce",
             "description": "Nonce is used to avoid replay attacks."
           },
-          "public_key": {
+          "publicKey": {
             "$ref": "#/components/schemas/PublicKey",
             "description": "The public key of the account which was used to sign the operation"
           }
@@ -1032,21 +1032,21 @@
         "type": "object",
         "description": "An operation to reveal an operation with a large payload of type `RevealType`. The root hash is the hash of the SignedOperation and the data is assumed to be available.",
         "required": [
-          "root_hash",
-          "reveal_type",
-          "original_op_hash"
+          "rootHash",
+          "revealType",
+          "originalOpHash"
         ],
         "properties": {
-          "original_op_hash": {
+          "originalOpHash": {
             "$ref": "#/components/schemas/Blake2b",
             "description": "The original operation hash that is being revealed."
           },
-          "reveal_type": {
+          "revealType": {
             "type": "string",
             "description": "The type of operation being revealed.",
             "example": "DeployFunction"
           },
-          "root_hash": {
+          "rootHash": {
             "type": "string",
             "description": "The root hash of the preimage of the operation used to reveal the operation data."
           }
@@ -1056,10 +1056,10 @@
         "type": "object",
         "required": [
           "receiver",
-          "proxy_l1_contract"
+          "proxyL1Contract"
         ],
         "properties": {
-          "proxy_l1_contract": {
+          "proxyL1Contract": {
             "$ref": "#/components/schemas/Kt1Hash"
           },
           "receiver": {
@@ -1075,7 +1075,7 @@
           "method",
           "headers",
           "body",
-          "gas_limit"
+          "gasLimit"
         ],
         "properties": {
           "body": {
@@ -1089,7 +1089,7 @@
               "minimum": 0
             }
           },
-          "gas_limit": {
+          "gasLimit": {
             "type": "integer",
             "description": "Maximum amount of gas that is allowed for the execution of this operation",
             "minimum": 0
@@ -1124,7 +1124,7 @@
         "type": "object",
         "required": [
           "body",
-          "status_code",
+          "statusCode",
           "headers"
         ],
         "properties": {
@@ -1144,7 +1144,7 @@
             "description": "Any valid HTTP headers",
             "additionalProperties": true
           },
-          "status_code": {
+          "statusCode": {
             "type": "integer",
             "description": "Valid status code",
             "minimum": 0
@@ -1190,13 +1190,13 @@
         "required": [
           "amount",
           "nonce",
-          "function_code"
+          "functionCode"
         ],
         "properties": {
           "amount": {
             "$ref": "#/components/schemas/u64"
           },
-          "function_code": {
+          "functionCode": {
             "$ref": "#/components/schemas/ParsedCode"
           },
           "nonce": {

--- a/crates/jstz_proto/src/api/smart_function.rs
+++ b/crates/jstz_proto/src/api/smart_function.rs
@@ -1219,11 +1219,11 @@ mod test {
                             }},
                             body: JSON.stringify({{
                                 amount: {withdraw_amount},
-                                routing_info: {{
+                                routingInfo: {{
                                     receiver: "{receiver}",
-                                    proxy_l1_contract: "{l1_proxy_contract}"
+                                    proxyL1Contract: "{l1_proxy_contract}"
                                 }},
-                                ticket_info: {{
+                                ticketInfo: {{
                                     id: {ticket_id},
                                     content: {json_ticket_content},
                                     ticketer: "{ticketer_string}"

--- a/crates/jstz_proto/src/context/account.rs
+++ b/crates/jstz_proto/src/context/account.rs
@@ -221,6 +221,7 @@ pub struct UserAccount {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, Encode, Decode, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct SmartFunctionAccount {
     pub amount: Amount,
     pub nonce: Nonce,

--- a/crates/jstz_proto/src/executor/deposit.rs
+++ b/crates/jstz_proto/src/executor/deposit.rs
@@ -61,7 +61,7 @@ mod test {
                 updated_balance,
             })) if account == Address::User(receiver) && updated_balance == 20
         ));
-        let raw_json_payload = r#"{"hash":[39,12,7,148,87,7,176,168,111,219,214,147,14,123,179,202,232,151,138,59,207,182,101,158,128,98,239,57,236,88,195,42],"result":{"_type":"Success","inner":{"_type":"Deposit","account":"tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx","updated_balance":20}}}"#;
+        let raw_json_payload = r#"{"hash":[39,12,7,148,87,7,176,168,111,219,214,147,14,123,179,202,232,151,138,59,207,182,101,158,128,98,239,57,236,88,195,42],"result":{"_type":"Success","inner":{"_type":"Deposit","account":"tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx","updatedBalance":20}}}"#;
         assert_eq!(raw_json_payload, serde_json::to_string(&receipt).unwrap());
     }
 }

--- a/crates/jstz_proto/src/executor/fa_deposit.rs
+++ b/crates/jstz_proto/src/executor/fa_deposit.rs
@@ -24,6 +24,7 @@ const NULL_ADDRESS: &str = "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx";
 const DEPOSIT_URI: &str = "/-/deposit";
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Encode, Decode)]
+#[serde(rename_all = "camelCase")]
 pub struct FaDepositReceipt {
     pub receiver: Address,
     pub ticket_balance: Amount,

--- a/crates/jstz_proto/src/executor/fa_withdraw.rs
+++ b/crates/jstz_proto/src/executor/fa_withdraw.rs
@@ -28,6 +28,7 @@ use crate::{
 const WITHDRAW_ENTRYPOINT: &str = "withdraw";
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema, Encode, Decode)]
+#[serde(rename_all = "camelCase")]
 pub struct FaWithdraw {
     pub amount: Amount,
     pub routing_info: RoutingInfo,
@@ -35,6 +36,7 @@ pub struct FaWithdraw {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema, Encode, Decode)]
+#[serde(rename_all = "camelCase")]
 pub struct RoutingInfo {
     pub receiver: Address,
     pub proxy_l1_contract: Kt1Hash,
@@ -82,6 +84,7 @@ impl TryFrom<FA2_1Ticket> for Ticket {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema, Encode, Decode)]
+#[serde(rename_all = "camelCase")]
 pub struct FaWithdrawReceipt {
     pub source: Address,
     #[serde(flatten)]

--- a/crates/jstz_proto/src/js_logger.rs
+++ b/crates/jstz_proto/src/js_logger.rs
@@ -14,6 +14,7 @@ pub use jstz_api::js_log::{JsLog, LogData, LogLevel};
 pub const LOG_PREFIX: &str = "[JSTZ:SMART_FUNCTION:LOG] ";
 
 #[derive(Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct LogRecord {
     pub address: SmartFunctionHash,
     pub request_id: String,

--- a/crates/jstz_proto/src/operation.rs
+++ b/crates/jstz_proto/src/operation.rs
@@ -17,6 +17,7 @@ use utoipa::ToSchema;
 #[derive(
     Debug, Serialize, Deserialize, PartialEq, Eq, ToSchema, Encode, Decode, Clone,
 )]
+#[serde(rename_all = "camelCase")]
 pub struct Operation {
     /// The public key of the account which was used to sign the operation
     pub public_key: PublicKey,
@@ -106,6 +107,7 @@ impl Operation {
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct DeployFunction {
     /// Smart function code
     pub function_code: ParsedCode,
@@ -117,6 +119,7 @@ pub struct DeployFunction {
 #[schema(description = "Request used to run a smart function. \
     The target smart function is given by the host part of the uri. \
     The rest of the attributes will be handled by the smart function itself.")]
+#[serde(rename_all = "camelCase")]
 pub struct RunFunction {
     /// Smart function URI in the form jstz://{smart_function_address}/rest/of/path
     #[serde(with = "http_serde::uri")]
@@ -163,6 +166,7 @@ impl TryFrom<&Content> for RevealType {
     description = "An operation to reveal an operation with a large payload of type `RevealType`. \
             The root hash is the hash of the SignedOperation and the data is assumed to be available."
 )]
+#[serde(rename_all = "camelCase")]
 pub struct RevealLargePayload {
     /// The root hash of the preimage of the operation used to reveal the operation data.
     #[schema(value_type = String)]
@@ -363,7 +367,7 @@ mod test {
             json!({
                 "_type":"RunFunction",
                 "body":[34,118,97,108,117,101,34,58,49,34],
-                "gas_limit":10000,
+                "gasLimit":10000,
                 "headers":{},
                 "method":"POST",
                 "uri":"jstz://tz1cD5CuvAALcxgypqBXcBQEA8dkLJivoFjU/nfts?status=sold"
@@ -389,8 +393,8 @@ mod test {
             json,
             json!({
                 "_type":"DeployFunction",
-                "account_credit":100000,
-                "function_code":"export default handler = () => new Response(\"hello world!\");"
+                "accountCredit":100000,
+                "functionCode":"export default handler = () => new Response(\"hello world!\");"
             })
         );
         let decoded = serde_json::from_value::<Content>(json).unwrap();
@@ -521,8 +525,8 @@ mod test {
         // Check the structure without hardcoding the exact serialization of root_hash
         let json_obj = json.as_object().unwrap();
         assert_eq!(json_obj.get("_type").unwrap(), "RevealLargePayload");
-        assert_eq!(json_obj.get("reveal_type").unwrap(), "DeployFunction");
-        assert!(json_obj.contains_key("root_hash"));
+        assert_eq!(json_obj.get("revealType").unwrap(), "DeployFunction");
+        assert!(json_obj.contains_key("rootHash"));
 
         let decoded = serde_json::from_value::<Content>(json).unwrap();
         assert_eq!(reveal_large_payload_operation, decoded);

--- a/crates/jstz_proto/src/receipt.rs
+++ b/crates/jstz_proto/src/receipt.rs
@@ -55,6 +55,7 @@ pub struct DeployFunctionReceipt {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct RunFunctionReceipt {
     #[schema(schema_with = crate::operation::openapi::http_body_schema)]
     pub body: HttpBody,
@@ -69,6 +70,7 @@ pub struct RunFunctionReceipt {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Encode, Decode)]
+#[serde(rename_all = "camelCase")]
 pub struct DepositReceipt {
     pub account: Address,
     pub updated_balance: u64,

--- a/crates/jstz_tps_bench/src/kernel/main.rs
+++ b/crates/jstz_tps_bench/src/kernel/main.rs
@@ -4,9 +4,9 @@ use std::sync::Once;
 
 use jstz_crypto::smart_function_hash::SmartFunctionHash;
 use jstz_crypto::{hash::Hash, public_key::PublicKey};
+use tezos_smart_rollup::prelude::Runtime;
 use tezos_smart_rollup::{entrypoint, storage::path::RefPath};
 use tezos_smart_rollup_core::smart_rollup_core::SmartRollupCore;
-use tezos_smart_rollup_host::runtime::Runtime;
 
 #[entrypoint::main]
 #[cfg_attr(


### PR DESCRIPTION
# Context
Since we target a primarily JS/TS audience, generated code should use camel case. Additionally, its [generally good practice](https://google.github.io/styleguide/jsoncstyleguide.xml?showone=Property_Name_Format#Property_Name_Format) to use camel case properties in API services

Closes: https://linear.app/tezos/issue/JSTZ-488/use-camelcase-for-json

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
Annotated structs that affect the open api generation with `#[serde(rename_all = "camelCase")]`
<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
Corresponding stainless changes - https://github.com/jstz-dev/jstz-client/commit/8e1a71486a6b0ef41c5ed736d17c9e2394f9454a#diff-25fd7ba932755790a659d8dfcf1c25b9d628e7b642e9087dfd55af137db086e6 
<!-- Describe how reviewers and approvers can test this PR. -->
