### PR TITLE
Replace "request" with "method" in CLI

### DIFF
--- a/crates/jstz_cli/src/main.rs
+++ b/crates/jstz_cli/src/main.rs
@@ -74,7 +74,7 @@ enum Command {
         #[arg(short, long, default_value_t = DEFAULT_GAS_LIMIT)]
         gas_limit: u32,
         /// The HTTP method used in the request.
-        #[arg(name = "request", short, long, default_value = "GET")]
+        #[arg(name = "method", short, long, default_value = "GET")]
         http_method: String,
         /// The JSON data in the request body.
         #[arg(name = "data", short, long, default_value = None, value_hint = clap::ValueHint::FilePath)]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -157,7 +157,7 @@ jstz run [OPTIONS] <URL>
 
 - `--gas-limit (-g) <GAS_LIMIT>`: The maximum amount of gas to be used. Default is `100000`.
 
-- `--request (-r) <request>`: Specifies the HTTP method used in the request. Default is `GET`.
+- `--method (-m) <method>`: Specifies the HTTP method used in the request. Default is `GET`.
 
 - `--data (-d) <data>`: Defines the JSON data to be included in the request body.
 


### PR DESCRIPTION
# Context

release chore
# Description

fix the run cli arg. simply renamed from "request" to "method"

# Manually testing the PR

```
cargo run --bin jstz -- run jstz://KT1RoV8imUNX6xMYiX3YTrzHZifqS4N1yU7A/ --method POST --network dev --trace
```
