### PR TITLE
fix(ci): move built dev docs properly

### DIFF
--- a/.github/workflows/deploy-dev-docs.yml
+++ b/.github/workflows/deploy-dev-docs.yml
@@ -64,8 +64,8 @@ jobs:
           path: dest_repo
       - name: setup git config
         run: |
+          cd $GITHUB_WORKSPACE/dest_repo/ && find . -mindepth 1 -maxdepth 1 ! -name '.git' -type d -exec rm -rf {} +
           mv $GITHUB_WORKSPACE/docs/* $GITHUB_WORKSPACE/dest_repo/
-          cd $GITHUB_WORKSPACE/dest_repo
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
           git add .


### PR DESCRIPTION
# Context

Fixes #973.

A [build](https://github.com/jstz-dev/jstz/actions/runs/14730155797/job/41342204433) failed because the script could not move the built doc files when the destination folders were not empty.

# Description

Remove folders in `dev-docs` so that the new built doc files can be moved to the target repo.

# Manually testing the PR

[Test run](https://github.com/jstz-dev/jstz/actions/runs/14731992946/job/41348342036)
