### PR TITLE
feat(docs): building and deploying topics

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -39,6 +39,8 @@ export default defineConfig({
         text: "Smart functions",
         items: [
           { text: "Overview", link: "/functions/overview" },
+          { text: "Building", link: "/functions/building" },
+          { text: "Deploying", link: "/functions/deploying" },
           { text: "Handling requests", link: "/functions/requests" },
           { text: "Storing data", link: "/functions/data_storage" },
           { text: "Calling other smart functions", link: "/functions/calling" },

--- a/docs/functions/building.md
+++ b/docs/functions/building.md
@@ -1,0 +1,65 @@
+# Building smart functions
+
+Smart functions are written and run in ordinary TypeScript, but you must still build them with the Jstz dependencies before deploying them.
+
+For examples of smart function projects, see the examples folder: https://github.com/jstz-dev/jstz/tree/main/examples.
+
+Follow these steps to create and build a TypeScript project for your smart function:
+
+1. Create a `package.json` file appropriate for a TypeScript project.
+   You can use the `npm init` command, the `yarn init` command, or create a `package.json` file manually to describe the project.
+
+1. Add the `@jstz-dev/jstz` dependency and `esbuild` build dependencies.
+
+1. Add a build script that looks like this, with the name of your smart function source file in place of the variable `<SOURCE_FILE>`:
+
+   ```bash
+   esbuild <SOURCE_FILE> --bundle --format=esm --target=esnext --minify --outfile=dist/index.js
+   ```
+
+   Here is an example of a `package.json` file for a smart function project:
+
+   ```json
+   {
+     "name": "my-smart-function",
+     "authors": "",
+     "version": "0.0.0",
+     "main": "index.ts",
+     "dependencies": {
+       "@jstz-dev/jstz": "^0.0.0"
+     },
+     "devDependencies": {
+       "esbuild": "^0.20.2"
+     },
+     "scripts": {
+       "build": "esbuild index.ts --bundle --format=esm --target=esnext --minify --outfile=dist/index.js"
+     }
+   }
+   ```
+
+1. Add a `tsconfig.json` file to specify how TypeScript builds the file, including accessing types for Jstz code, as in this example:
+
+   ```json
+   {
+     "compilerOptions": {
+       "lib": ["esnext"],
+       "module": "esnext",
+       "target": "esnext",
+       "strict": true,
+       "moduleResolution": "node",
+       "types": ["@jstz-dev/types"]
+     },
+     "exclude": ["node_modules"]
+   }
+   ```
+
+1. Install the dependencies by running `npm install` or `yarn install`.
+
+1. Add the code of your smart function to a TypeScript file in the project and make sure that the `build` script builds it.
+   For example, you can use the example smart function in [Smart functions](/functions/overview) or any of the smart functions in the [examples folder](https://github.com/jstz-dev/jstz/tree/main/examples).
+
+1. Build the smart function with the `build` script, either by running `npm run build` or `yarn build`.
+   Jstz builds the smart function with the necessary dependencies and writes the output to `dist/index.ts`.
+
+Now you can deploy the smart function to the local sandbox.
+See [Deploying](/functions/deploying).

--- a/docs/functions/deploying.md
+++ b/docs/functions/deploying.md
@@ -1,0 +1,37 @@
+# Deploying smart functions
+
+Deploying a smart function to Jstz is different from deploying most web or JavaScript/TypeScript applications because you cannot change the code of a smart function or delete it after you deploy it.
+When you deploy a smart function, Jstz records code of the smart function in its ledger of transactions and there is no way to change or delete entries from the ledger.
+
+## Deploying to the local sandbox
+
+You can use the local sandbox to test smart functions in a simulated environment.
+
+1. Ensure that Docker is installed.
+
+1. Build the smart function as described in [Building smart functions](/functions/building).
+
+1. Start the Jstz sandbox in a Docker container by running `jstz sandbox --container start`.
+   The sandbox persists as long as the container is running.
+
+1. Deploy the built smart function with the `jstz deploy` command, including the `-n dev` argument to deploy it to the sandbox, as in this example:
+
+   ```bash
+   jstz deploy dist/index.js -n dev
+   ```
+
+   If the deployment is successful, the response includes the address of the deployed smart function.
+
+1. If you need to fund the smart function, you can bridge funds from bootstrap accounts with the `jstz bridge deposit` command, as in this example, which uses the variable `<ADDRESS>` for the address of the deployed smart function:
+
+   ```bash
+   jstz bridge deposit --from bootstrap1 --to <ADDRESS> --amount 1000 -n dev
+   ```
+
+1. Verify that the smart function is deployed by calling it with the `jstz run` command or by checking its balance by running this command:
+
+   ```bash
+   jstz account balance -a <ADDRESS> -n dev
+   ```
+
+<!-- TODO ## Deploying to Jstz networks -->

--- a/docs/functions/overview.md
+++ b/docs/functions/overview.md
@@ -80,6 +80,7 @@ Smart functions look like ordinary JavaScript functions, but because they run on
 - Smart functions are permissionless, so anyone can call them, but you can add your own logic to them to restrict who can call them.
 - Anyone can inspect the code and storage of deployed smart functions.
 - Because smart functions run in a decentralized manner on many Jstz Smart Rollup nodes, they are censorship-resistant.
+- Smart functions must be built with Jstz dependencies as described in [Building smart functions](/functions/building).
 
 ## Limitations of smart functions
 


### PR DESCRIPTION
# Context

We had an internal user hear that Jstz runs your TS code without having to build it so they tried to deploy a smart function without building it with the Jstz dependencies. 

# Description

Make it clear that you have to build smart functions with the Jstz dependencies before deploying them.

This PR also adds instructions for deploying smart functions to the sandbox; are we ready to provide instructions for deploying to any other network?

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->
