### PR TITLE
feat(crypto): get key pairs from secret keys

### DIFF
--- a/crates/jstz_cli/src/account.rs
+++ b/crates/jstz_cli/src/account.rs
@@ -24,7 +24,7 @@ fn generate_mnemonic() -> String {
 
 impl User {
     pub fn from_mnemonic(mnemonic: String, passphrase: String) -> Result<Self> {
-        let (sk, pk) = keypair_from_mnemonic(&mnemonic, &passphrase)?;
+        let (pk, sk) = keypair_from_mnemonic(&mnemonic, &passphrase)?;
 
         let address = PublicKeyHash::from(&pk);
 

--- a/crates/jstz_tps_bench/src/bench/generate.rs
+++ b/crates/jstz_tps_bench/src/bench/generate.rs
@@ -259,7 +259,7 @@ fn gen_keys(num: usize) -> Result<Vec<Account>> {
         let mnemonic = Mnemonic::generate_in(Language::English, 12)
             .expect("generate_in should generate mnemonics")
             .to_string();
-        let (sk, pk) = keypair_from_mnemonic(&mnemonic, "")?;
+        let (pk, sk) = keypair_from_mnemonic(&mnemonic, "")?;
         let account = Account {
             address: Address::from_base58(&pk.hash())?,
             sk,


### PR DESCRIPTION
# Context

Part of JSTZ-485.
[JSTZ-485](https://linear.app/tezos/issue/JSTZ-485/import-jstz-accounts-with-secret-keys-in-cli)

# Description

Get key pairs from secret key strings. Essentially,
```
"edsk..." --> (PublicKey, SecretKey)
```

# Manually testing the PR

Added one unit test.
