### PR TITLE
chore(proto): remove outbox messasge id

### DIFF
--- a/crates/jstz_crypto/src/smart_function_hash.rs
+++ b/crates/jstz_crypto/src/smart_function_hash.rs
@@ -33,12 +33,41 @@ use utoipa::{schema, ToSchema};
     value_type = String,
     example = json!("KT1RycYvM4EVs6BAXWEsGXaAaRqiMP53KT4w")
 )]
-pub struct SmartFunctionHash(pub ContractKt1Hash);
+pub struct Kt1Hash(pub ContractKt1Hash);
 
-impl_bincode_for_hash!(SmartFunctionHash, ContractKt1Hash);
+impl_bincode_for_hash!(Kt1Hash, ContractKt1Hash);
+
+#[derive(
+    Deref,
+    From,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    Finalize,
+    Encode,
+    Decode,
+    ToSchema,
+)]
+pub struct SmartFunctionHash(pub Kt1Hash);
 
 unsafe impl Trace for SmartFunctionHash {
     empty_trace!();
+}
+
+impl From<SmartFunctionHash> for ContractKt1Hash {
+    fn from(value: SmartFunctionHash) -> ContractKt1Hash {
+        value.0 .0
+    }
+}
+
+impl From<ContractKt1Hash> for SmartFunctionHash {
+    fn from(value: ContractKt1Hash) -> Self {
+        Kt1Hash(value).into()
+    }
 }
 
 impl FromStr for SmartFunctionHash {
@@ -61,7 +90,9 @@ impl<'a> Hash<'a> for SmartFunctionHash {
             return Err(Error::InvalidSmartFunctionHash);
         }
         match &data[..3] {
-            "KT1" => Ok(SmartFunctionHash(ContractKt1Hash::from_base58_check(data)?)),
+            "KT1" => Ok(SmartFunctionHash(
+                ContractKt1Hash::from_base58_check(data)?.into(),
+            )),
             _ => Err(Error::InvalidSmartFunctionHash),
         }
     }
@@ -77,7 +108,9 @@ impl<'a> Hash<'a> for SmartFunctionHash {
     fn digest(data: &[u8]) -> Result<Self> {
         let out_len = ContractKt1Hash::hash_size();
         let bytes = blake2b::digest(data, out_len)?;
-        Ok(SmartFunctionHash(ContractKt1Hash::try_from_bytes(&bytes)?))
+        Ok(SmartFunctionHash(
+            ContractKt1Hash::try_from_bytes(&bytes)?.into(),
+        ))
     }
 }
 

--- a/crates/jstz_crypto/src/smart_function_hash.rs
+++ b/crates/jstz_crypto/src/smart_function_hash.rs
@@ -37,6 +37,12 @@ pub struct Kt1Hash(pub ContractKt1Hash);
 
 impl_bincode_for_hash!(Kt1Hash, ContractKt1Hash);
 
+impl From<Kt1Hash> for ContractKt1Hash {
+    fn from(value: Kt1Hash) -> Self {
+        value.0
+    }
+}
+
 #[derive(
     Deref,
     From,

--- a/crates/jstz_kernel/src/parsing.rs
+++ b/crates/jstz_kernel/src/parsing.rs
@@ -12,7 +12,7 @@ pub fn try_parse_contract(contract: &Contract) -> Result<Address> {
             Ok(Address::User(PublicKeyHash::Tz1(tz1.clone().into())))
         }
         Contract::Originated(contract_kt1_hash) => Ok(Address::SmartFunction(
-            SmartFunctionHash(contract_kt1_hash.clone()),
+            SmartFunctionHash(contract_kt1_hash.clone().into()),
         )),
         _ => Err(jstz_proto::Error::InvalidAddress),
     }

--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -703,20 +703,42 @@
           }
         }
       },
-      "FaWithdrawReceipt": {
+      "FaWithdraw": {
         "type": "object",
         "required": [
-          "source",
-          "outbox_message_id"
+          "amount",
+          "routing_info",
+          "ticket_info"
         ],
         "properties": {
-          "outbox_message_id": {
-            "$ref": "#/components/schemas/String"
+          "amount": {
+            "$ref": "#/components/schemas/u64"
           },
-          "source": {
-            "$ref": "#/components/schemas/Address"
+          "routing_info": {
+            "$ref": "#/components/schemas/RoutingInfo"
+          },
+          "ticket_info": {
+            "$ref": "#/components/schemas/TicketInfo"
           }
         }
+      },
+      "FaWithdrawReceipt": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/FaWithdraw"
+          },
+          {
+            "type": "object",
+            "required": [
+              "source"
+            ],
+            "properties": {
+              "source": {
+                "$ref": "#/components/schemas/Address"
+              }
+            }
+          }
+        ]
       },
       "KvValue": {
         "type": "string",
@@ -1025,6 +1047,21 @@
           }
         }
       },
