### PR TITLE
ci: set up nightly tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,56 +46,6 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-  benchmark:
-    name: Benchmark
-    runs-on: [x86_64, linux, nix]
-    needs: [build]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run benchmark
-        id: bench_head
-        run: |
-          result=$(nix --accept-flake-config --log-format raw -L run .#tps_bench)
-          echo "result=$result" >> $GITHUB_OUTPUT || true
-      - uses: actions/checkout@v4
-        if: github.event_name == 'pull_request'
-        with:
-          ref: ${{ github.event.pull_request.base.ref }}
-      - name: Run benchmark with base
-        id: bench_base
-        if: github.event_name == 'pull_request'
-        run: |
-          echo "result=$(nix --accept-flake-config --log-format raw -L run .#tps_bench)" >> $GITHUB_OUTPUT || true
-      - name: Display result
-        run: |
-          echo "Current branch: ${{ steps.bench_head.outputs.result }}"
-          if [ -n "${{ steps.bench_base.outputs.result }}" ]; then
-            echo "Base branch (${{ github.event.pull_request.base.ref }}): ${{ steps.bench_base.outputs.result }}"
-          fi
-
-  wpt:
-    name: Web Platform Test
-    runs-on: ubuntu-latest
-    container:
-      image: rust:1.82-slim
-    steps:
-      - name: Setup
-        run: apt update && apt install -y git curl python3.11 pkg-config libssl-dev
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Run
-        run: |
-          ln -s /usr/bin/python3.11 /usr/bin/python3
-          cd crates/jstz_wpt/wpt && python3 wpt make-hosts-file >> /etc/hosts
-          python3 wpt serve &
-          cd ../../jstz_runtime
-          curl -s --output tests/deno_report.json https://storage.googleapis.com/wptd-results/e78446e34a1921371658a5df08c71d83f50a2a2f/deno-2.1.10_4921411-linux-unknown-fccd901f99/report.json
-          STATS_PATH=$(pwd)/out.txt cargo test --test wpt
-          while read line; do
-            echo "$line" >> $GITHUB_STEP_SUMMARY
-          done < $(pwd)/out.txt
-
   build-docs:
     name: Build Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -1,0 +1,44 @@
+name: Run nightly long-running tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 4 * * *" # Runs at 4:30 am daily
+
+jobs:
+  wpt:
+    name: Web Platform Test
+    runs-on: ubuntu-latest
+    container:
+      image: rust:1.82-slim
+    steps:
+      - name: Setup
+        run: apt update && apt install -y git curl python3.11 pkg-config libssl-dev
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Run
+        run: |
+          ln -s /usr/bin/python3.11 /usr/bin/python3
+          cd crates/jstz_wpt/wpt && python3 wpt make-hosts-file >> /etc/hosts
+          python3 wpt serve &
+          cd ../../jstz_runtime
+          curl -s --output tests/deno_report.json https://storage.googleapis.com/wptd-results/e78446e34a1921371658a5df08c71d83f50a2a2f/deno-2.1.10_4921411-linux-unknown-fccd901f99/report.json
+          STATS_PATH=$(pwd)/out.txt cargo test --test wpt
+          while read line; do
+            echo "$line" >> $GITHUB_STEP_SUMMARY
+          done < $(pwd)/out.txt
+
+  benchmark:
+    name: Benchmark
+    runs-on: [x86_64, linux, nix]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run benchmark
+        id: bench
+        run: |
+          result=$(nix --accept-flake-config --log-format raw -L run .#tps_bench)
+          echo "result=$result" >> $GITHUB_OUTPUT || true
+      - name: Display result
+        run: |
+          echo "Result for commit $GITHUB_SHA: ${{ steps.bench.outputs.result }}"


### PR DESCRIPTION
# Context

WPT and benchmark are two jobs that are part of CI now. They take quite a bit of time, especially WPT because its results are not cached.

# Description

Create a new workflow that runs WPT and benchmark nightly instead of for every PR push. The original discussion was only about moving WPT, but I think it makes sense to move benchmark as well.

The new workflow will also be able to be triggered manually.

# Manually testing the PR

N/A
