### PR TITLE
chore(ci): update octez base image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,7 +43,7 @@ jobs:
       - id: run
         run: |
           input_tag=${{ inputs.octez-tag }}
-          octez_tag=${input_tag:-"master_d21359af_20241220171048"}
+          octez_tag=${input_tag:-"octez-v22.0"}
           echo "OCTEZ_TAG=${octez_tag}" >> ${GITHUB_OUTPUT}
   build-kernel:
     name: Build (Kernel)

--- a/crates/jstzd/Dockerfile
+++ b/crates/jstzd/Dockerfile
@@ -1,4 +1,4 @@
-ARG OCTEZ_TAG
+ARG OCTEZ_TAG=octez-v22.0
 FROM tezos/tezos:${OCTEZ_TAG} AS octez
 USER root
 RUN mkdir /octez-bin && mv /usr/local/bin/octez-client /usr/local/bin/octez-node /usr/local/bin/octez-smart-rollup-node /usr/local/bin/octez-baker-* /octez-bin


### PR DESCRIPTION
# Context

Part of the release chores.

# Description

Update the default tag of the octez base image used by the jstzd image to `octez-v22.0`.

# Manually testing the PR

N/A
