### PR TITLE
fix(ci): remove cli checks that require input

### DIFF
--- a/.github/actions/test-cli/action.yml
+++ b/.github/actions/test-cli/action.yml
@@ -21,6 +21,4 @@ runs:
 
         chmod +x ./jstz
         export PATH=$PATH:$PWD
-        check "$(jstz account create test 2>&1)" "User created with address"
-        check "$(jstz account list 2>&1)" "test:"
-        check "$(jstz login test 2>&1)" "Logged in to account test with address"
+        check "$(jstz account list 2>&1)" "Accounts:"


### PR DESCRIPTION
# Context

CLI release check [failed](https://github.com/jstz-dev/jstz/actions/runs/14640353127/job/41081511102) because `jstz account create` is now aligned with the other account creation flow where users are asked to input a passphrase and the library we use for user prompts does not work properly in certain cases.

# Description

Keep `jstz account list` in the check and remove other lines. It should be fine as the main idea of the check was to ensure that the binaries are packaged properly.

I find it surprising that the prompt library does not even accept pipes. We should probably replace that library since it means CLI cannot be used in automation.

# Manually testing the PR

[Test run](https://github.com/jstz-dev/jstz/actions/runs/14641309059/job/41084238779)
