### PR TITLE
refactor(proto): merge logic between `SmartFunction::call` and `smart_function::run::execute`

### DIFF
--- a/crates/jstz_cli/src/repl/debug_api/account.rs
+++ b/crates/jstz_cli/src/repl/debug_api/account.rs
@@ -70,7 +70,7 @@ impl AccountApi {
         let address = try_parse_smart_function_address(account.as_str())?;
 
         runtime::with_js_hrt_and_tx(|hrt, tx| -> JsResult<JsValue> {
-            match Account::function_code(hrt.deref(), tx, &address)? {
+            match Account::function_code(hrt.deref(), tx, &address)?.as_str() {
                 "" => Ok(JsValue::null()),
                 value => Ok(JsValue::String(value.to_string().into())),
             }

--- a/crates/jstz_node/src/services/operations.rs
+++ b/crates/jstz_node/src/services/operations.rs
@@ -260,8 +260,9 @@ mod tests {
         SignedOperation::new(sig, deploy_op)
     }
 
-    fn mock_code(size: usize) -> String {
-        "a".repeat(size)
+    fn mock_code(size: usize) -> ParsedCode {
+        // SAFETY: This code is never interpreted (so does not need to be parsable)
+        unsafe { ParsedCode::new_unchecked("a".repeat(size)) }
     }
 
     fn get_dir_size(path: &Path) -> u64 {
@@ -287,7 +288,7 @@ mod tests {
         let code = mock_code(1);
         let operation = make_signed_op(Content::DeployFunction(DeployFunction {
             account_credit: Amount::default(),
-            function_code: ParsedCode::try_from(code).unwrap(),
+            function_code: code,
         }));
         let key_pair = KeyPair(pk, sk);
         let temp_dir = tempfile::tempdir().unwrap();
@@ -316,7 +317,7 @@ mod tests {
         let code_size: u64 = code.len() as u64;
         let operation = make_signed_op(Content::DeployFunction(DeployFunction {
             account_credit: Amount::default(),
-            function_code: ParsedCode::try_from(code).unwrap(),
+            function_code: code,
         }));
         let key_pair = KeyPair(pk, sk);
         let result =
@@ -336,7 +337,7 @@ mod tests {
         let code = mock_code(MAX_REVEAL_SIZE + 1);
         let operation = make_signed_op(Content::DeployFunction(DeployFunction {
             account_credit: Amount::default(),
-            function_code: ParsedCode::try_from(code).unwrap(),
+            function_code: code,
         }));
         let key_pair = KeyPair(pk, sk);
         let temp_dir = tempfile::tempdir().unwrap();
@@ -363,7 +364,7 @@ mod tests {
         let code = mock_code(MAX_DIRECT_OPERATION_SIZE);
         let operation = make_signed_op(Content::DeployFunction(DeployFunction {
             account_credit: Amount::default(),
-            function_code: ParsedCode::try_from(code).unwrap(),
+            function_code: code,
         }));
         let key_pair = KeyPair(pk, sk);
         let result =

--- a/crates/jstz_node/src/services/operations.rs
+++ b/crates/jstz_node/src/services/operations.rs
@@ -287,7 +287,7 @@ mod tests {
         let code = mock_code(1);
         let operation = make_signed_op(Content::DeployFunction(DeployFunction {
             account_credit: Amount::default(),
-            function_code: ParsedCode(code),
+            function_code: ParsedCode::try_from(code).unwrap(),
         }));
         let key_pair = KeyPair(pk, sk);
         let temp_dir = tempfile::tempdir().unwrap();
@@ -316,7 +316,7 @@ mod tests {
         let code_size: u64 = code.len() as u64;
         let operation = make_signed_op(Content::DeployFunction(DeployFunction {
             account_credit: Amount::default(),
-            function_code: ParsedCode(code),
+            function_code: ParsedCode::try_from(code).unwrap(),
         }));
         let key_pair = KeyPair(pk, sk);
         let result =
@@ -336,7 +336,7 @@ mod tests {
         let code = mock_code(MAX_REVEAL_SIZE + 1);
         let operation = make_signed_op(Content::DeployFunction(DeployFunction {
             account_credit: Amount::default(),
-            function_code: ParsedCode(code),
+            function_code: ParsedCode::try_from(code).unwrap(),
         }));
         let key_pair = KeyPair(pk, sk);
         let temp_dir = tempfile::tempdir().unwrap();
@@ -363,7 +363,7 @@ mod tests {
         let code = mock_code(MAX_DIRECT_OPERATION_SIZE);
         let operation = make_signed_op(Content::DeployFunction(DeployFunction {
             account_credit: Amount::default(),
-            function_code: ParsedCode(code),
+            function_code: ParsedCode::try_from(code).unwrap(),
         }));
         let key_pair = KeyPair(pk, sk);
         let result =

--- a/crates/jstz_proto/src/api/smart_function.rs
+++ b/crates/jstz_proto/src/api/smart_function.rs
@@ -1247,9 +1247,13 @@ mod test {
         .unwrap();
         let request = JsNativeObject::new::<RequestClass>(request, context).unwrap();
         let operation_hash = OperationHash::from(b"abcdefghijslmnop".as_slice());
-        let js_error =
+        let mut host = MockHost::default();
+        let mut tx = Transaction::default();
+        tx.begin();
+        let js_error = runtime::enter_js_host_context(&mut host, &mut tx, || {
             SmartFunction::call(&self_address, &request, operation_hash, context)
-                .unwrap_err();
+                .unwrap_err()
+        });
         assert_eq!("EvalError: InvalidScheme", js_error.to_string())
     }
 }

--- a/crates/jstz_proto/src/context/account.rs
+++ b/crates/jstz_proto/src/context/account.rs
@@ -73,6 +73,17 @@ impl Display for Nonce {
 )]
 pub struct ParsedCode(String);
 
+impl ParsedCode {
+    /// Creates a new `ParsedCode`.
+    ///
+    /// # Safety
+    ///
+    /// `code` must be well-formed JavaScript code
+    pub unsafe fn new_unchecked(code: String) -> Self {
+        Self(code)
+    }
+}
+
 impl From<ParsedCode> for String {
     fn from(ParsedCode(code): ParsedCode) -> Self {
         code

--- a/crates/jstz_proto/src/context/account.rs
+++ b/crates/jstz_proto/src/context/account.rs
@@ -8,6 +8,7 @@ use crate::error::{Error, Result};
 use bincode::{Decode, Encode};
 use boa_engine::{Context, JsError, JsResult, Module, Source};
 use boa_gc::{empty_trace, Finalize, Trace};
+use derive_more::Deref;
 use jstz_core::{
     host::HostRuntime,
     kv::{Entry, Transaction},
@@ -54,23 +55,36 @@ impl Display for Nonce {
 
 // Invariant: if code is present it parses successfully
 #[derive(
-    Default, PartialEq, Eq, Debug, Clone, Serialize, Deserialize, ToSchema, Encode, Decode,
+    Default,
+    PartialEq,
+    Eq,
+    Debug,
+    Clone,
+    Serialize,
+    Deserialize,
+    ToSchema,
+    Encode,
+    Decode,
+    Deref,
 )]
 #[schema(
     format = "javascript",
     example = "export default (request) => new Response('Hello world!')"
 )]
-pub struct ParsedCode(pub String);
+pub struct ParsedCode(String);
+
 impl From<ParsedCode> for String {
     fn from(ParsedCode(code): ParsedCode) -> Self {
         code
     }
 }
+
 impl Display for ParsedCode {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> result::Result<(), fmt::Error> {
         Display::fmt(&self.0, formatter)
     }
 }
+
 impl TryFrom<String> for ParsedCode {
     type Error = JsError;
     fn try_from(code: String) -> JsResult<Self> {
@@ -321,11 +335,11 @@ impl Account {
         hrt: &impl HostRuntime,
         tx: &'a mut Transaction,
         addr: &SmartFunctionHash,
-    ) -> Result<&'a str> {
+    ) -> Result<&'a ParsedCode> {
         let account = Self::get_mut(hrt, tx, addr)?;
         match account {
             Self::SmartFunction(SmartFunctionAccount { function_code, .. }) => {
-                Ok(&function_code.0)
+                Ok(function_code)
             }
             Self::User(_) => Err(Error::AddressTypeMismatch),
         }
@@ -780,7 +794,7 @@ mod test {
 
             // Test empty initial code
             let code = Account::function_code(&host, &mut tx, sf_hash).unwrap();
-            assert_eq!(code, "");
+            assert_eq!(code.as_str(), "");
 
             // Test empty function code
             assert!(
@@ -798,7 +812,7 @@ mod test {
             )
             .is_ok());
             let updated_code = Account::function_code(&host, &mut tx, sf_hash).unwrap();
-            assert_eq!(updated_code, valid_code);
+            assert_eq!(updated_code.as_str(), valid_code.as_str());
 
             let account = Account::get_mut(&host, &mut tx, &user_addr).unwrap();
             assert!(matches!(account, Account::User(_)));

--- a/crates/jstz_proto/src/executor/smart_function.rs
+++ b/crates/jstz_proto/src/executor/smart_function.rs
@@ -755,18 +755,15 @@ pub mod run {
             );
 
             // 4. transferring to the smart function should fail (source has insufficient funds)
-            let error = execute(
+            let result = execute(
                 host,
                 &mut tx,
                 &source,
                 run_function.clone(),
                 fake_op_hash.clone(),
             )
-            .expect_err("Expected error");
-            assert_eq!(
-                error.to_string(),
-                "EvalError: Transfer failed: InsufficientFunds"
-            );
+            .unwrap();
+            assert!(result.status_code.is_server_error());
 
             // 5. transferring from the smart function should fail with insufficient funds and the balance is rolled back
             let balance_before = Account::balance(host, &mut tx, &source).unwrap();
@@ -777,7 +774,7 @@ pub mod run {
                 X_JSTZ_TRANSFER,
                 transfer_amount.to_string().try_into().unwrap(),
             );
-            let error = execute(
+            let result = execute(
                 host,
                 &mut tx,
                 &source,
@@ -787,13 +784,11 @@ pub mod run {
                 },
                 fake_op_hash.clone(),
             )
-            .expect_err("Expected error");
-            let balance_after = Account::balance(host, &mut tx, &source).unwrap();
-            assert_eq!(
-                error.to_string(),
-                "EvalError: Transfer failed: InsufficientFunds"
-            );
+            .unwrap();
+            assert!(result.status_code.is_server_error());
+
             // tx rolled back as smart function has insufficient funds
+            let balance_after = Account::balance(host, &mut tx, &source).unwrap();
             assert_eq!(balance_after, balance_before);
         }
 
@@ -909,12 +904,9 @@ pub mod run {
 
             // 3. transferring again should fail
             let fake_op_hash2 = Blake2b::from(b"fake_op_hash2".as_ref());
-            let error = execute(host, &mut tx, &source, run_function, fake_op_hash2)
-                .expect_err("Expected error");
-            assert_eq!(
-                error.to_string(),
-                "EvalError: Transfer failed: InsufficientFunds"
-            );
+            let result =
+                execute(host, &mut tx, &source, run_function, fake_op_hash2).unwrap();
+            assert!(result.status_code.is_server_error());
         }
 
         #[test]


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

This PR merges the logic between `SmartFunction::call` and `smart_function::run::execute` (in theory they should do the same thing anyway). 

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
 **Dependencies**: #948 

This PR is split into two commits. 

The first commit handles the merging of the logic between `SmartFunction::call` and `smart_function::run::execute`. In some places, I discovered inconsistencies around how transfers were handled. This was discussed offline and the conclusion was that if a transfer fails, then it should revert the callee's transaction and return `Response.error()`. 

The second commit updates all the tests affected by the change of semantics in transfers. 

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

```
cargo nextest run -p jstz_proto
```