### PR TITLE
ci: deploy prod docs on release

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,15 +1,16 @@
-# Sample workflow for building and deploying a VitePress site to GitHub Pages
-#
-name: Deploy VitePress site to Pages
+name: Deploy prod docs
 
 on:
-  # Runs on pushes targeting the `main` branch. Change this to `master` if you're
-  # using the `master` branch as the default branch.
   push:
-    branches: [main]
+    tags:
+      - "*"
 
-  # Allows you to run this workflow manually from the Actions tab
+  # In case we want to deploy cherrypicked changes, e.g. hot fixes for docs before the next release
   workflow_dispatch:
+    inputs:
+      ref:
+        description: "ref (branch, tag, or SHA) that will be used to build docs"
+        type: string
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -24,35 +25,46 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Build job
+  set-ref:
+    name: Set ref for workflows triggered by tags
+    runs-on: ubuntu-latest
+    outputs:
+      target_ref: ${{ steps.run.outputs.TARGET_REF }}
+    steps:
+      - id: run
+        run: |
+          input_ref=${{ inputs.ref }}
+          trigger_ref=${{ github.ref }}
+          ref=${input_ref:-"$trigger_ref"}
+          echo "TARGET_REF=${ref:-"main"}" >> ${GITHUB_OUTPUT}
+
   build:
     runs-on: ubuntu-latest
+    needs: [set-ref]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ needs.set-ref.outputs.target_ref }}
           fetch-depth: 0 # Not needed if lastUpdated is not enabled
-      # - uses: pnpm/action-setup@v2 # Uncomment this if you're using pnpm
-      # - uses: oven-sh/setup-bun@v1 # Uncomment this if you're using Bun
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: npm # or pnpm / yarn
+          cache: npm
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Install dependencies
-        run: npm ci # or pnpm install / yarn install / bun install
+        run: npm ci
       - name: Build with VitePress
         run: |
-          npm run docs:build # or pnpm docs:build / yarn docs:build / bun run docs:build
+          npm run docs:build
           touch docs/.vitepress/dist/.nojekyll
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: docs/.vitepress/dist
 
-  # Deployment job
   deploy:
     environment:
       name: github-pages


### PR DESCRIPTION
# Context

Completes JSTZ-509.
[JSTZ-509](https://linear.app/tezos/issue/JSTZ-509/deploy-docs-on-release)

# Description

Deploy docs to prod on release. This workflow can also be triggered manually with any commit ref. The rules are:
* If a ref is given to the workflow (manual run,) the ref is used to deploy the pages.
* If no ref is given to the workflow (manual run,) `main` is used to deploy the pages.
* If the workflow is triggered by a tag, the tag is used to deploy the pages.

Note that to allow tags to trigger this workflow, this repo setting needs to be updated:

`Environments` -> `github-pages` -> `Deployment branches and tags` -> Add tag rule "*"

# Manually testing the PR

Tested with my fork.

[Tag in the main branch](https://github.com/huancheng-trili/jstz/actions/runs/14704612789)
[Workflow dispatch](https://github.com/huancheng-trili/jstz/actions/runs/14704814735)
[Tag in a different branch](https://github.com/huancheng-trili/jstz/actions/runs/14704859651)
