### PR TITLE
feat(cli): overwrite smart function name

### DIFF
--- a/crates/jstz_cli/src/deploy.rs
+++ b/crates/jstz_cli/src/deploy.rs
@@ -21,6 +21,7 @@ pub async fn exec(
     balance: Option<Tez>,
     name: Option<String>,
     network: Option<NetworkName>,
+    force: bool,
 ) -> Result<()> {
     let mut cfg = Config::load().await?;
     // Load sandbox if the selected network is Dev and sandbox is not already loaded
@@ -36,11 +37,11 @@ pub async fn exec(
         styles::command("jstz login")
     ))?;
 
-    // 1. Check if smart function account already exists
+    // 1. Check if the name already exists
     if let Some(name) = &name {
-        if cfg.accounts.contains(name) {
+        if cfg.accounts.contains(name) && !force {
             bail_user_error!(
-                "A user/smart function with the alias '{}' already exists.",
+                "The name '{}' is already used by another smart function or a user account. Please choose another name or specify the `--force` flag to overwrite the name.",
                 name
             );
         }

--- a/crates/jstz_cli/src/main.rs
+++ b/crates/jstz_cli/src/main.rs
@@ -41,6 +41,9 @@ enum Command {
         /// Use `dev` for the local sandbox.
         #[arg(short, long, default_value = None)]
         network: Option<NetworkName>,
+        /// Overwrites an existing function name. Effective only when `name` is specified.
+        #[arg(short, long)]
+        force: bool,
     },
     /// 🏃 Send a request to a transfer XTZ
     Transfer {
@@ -158,7 +161,8 @@ async fn exec(command: Command) -> Result<()> {
             balance,
             name,
             network,
-        } => deploy::exec(code, balance, name, network).await,
+            force,
+        } => deploy::exec(code, balance, name, network, force).await,
         Command::Transfer {
             amount,
             to,

--- a/crates/jstz_cli/tests/deploy.rs
+++ b/crates/jstz_cli/tests/deploy.rs
@@ -1,0 +1,134 @@
+use jstz_crypto::{
+    hash::Blake2b,
+    smart_function_hash::{Kt1Hash, SmartFunctionHash},
+};
+use jstz_proto::receipt::{DeployFunctionReceipt, Receipt};
+use std::{fs::File, io::Write};
+use tempfile::{NamedTempFile, TempDir};
+use tezos_crypto_rs::hash::ContractKt1Hash;
+use utils::jstz_cmd;
+
+#[path = "./utils.rs"]
+mod utils;
+
+fn config(endpoint: &str) -> serde_json::Value {
+    serde_json::json!({
+        "current_alias": "test_user",
+        "accounts": {
+            "test_user": {
+                "User": {
+                    "address": "tz1ficxJFv7MUtsCimF8bmT9SYPDok52ySg6",
+                    "secret_key": "edsk3a3gq6ocr51rGDqqSb8sxxV46v77GZYmhyKyjqWjckhVTJXYCf",
+                    "public_key": "edpktpcAZ3d8Yy1EZUF1yX4xFgLq5sJ7cL9aVhp7aV12y89RXThE3N"
+                }
+            },
+        },
+        "default_network": "test",
+        "networks": {"test": {"octez_node_rpc_endpoint": endpoint, "jstz_node_endpoint": endpoint}},
+    })
+}
+
+#[test]
+fn deploy() {
+    let mut server = mockito::Server::new();
+    server
+        .mock(
+            "GET",
+            "/accounts/tz1ficxJFv7MUtsCimF8bmT9SYPDok52ySg6/nonce",
+        )
+        .with_body("0")
+        .create();
+    server.mock("POST", "/operations").with_status(200).create();
+    let receipt = Receipt::new(
+        Blake2b::default(),
+        Ok(jstz_proto::receipt::ReceiptContent::DeployFunction(
+            DeployFunctionReceipt {
+                address: SmartFunctionHash(Kt1Hash(
+                    ContractKt1Hash::from_base58_check(
+                        "KT19GXucGUitURBXXeEMMfqqhSQ5byt4P1zX",
+                    )
+                    .unwrap(),
+                )),
+            },
+        )),
+    );
+    server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(r"^/operations/\w+/receipt$".to_string()),
+        )
+        .with_body(serde_json::to_string(&receipt).unwrap())
+        .create();
+
+    let success_msg = "Smart function deployed by test_user at address: KT1";
+    let tmp_dir = TempDir::new().unwrap();
+    let path = tmp_dir.path().join("config.json");
+    let file = File::create(&path).expect("should create file");
+    serde_json::to_writer(file, &config(&server.url()))
+        .expect("should write config file");
+    let mut source_file = NamedTempFile::new().unwrap();
+    source_file
+        .write_all("export default (() => new Response('hello world'))".as_bytes())
+        .unwrap();
+
+    let (mut process, tmp_dir) = jstz_cmd(
+        [
+            "deploy",
+            source_file.path().to_str().unwrap(),
+            "--name",
+            "dummy",
+        ],
+        Some(tmp_dir),
+    );
+    let output = process.exp_eof().unwrap();
+    assert!(output.contains(success_msg));
+
+    let (mut process, tmp_dir) = jstz_cmd(
+        [
+            "deploy",
+            source_file.path().to_str().unwrap(),
+            "--name",
+            "dummy",
+        ],
+        Some(tmp_dir),
+    );
+    let output = process.exp_eof().unwrap();
+    assert!(output.contains(
+        "The name 'dummy' is already used by another smart function or a user account."
+    ));
+
+    let (mut process, tmp_dir) = jstz_cmd(
+        [
+            "deploy",
+            source_file.path().to_str().unwrap(),
+            "--name",
+            "dummy",
+            "--force",
+        ],
+        Some(tmp_dir),
+    );
+    let output = process.exp_eof().unwrap();
+    assert!(output.contains(success_msg));
+
+    // a new name with force should work
+    let (mut process, tmp_dir) = jstz_cmd(
+        [
+            "deploy",
+            source_file.path().to_str().unwrap(),
+            "--name",
+            "dummy-new",
+            "--force",
+        ],
+        Some(tmp_dir),
+    );
+    let output = process.exp_eof().unwrap();
+    assert!(output.contains(success_msg));
+
+    // force without a name should work
+    let (mut process, _tmp_dir) = jstz_cmd(
+        ["deploy", source_file.path().to_str().unwrap(), "--force"],
+        Some(tmp_dir),
+    );
+    let output = process.exp_eof().unwrap();
+    assert!(output.contains(success_msg));
+}


### PR DESCRIPTION
# Context

Completes JSTZ-498.
Closes #926.
[JSTZ-498](https://linear.app/tezos/issue/JSTZ-498/jstz-deploy-name-needs-a-f-argument)

# Description

Add one flag `--force` to `jstz deploy` to overwrite known smart functions. Example:
```
$ jstz deploy index.js --name foo
...
Smart function deployed by test_user at address: KT1...
Run with `jstz run jstz://KT1.../`
$ jstz deploy index.js --name foo
✕  ERROR  The smart function name 'foo' already exists. Please choose another name or specify the `--force` flag to overwrite the name.
$ jstz deploy index.js --name foo --force
...
Smart function deployed by test_user at address: KT1...
Run with `jstz run jstz://KT1.../`
```
# Manually testing the PR

Added one integration test.