+      "RoutingInfo": {
+        "type": "object",
+        "required": [
+          "receiver",
+          "proxy_l1_contract"
+        ],
+        "properties": {
+          "proxy_l1_contract": {
+            "$ref": "#/components/schemas/SmartFunctionHash"
+          },
+          "receiver": {
+            "$ref": "#/components/schemas/Address"
+          }
+        }
+      },
       "RunFunction": {
         "type": "object",
         "description": "Request used to run a smart function. The target smart function is given by the host part of the uri. The rest of the attributes will be handled by the smart function itself.",
@@ -1169,6 +1206,34 @@
       },
       "String": {
         "type": "string"
+      },
+      "TicketInfo": {
+        "type": "object",
+        "required": [
+          "id",
+          "ticketer"
+        ],
+        "properties": {
+          "content": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "ticketer": {
+            "$ref": "#/components/schemas/SmartFunctionHash"
+          }
+        }
       },
       "UserAccount": {
         "type": "object",

--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -740,6 +740,11 @@
           }
         ]
       },
+      "Kt1Hash": {
+        "type": "string",
+        "title": "KT1",
+        "example": "KT1RycYvM4EVs6BAXWEsGXaAaRqiMP53KT4w"
+      },
       "KvValue": {
         "type": "string",
         "format": "json",
@@ -1200,9 +1205,7 @@
         }
       },
       "SmartFunctionHash": {
-        "type": "string",
-        "title": "KT1",
-        "example": "KT1RycYvM4EVs6BAXWEsGXaAaRqiMP53KT4w"
+        "$ref": "#/components/schemas/Kt1Hash"
       },
       "String": {
         "type": "string"

--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -1060,7 +1060,7 @@
         ],
         "properties": {
           "proxy_l1_contract": {
-            "$ref": "#/components/schemas/SmartFunctionHash"
+            "$ref": "#/components/schemas/Kt1Hash"
           },
           "receiver": {
             "$ref": "#/components/schemas/Address"
@@ -1234,7 +1234,7 @@
             "minimum": 0
           },
           "ticketer": {
-            "$ref": "#/components/schemas/SmartFunctionHash"
+            "$ref": "#/components/schemas/Kt1Hash"
           }
         }
       },

