### PR TITLE
fix(examples): use jstz sdk from npm instead of local

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "@jstz-dev/dashboard": "^0.0.0",
         "@jstz-dev/jstz": "^0.0.0",
         "@jstz-dev/sdk": "^0.0.0",
-        "@jstz-dev/types": "^0.0.0"
+        "@jstz-dev/types": "^0.0.0",
+        "jstz_sdk": "^0.1.0-alpha.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.2.1",
@@ -28,10 +29,6 @@
         "typescript": "^5.4.2",
         "vitepress": "^1.0.0-rc.45"
       }
-    },
-    "crates/jstz_sdk/pkg": {
-      "name": "jstz_sdk",
-      "version": "0.1.0-alpha.0"
     },
     "examples/dashboard": {
       "name": "@jstz-dev/dashboard",
@@ -4378,8 +4375,9 @@
       }
     },
     "node_modules/jstz_sdk": {
-      "resolved": "crates/jstz_sdk/pkg",
-      "link": true
+      "version": "0.1.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/jstz_sdk/-/jstz_sdk-0.1.0-alpha.0.tgz",
+      "integrity": "sha512-xBax5a2HBN/b78QxU60HwyLI2u50nCylop8Pj6MIXGjpNWfnofGooRp5VFsEuZNnQHMh5ERlrpYeFmPiLIod2w=="
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -6344,7 +6342,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@zcabter/jstz-client": "0.1.0-alpha",
-        "jstz_sdk": "file:../../crates/jstz_sdk/pkg"
+        "jstz_sdk": "0.1.0-alpha.0"
       }
     },
     "packages/types": {
@@ -7349,7 +7347,7 @@
       "version": "file:packages/sdk",
       "requires": {
         "@zcabter/jstz-client": "0.1.0-alpha",
-        "jstz_sdk": "file:../../crates/jstz_sdk/pkg"
+        "jstz_sdk": "0.1.0-alpha.0"
       }
     },
     "@jstz-dev/types": {
@@ -9326,7 +9324,9 @@
       }
     },
     "jstz_sdk": {
-      "version": "file:crates/jstz_sdk/pkg"
+      "version": "0.1.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/jstz_sdk/-/jstz_sdk-0.1.0-alpha.0.tgz",
+      "integrity": "sha512-xBax5a2HBN/b78QxU60HwyLI2u50nCylop8Pj6MIXGjpNWfnofGooRp5VFsEuZNnQHMh5ERlrpYeFmPiLIod2w=="
     },
     "keyv": {
       "version": "4.5.4",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,11 @@
     "docs:preview": "vitepress preview docs"
   },
   "dependencies": {
+    "@jstz-dev/dashboard": "^0.0.0",
     "@jstz-dev/jstz": "^0.0.0",
-    "@jstz-dev/types": "^0.0.0",
     "@jstz-dev/sdk": "^0.0.0",
-    "@jstz-dev/dashboard": "^0.0.0"
+    "@jstz-dev/types": "^0.0.0",
+    "jstz_sdk": "^0.1.0-alpha.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.2.1",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -10,6 +10,6 @@
   },
   "dependencies": {
     "@zcabter/jstz-client": "0.1.0-alpha",
-    "jstz_sdk": "file:../../crates/jstz_sdk/pkg"
+    "jstz_sdk": "0.1.0-alpha.0"
   }
 }


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->
Ensures the dashboard example does not break when main changes.


<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
Updates `jstz_sdk` dependency in `examples/dashboard` to be pulled from npm registry
<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->
