### PR TITLE
chore(openapi): update kv value type to any

### DIFF
--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -746,8 +746,6 @@
         "example": "KT1RycYvM4EVs6BAXWEsGXaAaRqiMP53KT4w"
       },
       "KvValue": {
-        "type": "string",
-        "format": "json",
         "description": "A value stored in the Key-Value store. Always valid JSON."
       },
       "LogLevel": {

--- a/crates/jstz_proto/src/api/kv.rs
+++ b/crates/jstz_proto/src/api/kv.rs
@@ -23,7 +23,7 @@ const KV_PATH: RefPath = RefPath::assert_from(b"/jstz_kv");
 // TODO: Figure out a more effective way of serializing values using json
 /// A value stored in the Key-Value store. Always valid JSON.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-#[schema(value_type = String, format = "json")]
+#[schema(value_type = Value)]
 pub struct KvValue(pub serde_json::Value);
 
 impl Decode for KvValue {


### PR DESCRIPTION
# Context
Kv values can be `any` type

Closes https://linear.app/tezos/issue/JSTZ-315/jstzclientgetkv-should-return-anyunknown-instead-of-string 

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
* Change `value_type` of `KvValue` to `Value` which generates a schema with `any` type according to `utoipa` docs. The change gets reflects as `unknown` in generated client code which enforces narrowing to a more specific type 
<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
Client changes - https://github.com/jstz-dev/jstz-client/commit/74424af176240c2539cd6900f7d57a10d92dc9d3#diff-6115f1e5afaba23f2a3d1a208e6662475a463d79bb53df12c7c7f2bd6ddc848aR41
<!-- Describe how reviewers and approvers can test this PR. -->