--- a/crates/jstz_proto/src/executor/fa_withdraw.rs
+++ b/crates/jstz_proto/src/executor/fa_withdraw.rs
@@ -51,7 +51,7 @@ pub struct TicketInfo {
 impl TicketInfo {
     pub(super) fn to_ticket(&self, amount: Amount) -> Result<Ticket> {
         FA2_1Ticket::new(
-            Contract::Originated(self.ticketer.0.clone()),
+            Contract::Originated(self.ticketer.clone().into()),
             MichelsonPair(
                 self.id.into(),
                 MichelsonOption(self.content.clone().map(MichelsonBytes)),
@@ -105,7 +105,7 @@ fn create_fa_withdrawal_message(
     ticket: FA2_1Ticket,
 ) -> Result<OutboxMessage> {
     let receiver_pkh = routing_info.receiver.to_base58();
-    let destination = Contract::Originated(routing_info.proxy_l1_contract.0.clone());
+    let destination = Contract::Originated(routing_info.proxy_l1_contract.clone().into());
     let message = OutboxMessage::new_withdrawal_message(
         &Contract::try_from(receiver_pkh).unwrap(),
         &destination,
@@ -275,7 +275,7 @@ mod test {
                     vec![OutboxMessageTransaction {
                         parameters,
                         destination: Contract::Originated(
-                            routing_info.clone().proxy_l1_contract.0
+                            routing_info.clone().proxy_l1_contract.into()
                         ),
                         entrypoint: Entrypoint::try_from(WITHDRAW_ENTRYPOINT.to_string())
                             .unwrap(),

--- a/crates/jstz_proto/src/executor/fa_withdraw.rs
+++ b/crates/jstz_proto/src/executor/fa_withdraw.rs
@@ -5,9 +5,9 @@ use jstz_core::{
     host::HostRuntime,
     kv::{outbox::OutboxMessage, Transaction},
 };
+use jstz_crypto::smart_function_hash::SmartFunctionHash;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use tezos_crypto_rs::hash::ContractKt1Hash;
 use tezos_smart_rollup::{
     michelson::{
         ticket::{FA2_1Ticket, TicketHash},
@@ -27,30 +27,31 @@ use crate::{
 
 const WITHDRAW_ENTRYPOINT: &str = "withdraw";
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema, Encode, Decode)]
 pub struct FaWithdraw {
     pub amount: Amount,
     pub routing_info: RoutingInfo,
     pub ticket_info: TicketInfo,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema, Encode, Decode)]
 pub struct RoutingInfo {
     pub receiver: Address,
-    pub proxy_l1_contract: ContractKt1Hash,
+    pub proxy_l1_contract: SmartFunctionHash,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema, Encode, Decode)]
 pub struct TicketInfo {
     pub id: u32,
     pub content: Option<Vec<u8>>,
-    pub ticketer: ContractKt1Hash,
+    #[bincode(with_serde)]
+    pub ticketer: SmartFunctionHash,
 }
 
 impl TicketInfo {
     pub(super) fn to_ticket(&self, amount: Amount) -> Result<Ticket> {
         FA2_1Ticket::new(
-            Contract::Originated(self.ticketer.clone()),
+            Contract::Originated(self.ticketer.0.clone()),
             MichelsonPair(
                 self.id.into(),
                 MichelsonOption(self.content.clone().map(MichelsonBytes)),
@@ -80,12 +81,11 @@ impl TryFrom<FA2_1Ticket> for Ticket {
     }
 }
 
-type OutboxMessageId = String;
-
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema, Encode, Decode)]
 pub struct FaWithdrawReceipt {
     pub source: Address,
-    pub outbox_message_id: OutboxMessageId,
+    #[serde(flatten)]
+    pub withdrawal: FaWithdraw,
 }
 
 impl FaWithdrawReceipt {
@@ -105,7 +105,7 @@ fn create_fa_withdrawal_message(
     ticket: FA2_1Ticket,
 ) -> Result<OutboxMessage> {
     let receiver_pkh = routing_info.receiver.to_base58();
-    let destination = Contract::Originated(routing_info.proxy_l1_contract.clone());
+    let destination = Contract::Originated(routing_info.proxy_l1_contract.0.clone());
     let message = OutboxMessage::new_withdrawal_message(
         &Contract::try_from(receiver_pkh).unwrap(),
         &destination,
@@ -125,13 +125,13 @@ fn withdraw_from_ticket_owner(
     routing_info: &RoutingInfo,
     amount: Amount,
     ticket: Ticket,
-) -> Result<OutboxMessageId> {
+) -> Result<()> {
     TicketTable::sub(rt, tx, ticket_owner, &ticket.hash, amount)?;
     let message = create_fa_withdrawal_message(routing_info, ticket.value)?;
     tx.queue_outbox_message(rt, message)?;
     // TODO: https://linear.app/tezos/issue/JSTZ-113/implement-outbox-message-id
     // Implement outbox message id
-    Ok("".to_string())
+    Ok(())
 }
 
 impl FaWithdraw {
@@ -156,13 +156,12 @@ impl FaWithdraw {
             amount,
             routing_info,
             ticket_info,
-        } = self;
-        let ticket = ticket_info.to_ticket(amount)?;
-        let outbox_message_id =
-            withdraw_from_ticket_owner(rt, tx, source, &routing_info, amount, ticket)?;
+        } = &self;
+        let ticket = ticket_info.to_ticket(*amount)?;
+        withdraw_from_ticket_owner(rt, tx, source, routing_info, *amount, ticket)?;
         Ok(FaWithdrawReceipt {
             source: source.clone().into(),
-            outbox_message_id,
+            withdrawal: self,
         })
     }
 
@@ -206,11 +205,11 @@ mod test {
         let ticket_info = TicketInfo {
             id: 1234,
             content: Some(b"random ticket content".to_vec()),
-            ticketer: jstz_mock::kt1_account1(),
+            ticketer: jstz_mock::kt1_account1().into(),
         };
         let routing_info = RoutingInfo {
             receiver: Address::User(jstz_mock::account2()),
-            proxy_l1_contract: jstz_mock::kt1_account1(),
+            proxy_l1_contract: jstz_mock::kt1_account1().into(),
         };
         FaWithdraw {
             amount: 10,
@@ -243,13 +242,14 @@ mod test {
 
         tx.begin();
         let fa_withdrawal_receipt_content = fa_withdrawal
+            .clone()
             .execute(&mut rt, &mut tx, &source, 100)
             .expect("Should succeed");
         tx.commit(&mut rt).unwrap();
         assert_eq!(
             FaWithdrawReceipt {
                 source,
-                outbox_message_id: "".to_string() // outbox message not implemented yet
+                withdrawal: fa_withdrawal
             },
             fa_withdrawal_receipt_content,
         );
@@ -275,7 +275,7 @@ mod test {
                     vec![OutboxMessageTransaction {
                         parameters,
                         destination: Contract::Originated(
-                            routing_info.clone().proxy_l1_contract
+                            routing_info.clone().proxy_l1_contract.0
                         ),
                         entrypoint: Entrypoint::try_from(WITHDRAW_ENTRYPOINT.to_string())
                             .unwrap(),
@@ -322,11 +322,11 @@ mod test {
         let ticket_info = TicketInfo {
             id: 1234,
             content: Some(b"random ticket content".to_vec()),
-            ticketer: jstz_mock::kt1_account1(),
+            ticketer: jstz_mock::kt1_account1().into(),
         };
         let routing_info = RoutingInfo {
             receiver: Address::User(jstz_mock::account2()),
-            proxy_l1_contract: jstz_mock::kt1_account1(),
+            proxy_l1_contract: jstz_mock::kt1_account1().into(),
         };
         let fa_withdrawal = FaWithdraw {
             amount: 0,

--- a/crates/jstz_proto/src/executor/fa_withdraw.rs
+++ b/crates/jstz_proto/src/executor/fa_withdraw.rs
@@ -5,7 +5,7 @@ use jstz_core::{
     host::HostRuntime,
     kv::{outbox::OutboxMessage, Transaction},
 };
-use jstz_crypto::smart_function_hash::SmartFunctionHash;
+use jstz_crypto::smart_function_hash::Kt1Hash;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tezos_smart_rollup::{
@@ -37,7 +37,7 @@ pub struct FaWithdraw {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema, Encode, Decode)]
 pub struct RoutingInfo {
     pub receiver: Address,
-    pub proxy_l1_contract: SmartFunctionHash,
+    pub proxy_l1_contract: Kt1Hash,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema, Encode, Decode)]
@@ -45,7 +45,7 @@ pub struct TicketInfo {
     pub id: u32,
     pub content: Option<Vec<u8>>,
     #[bincode(with_serde)]
-    pub ticketer: SmartFunctionHash,
+    pub ticketer: Kt1Hash,
 }
 
 impl TicketInfo {

--- a/crates/jstz_proto/src/executor/smart_function.rs
+++ b/crates/jstz_proto/src/executor/smart_function.rs
@@ -1309,11 +1309,11 @@ pub mod jstz_run {
             let ticket_info = TicketInfo {
                 id: 1234,
                 content: Some(b"random ticket content".to_vec()),
-                ticketer: jstz_mock::kt1_account1(),
+                ticketer: jstz_mock::kt1_account1().into(),
             };
             let routing_info = RoutingInfo {
                 receiver: Address::User(jstz_mock::account2()),
-                proxy_l1_contract: jstz_mock::kt1_account1(),
+                proxy_l1_contract: jstz_mock::kt1_account1().into(),
             };
             let fa_withdrawal = FaWithdraw {
                 amount: 10,
@@ -1522,7 +1522,7 @@ pub mod jstz_run {
             let ticket = TicketInfo {
                 id: 1234,
                 content: Some(b"random ticket content".to_vec()),
-                ticketer: jstz_mock::kt1_account1(),
+                ticketer: jstz_mock::kt1_account1().into(),
             }
             .to_ticket(1)
             .unwrap();

--- a/crates/jstzd/build.rs
+++ b/crates/jstzd/build.rs
@@ -123,7 +123,9 @@ fn make_kernel_installer(kernel_file: &Path, preimages_dir: &Path) -> Result<Str
         // 2. Set `jstz` ticketer as the bridge contract address
         OwnedConfigInstruction::set_instr(
             OwnedBytes(bincode::encode_to_vec(
-                SmartFunctionHash(ContractKt1Hash::from_base58_check(EXCHANGER_ADDRESS)?),
+                SmartFunctionHash(
+                    ContractKt1Hash::from_base58_check(EXCHANGER_ADDRESS)?.into(),
+                ),
                 bincode::config::legacy(),
             )?),
             OwnedPath::from(TICKETER),


### PR DESCRIPTION
# Context
Removes outbox message ID to avoid confusion among end users. 

Outbox message id field was intended to be used by users to track their bridge withdrawal. However, completing this feature requires a  lot more work that we cannot prioritize right now. So instead of allowing this to linger, we remove it and set the withdrawal request fields as part of its receipt.

Closes: [JSTZ-489](https://linear.app/tezos/issue/JSTZ-489/remove-outbox-message-id-temporarily)
<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
* Remove outbox message id
* Add Fa withdraw request fields into the receipt
* Regenerate the new open api doc
* ticketer and proxy l1 contract were converted into smart function hash because it needs encoding and openapi derivations. This change should be safe since Jstz uses the same hashing scheme for contracts
* Added newtype `Kt1Hash` over `ContractKt1Hash` and make `SmartFunctionHash` wrap `Kt1Hash` instead. This allows open api to be generated with `Kt1Hash` schema instead, avoiding confusion.
<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
Current tests passes
<!-- Describe how reviewers and approvers can test this PR. -->
