### PR TITLE
chore(release): bump version to 0.1.1-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2794,7 +2794,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_api"
-version = "0.1.0-alpha.0"
+version = "0.1.1-alpha.1"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2823,7 +2823,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_cli"
-version = "0.1.0-alpha.0"
+version = "0.1.1-alpha.1"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -2889,7 +2889,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_core"
-version = "0.1.0-alpha.0"
+version = "0.1.1-alpha.1"
 dependencies = [
  "anyhow",
  "bincode 2.0.0-rc.3",
@@ -2916,7 +2916,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_crypto"
-version = "0.1.0-alpha.0"
+version = "0.1.1-alpha.1"
 dependencies = [
  "anyhow",
  "bincode 2.0.0-rc.3",
@@ -2933,7 +2933,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_kernel"
-version = "0.1.0-alpha.0"
+version = "0.1.1-alpha.1"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "boa_engine",
@@ -2953,7 +2953,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_mock"
-version = "0.1.0-alpha.0"
+version = "0.1.1-alpha.1"
 dependencies = [
  "derive_more",
  "jstz_core",
@@ -2965,7 +2965,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_node"
-version = "0.1.0-alpha.0"
+version = "0.1.1-alpha.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3009,7 +3009,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_proto"
-version = "0.1.0-alpha.0"
+version = "0.1.1-alpha.1"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "boa_engine",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_rollup"
-version = "0.1.0-alpha.0"
+version = "0.1.1-alpha.1"
 dependencies = [
  "anyhow",
  "bincode 2.0.0-rc.3",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_runtime"
-version = "0.1.0-alpha.0"
+version = "0.1.1-alpha.1"
 dependencies = [
  "anyhow",
  "bincode 2.0.0-rc.3",
@@ -3085,7 +3085,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_sdk"
-version = "0.1.0-alpha.0"
+version = "0.1.1-alpha.1"
 dependencies = [
  "jstz_crypto",
  "jstz_proto",
@@ -3095,7 +3095,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_tps_bench"
-version = "0.1.0-alpha.0"
+version = "0.1.1-alpha.1"
 dependencies = [
  "base64 0.21.7",
  "bincode 2.0.0-rc.3",
@@ -3119,7 +3119,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_wpt"
-version = "0.1.0-alpha.0"
+version = "0.1.1-alpha.1"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -3137,7 +3137,7 @@ dependencies = [
 
 [[package]]
 name = "jstzd"
-version = "0.1.0-alpha.0"
+version = "0.1.1-alpha.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3586,7 +3586,7 @@ dependencies = [
 
 [[package]]
 name = "octez"
-version = "0.1.0-alpha.0"
+version = "0.1.1-alpha.1"
 dependencies = [
  "anyhow",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.1.0-alpha.0"
+version = "0.1.1-alpha.1"
 authors = ["TriliTech <contact@trili.tech>"]
 repository = "https://github.com/jstz-dev/jstz"
 homepage = "https://github.com/jstz-dev/jstz"

--- a/crates/jstz_cli/src/sandbox/mod.rs
+++ b/crates/jstz_cli/src/sandbox/mod.rs
@@ -10,7 +10,7 @@ pub use consts::*;
 use container::*;
 
 const SANDBOX_CONTAINER_NAME: &str = "jstz-sandbox";
-const SANDBOX_IMAGE: &str = "ghcr.io/jstz-dev/jstz/jstzd:0.1.1-alpha.0";
+const SANDBOX_IMAGE: &str = "ghcr.io/jstz-dev/jstz/jstzd:0.1.1-alpha.1";
 
 pub async fn assert_sandbox_running(sandbox_base_url: &str) -> Result<()> {
     match jstzd::is_jstzd_running(sandbox_base_url).await {

--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -11,7 +11,7 @@
       "name": "MIT",
       "url": "https://github.com/jstz-dev/jstz/blob/main/LICENSE"
     },
-    "version": "0.1.0-alpha.0"
+    "version": "0.1.1-alpha.1"
   },
   "paths": {
     "/accounts/{address}": {

--- a/packages/cli/main/package.json
+++ b/packages/cli/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jstz-dev/cli",
-  "version": "0.1.1-alpha.0",
+  "version": "0.1.1-alpha.1",
   "dependencies": {},
   "scripts": {
     "postinstall": "node install.js"


### PR DESCRIPTION
# Context
Bump version to 0.1.1-alpha.1 for the next release

# Description
* Bump version in workspace `Cargo.toml`
* Bump version in `packages/cli/main/package.json`
* Bump version of `SANDBOX_IMAGE` in `crates/jstz_cli/src/sandbox/mod.rs`
* Regenerate openapi schema - `cargo run --bin jstz-node -- spec -o crates/jstz_node/openapi.json`