### PR TITLE
fix(docs): fix invisible text

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -185,7 +185,7 @@ Follow these instructions to deploy the sample smart function to a local sandbox
     <details>
     <summary>Output</summary>
     <pre style="border: 1px solid #ccc; padding: 10px; border-radius: 4px; overflow-x: auto;">
-    <code style="color: #FFF;">$ jstz sandbox start
+    <code>$ jstz sandbox start
 
                __________
                \  jstz  /
@@ -228,7 +228,7 @@ Follow these instructions to deploy the sample smart function to a local sandbox
     <details>
     <summary>Output</summary>
     <pre style="border: 1px solid #ccc; padding: 10px; border-radius: 4px; overflow-x: auto;">
-    <code style="color: #FFF;">$ npm run build
+    <code>$ npm run build
     > @jstz-dev/get-tez@0.0.0 build
     > esbuild index.ts --bundle --format=esm --target=esnext --minify --outfile=dist/index.js
 


### PR DESCRIPTION
# Context

Completes JSTZ-508.
Fixes #904.
[JSTZ-508](https://linear.app/tezos/issue/JSTZ-508/fix-invisible-text-in-docs)

# Description

Remove the inline style for code blocks. Setting the foreground colour to #FFF makes the text invisible in light mode.

# Manually testing the PR

Before:
<img width="719" alt="image" src="https://github.com/user-attachments/assets/61438525-bfee-48b6-b4cb-cec16e6d315b" />


After:
![Untitled2](https://github.com/user-attachments/assets/3bf0bde6-62c9-4bd9-b515-84946156514e)

