### PR TITLE
fix(cli, proto): validate jstz scheme in run function

### DIFF
--- a/crates/jstz_cli/src/run.rs
+++ b/crates/jstz_cli/src/run.rs
@@ -192,6 +192,8 @@ pub async fn exec(args: RunArgs) -> Result<()> {
         .parse()
         .expect("`url_object` is an invalid URL.");
 
+    validate_scheme(&url)?;
+
     let method = Method::from_str(&args.http_method)
         .map_err(|_| user_error!("Invalid HTTP method: {}", args.http_method))?;
 
@@ -298,6 +300,17 @@ pub async fn exec(args: RunArgs) -> Result<()> {
     cfg.save()?;
 
     Ok(())
+}
+
+fn validate_scheme(url: &Uri) -> Result<()> {
+    let supported_scheme_msg = "URL scheme must be 'jstz'";
+    match url.scheme_str() {
+        Some("jstz") => Ok(()),
+        Some(invalid_scheme) => bail!(format!(
+            "Unsupport scheme '{invalid_scheme}'. {supported_scheme_msg}"
+        )),
+        None => bail!(format!("Missing scheme. {supported_scheme_msg}")),
+    }
 }
 
 async fn spawn_trace(address: &Address, jstz_client: &JstzClient) -> Result<()> {

--- a/crates/jstz_cli/tests/account.rs
+++ b/crates/jstz_cli/tests/account.rs
@@ -7,7 +7,7 @@ use utils::jstz_cmd;
 #[test]
 fn create_account() {
     let address_pattern = Regex::new(r"tz1\w{33}").unwrap();
-    let (mut process, tmp_dir) = jstz_cmd(["account", "create", "foo"], None);
+    let mut process = jstz_cmd(["account", "create", "foo"], None);
 
     // empty passphrase
     process.send_line("").unwrap();
@@ -19,13 +19,13 @@ fn create_account() {
     assert!(output.contains("User created with address: tz1"));
     let address1 = address_pattern.captures(&output).unwrap();
 
-    let (mut process, tmp_dir) = jstz_cmd(["account", "create", "foo"], Some(tmp_dir));
+    let mut process = jstz_cmd(["account", "create", "foo"], Some(process.tmp));
 
     let output = process.exp_eof().unwrap();
     assert!(output.contains("The account 'foo' already exists."));
 
-    let (mut process, _) =
-        jstz_cmd(["account", "create", "foo", "--force"], Some(tmp_dir));
+    let mut process =
+        jstz_cmd(["account", "create", "foo", "--force"], Some(process.tmp));
 
     // empty passphrase
     process.send_line("").unwrap();
@@ -42,7 +42,7 @@ fn create_account() {
 
 #[test]
 fn login_new_account() {
-    let (mut process, _tmp_dir) = jstz_cmd(["login", "foo"], None);
+    let mut process = jstz_cmd(["login", "foo"], None);
 
     process.send_line("y").unwrap();
     // empty passphrase
@@ -61,7 +61,7 @@ fn login_new_account() {
 
 #[test]
 fn import_account() {
-    let (mut process, tmp_dir) = jstz_cmd(["account", "import", "foo"], None);
+    let mut process = jstz_cmd(["account", "import", "foo"], None);
 
     process
         .send_line("edsk4YBTjLtZgLNWKUN95unbAZ6cfq2eXhRveVt4J5oFPYHMzadpc8")
@@ -74,14 +74,14 @@ fn import_account() {
     ));
 
     // import to the same alias should fail
-    let (mut process, tmp_dir) = jstz_cmd(["account", "import", "foo"], Some(tmp_dir));
+    let mut process = jstz_cmd(["account", "import", "foo"], Some(process.tmp));
 
     let output = process.exp_eof().unwrap();
     assert!(output.contains("The account 'foo' already exists."));
 
     // import to the same alias with --force should work
-    let (mut process, _) =
-        jstz_cmd(["account", "import", "foo", "--force"], Some(tmp_dir));
+    let mut process =
+        jstz_cmd(["account", "import", "foo", "--force"], Some(process.tmp));
 
     process
         .send_line("edsk3a3gq6ocr51rGDqqSb8sxxV46v77GZYmhyKyjqWjckhVTJXYCf")
@@ -96,7 +96,7 @@ fn import_account() {
 
 #[test]
 fn import_account_empty_input() {
-    let (mut process, _) = jstz_cmd(["account", "import", "foo"], None);
+    let mut process = jstz_cmd(["account", "import", "foo"], None);
 
     process.send_line("").unwrap();
 
@@ -106,7 +106,7 @@ fn import_account_empty_input() {
 
 #[test]
 fn import_account_bad_key() {
-    let (mut process, _) = jstz_cmd(["account", "import", "foo"], None);
+    let mut process = jstz_cmd(["account", "import", "foo"], None);
 
     process.send_line("aaa").unwrap();
 

--- a/crates/jstz_cli/tests/deploy.rs
+++ b/crates/jstz_cli/tests/deploy.rs
@@ -71,7 +71,7 @@ fn deploy() {
         .write_all("export default (() => new Response('hello world'))".as_bytes())
         .unwrap();
 
-    let (mut process, tmp_dir) = jstz_cmd(
+    let mut process = jstz_cmd(
         [
             "deploy",
             source_file.path().to_str().unwrap(),
@@ -83,21 +83,21 @@ fn deploy() {
     let output = process.exp_eof().unwrap();
     assert!(output.contains(success_msg));
 
-    let (mut process, tmp_dir) = jstz_cmd(
+    let mut process = jstz_cmd(
         [
             "deploy",
             source_file.path().to_str().unwrap(),
             "--name",
             "dummy",
         ],
-        Some(tmp_dir),
+        Some(process.tmp),
     );
     let output = process.exp_eof().unwrap();
     assert!(output.contains(
         "The name 'dummy' is already used by another smart function or a user account."
     ));
 
-    let (mut process, tmp_dir) = jstz_cmd(
+    let mut process = jstz_cmd(
         [
             "deploy",
             source_file.path().to_str().unwrap(),
@@ -105,13 +105,13 @@ fn deploy() {
             "dummy",
             "--force",
         ],
-        Some(tmp_dir),
+        Some(process.tmp),
     );
     let output = process.exp_eof().unwrap();
     assert!(output.contains(success_msg));
 
     // a new name with force should work
-    let (mut process, tmp_dir) = jstz_cmd(
+    let mut process = jstz_cmd(
         [
             "deploy",
             source_file.path().to_str().unwrap(),
@@ -119,15 +119,15 @@ fn deploy() {
             "dummy-new",
             "--force",
         ],
-        Some(tmp_dir),
+        Some(process.tmp),
     );
     let output = process.exp_eof().unwrap();
     assert!(output.contains(success_msg));
 
     // force without a name should work
-    let (mut process, _tmp_dir) = jstz_cmd(
+    let mut process = jstz_cmd(
         ["deploy", source_file.path().to_str().unwrap(), "--force"],
-        Some(tmp_dir),
+        Some(process.tmp),
     );
     let output = process.exp_eof().unwrap();
     assert!(output.contains(success_msg));

--- a/crates/jstz_cli/tests/exec.rs
+++ b/crates/jstz_cli/tests/exec.rs
@@ -1,0 +1,49 @@
+use std::fs::File;
+
+use tempfile::TempDir;
+use utils::jstz;
+
+#[path = "./utils.rs"]
+mod utils;
+
+fn config(endpoint: &str) -> serde_json::Value {
+    serde_json::json!({
+        "current_alias": "test_user",
+        "accounts": {
+            "test_user": {
+                "User": {
+                    "address": "tz1ficxJFv7MUtsCimF8bmT9SYPDok52ySg6",
+                    "secret_key": "edsk3a3gq6ocr51rGDqqSb8sxxV46v77GZYmhyKyjqWjckhVTJXYCf",
+                    "public_key": "edpktpcAZ3d8Yy1EZUF1yX4xFgLq5sJ7cL9aVhp7aV12y89RXThE3N"
+                }
+            },
+        },
+        "default_network": "test",
+        "networks": {"test": {"octez_node_rpc_endpoint": endpoint, "jstz_node_endpoint": endpoint}},
+    })
+}
+
+#[test]
+fn run_with_invalid_scheme() {
+    let mut server = mockito::Server::new();
+    server
+        .mock(
+            "GET",
+            "/accounts/tz1ficxJFv7MUtsCimF8bmT9SYPDok52ySg6/nonce",
+        )
+        .with_body("0")
+        .create();
+
+    let tmp_dir = TempDir::new().unwrap();
+    let path = tmp_dir.path().join("config.json");
+    let file = File::create(&path).expect("should create file");
+    serde_json::to_writer(file, &config(&server.url()))
+        .expect("should write config file");
+
+    let mut process = jstz(
+        "run tezos://tz1ficxJFv7MUtsCimF8bmT9SYPDok52ySg6 -n test",
+        Some(tmp_dir),
+    );
+    let output = process.exp_eof().unwrap();
+    assert!(output.contains("URL scheme must be 'jstz'"));
+}

--- a/crates/jstz_proto/src/error.rs
+++ b/crates/jstz_proto/src/error.rs
@@ -19,6 +19,7 @@ pub enum Error {
     InsufficientFunds,
     InvalidNonce,
     InvalidAddress,
+    InvalidScheme,
     RefererShouldNotBeSet,
     GasLimitExceeded,
     UnsupportedPath,
@@ -128,6 +129,9 @@ impl From<Error> for JsError {
                 .into(),
             Error::InvalidInjector => {
                 JsNativeError::eval().with_message("InvalidInjector").into()
+            }
+            Error::InvalidScheme => {
+                JsNativeError::eval().with_message("InvalidScheme").into()
             }
         }
     }


### PR DESCRIPTION
# Context
Jstz supports `jstz://` scheme in its URL but this has never been validated which is a bug. This PR fixes that.

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
* Validate jstz scheme in cli, `RunFunction` operation and in `SmartFunction.call`
* Add `ProcessSession` to cli test utils to reduce friction
<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
```
cargo nextest run -p jstz_proto invalid_scheme
cargo nextest run -p jstz_cli invalid_scheme --test
```
<!-- Describe how reviewers and approvers can test this PR. -->
