### PR TITLE
chore(openapi): support settings transfer in sdk

### DIFF
--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -1095,6 +1095,14 @@
           "headers": {
             "type": "object",
             "description": "Any valid HTTP headers",
+            "properties": {
+              "X-JSTZ-TRANSFER": {
+                "type": "integer",
+                "format": "int64",
+                "description": "Amount in mutez to transfer on request",
+                "minimum": 1
+              }
+            },
             "additionalProperties": true
           },
           "method": {
@@ -1140,6 +1148,15 @@
           "headers": {
             "type": "object",
             "description": "Any valid HTTP headers",
+            "properties": {
+              "X-JSTZ-AMOUNT": {
+                "type": "integer",
+                "format": "int64",
+                "description": "Amount in mutez that was transferred on response",
+                "readOnly": true,
+                "minimum": 1
+              }
+            },
             "additionalProperties": true
           },
           "statusCode": {

--- a/crates/jstz_proto/src/receipt.rs
+++ b/crates/jstz_proto/src/receipt.rs
@@ -65,7 +65,7 @@ pub struct RunFunctionReceipt {
     pub status_code: StatusCode,
     /// Any valid HTTP headers
     #[serde(with = "http_serde::header_map")]
-    #[schema(schema_with = crate::operation::openapi::http_headers)]
+    #[schema(schema_with = crate::operation::openapi::response_headers)]
     pub headers: HeaderMap,
 }
 


### PR DESCRIPTION
# Context
We want to make it easy for dapps to attach transfers to run/deploy functions and read these values from responses

Closes https://linear.app/tezos/issue/JSTZ-457/allow-setting-transfer-headers-in-client-sdk 
<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
* Includes transfer headers in request and response headers of open api schema
<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
Generated client- https://github.com/jstz-dev/jstz-client/commit/527c7dcd0a4bf45b6a77229824bff9fc2dbf2b5a#diff-25fd7ba932755790a659d8dfcf1c25b9d628e7b642e9087dfd55af137db086e6
<!-- Describe how reviewers and approvers can test this PR. -->
