### PR TITLE
refactor(proto): rm `Script::deploy`, replace with `smart_function::deploy`

### DIFF
--- a/crates/jstz_kernel/src/lib.rs
+++ b/crates/jstz_kernel/src/lib.rs
@@ -79,10 +79,12 @@ mod test {
         host::{JstzMockHost, MOCK_SOURCE},
         message::{fa_deposit::MockFaDeposit, native_deposit::MockNativeDeposit},
     };
-    use jstz_proto::context::{
-        account::Address,
-        account::{Account, ParsedCode},
-        ticket_table::TicketTable,
+    use jstz_proto::{
+        context::{
+            account::{Account, Address, ParsedCode},
+            ticket_table::TicketTable,
+        },
+        executor::smart_function,
     };
     use tezos_smart_rollup::types::{Contract, PublicKeyHash};
 
@@ -134,14 +136,8 @@ mod test {
                 .unwrap(),
         );
         Account::set_balance(host.rt(), tx, &addr, 200).unwrap();
-        let proxy = crate::executor::smart_function::Script::deploy(
-            host.rt(),
-            tx,
-            &addr,
-            parsed_code,
-            100,
-        )
-        .unwrap();
+        let proxy =
+            smart_function::deploy(host.rt(), tx, &addr, parsed_code, 100).unwrap();
         tx.commit(host.rt()).unwrap();
 
         let deposit = MockFaDeposit {

--- a/crates/jstz_proto/src/executor/fa_deposit.rs
+++ b/crates/jstz_proto/src/executor/fa_deposit.rs
@@ -175,8 +175,14 @@ mod test {
     use tezos_smart_rollup_mock::MockHost;
 
     use crate::{
-        context::{account::Address, account::ParsedCode, ticket_table::TicketTable},
-        executor::fa_deposit::{FaDeposit, FaDepositReceipt},
+        context::{
+            account::{Address, ParsedCode},
+            ticket_table::TicketTable,
+        },
+        executor::{
+            fa_deposit::{FaDeposit, FaDepositReceipt},
+            smart_function,
+        },
         receipt::{Receipt, ReceiptContent, ReceiptResult},
     };
 
@@ -282,14 +288,8 @@ mod test {
         "#;
         let parsed_code = ParsedCode::try_from(code.to_string()).unwrap();
         tx.begin();
-        let proxy = crate::executor::smart_function::Script::deploy(
-            &mut host,
-            &mut tx,
-            &source,
-            parsed_code,
-            0,
-        )
-        .unwrap();
+        let proxy =
+            smart_function::deploy(&mut host, &mut tx, &source, parsed_code, 0).unwrap();
 
         let fa_deposit = mock_fa_deposit(Some(proxy.clone()));
         let ticket_hash = fa_deposit.ticket_hash.clone();
@@ -336,14 +336,8 @@ mod test {
         "#;
         let parsed_code = ParsedCode::try_from(code.to_string()).unwrap();
         tx.begin();
-        let proxy = crate::executor::smart_function::Script::deploy(
-            &mut host,
-            &mut tx,
-            &source,
-            parsed_code,
-            0,
-        )
-        .unwrap();
+        let proxy =
+            smart_function::deploy(&mut host, &mut tx, &source, parsed_code, 0).unwrap();
 
         let fa_deposit1 = mock_fa_deposit(Some(proxy.clone()));
         let ticket_hash = fa_deposit1.ticket_hash.clone();
@@ -391,14 +385,8 @@ mod test {
         }
         "#;
         let parsed_code = ParsedCode::try_from(code.to_string()).unwrap();
-        let proxy = crate::executor::smart_function::Script::deploy(
-            &mut host,
-            &mut tx,
-            &source,
-            parsed_code,
-            0,
-        )
-        .unwrap();
+        let proxy =
+            smart_function::deploy(&mut host, &mut tx, &source, parsed_code, 0).unwrap();
 
         let fa_deposit = mock_fa_deposit(Some(proxy.clone()));
         let expected_receiver = fa_deposit.receiver.clone();

--- a/crates/jstz_proto/src/executor/smart_function.rs
+++ b/crates/jstz_proto/src/executor/smart_function.rs
@@ -660,6 +660,7 @@ pub mod run {
 
         use crate::{
             context::account::{Account, Address, ParsedCode},
+            executor::smart_function,
             operation::RunFunction,
         };
 
@@ -696,7 +697,7 @@ pub mod run {
             let parsed_code = ParsedCode::try_from(code.to_string()).unwrap();
             tx.begin();
             let smart_function =
-                Script::deploy(host, &mut tx, &source, parsed_code, 0).unwrap();
+                smart_function::deploy(host, &mut tx, &source, parsed_code, 0).unwrap();
 
             let balance_before =
                 Account::balance(host, &mut tx, &smart_function).unwrap();
@@ -822,7 +823,7 @@ pub mod run {
             let parsed_code = ParsedCode::try_from(code.to_string()).unwrap();
             tx.begin();
             let smart_function =
-                Script::deploy(host, &mut tx, &source, parsed_code, 0).unwrap();
+                smart_function::deploy(host, &mut tx, &source, parsed_code, 0).unwrap();
 
             let balance_before =
                 Account::balance(host, &mut tx, &smart_function).unwrap();
@@ -936,7 +937,7 @@ pub mod run {
             let parsed_code = ParsedCode::try_from(code.to_string()).unwrap();
             tx.begin();
             let smart_function =
-                Script::deploy(host, &mut tx, &source, parsed_code, 0).unwrap();
+                smart_function::deploy(host, &mut tx, &source, parsed_code, 0).unwrap();
 
             tx.commit(host).unwrap();
 
@@ -1006,9 +1007,14 @@ pub mod run {
             // 1. Deploy smart function
             let parsed_code = ParsedCode::try_from(code.to_string()).unwrap();
             tx.begin();
-            let smart_function =
-                Script::deploy(host, &mut tx, &source, parsed_code, initial_balance)
-                    .unwrap();
+            let smart_function = smart_function::deploy(
+                host,
+                &mut tx,
+                &source,
+                parsed_code,
+                initial_balance,
+            )
+            .unwrap();
 
             let sf_balance_before =
                 Account::balance(host, &mut tx, &smart_function).unwrap();
@@ -1094,7 +1100,7 @@ pub mod run {
             let parsed_code = ParsedCode::try_from(code.to_string()).unwrap();
             tx.begin();
             let smart_function =
-                Script::deploy(host, &mut tx, &source, parsed_code, 0).unwrap();
+                smart_function::deploy(host, &mut tx, &source, parsed_code, 0).unwrap();
 
             tx.commit(host).unwrap();
 


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

`Script` is a runtime specific concept. Yet the `deploy` function doesn't rely on any runtime specific functions. 

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

This PR simply splits `deploy` from `Script` (and removes some redundant logic from `SmartFunction.create`)

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

Exiting tests should cover this refactor