### PR TITLE
fix(docs): revert #933

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ jstz sandbox start -d
 # Deploy smart function
 jstz deploy index.js --name example
 # Send request to smart function
-jstz run tezos://example/
+jstz run jstz://example/
 ```
 
 For a more detailed quick start, see [Quick start](https://jstz-dev.github.io/jstz/quick_start.html).

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -29,6 +29,7 @@ export default defineConfig({
           { text: "Quick Start", link: "/quick_start" },
           { text: "CLI", link: "/cli" },
           { text: "Sandbox", link: "/sandbox" },
+          { text: "Transfer", link: "/transfer" },
         ],
       },
 

--- a/docs/api/smart_function.md
+++ b/docs/api/smart_function.md
@@ -30,7 +30,7 @@ async function handler(_: Request): Promise<Response> {
   const newAddress = await SmartFunction.create(
     "export default handler () => new Response()",
   );
-  return SmartFunction.call(new Request(`tezos://${newAddress}`));
+  return SmartFunction.call(new Request(`jstz://${newAddress}`));
 }
 ```
 

--- a/docs/api/url.md
+++ b/docs/api/url.md
@@ -7,13 +7,13 @@
 There are two ways to create a URL: either as an absolute URL or a relative URL.
 
 ```typescript
-let url: URL = new URL(`tezos://${my_function.address}/entrypoint`);
+let url: URL = new URL(`jstz://${my_function.address}/entrypoint`);
 let url2: URL = new URL("../entrypoint_2", url.href);
 ```
 
 Each `jstz` smart function is assigned a unique address, akin to an IP address, starting with `KT1` when the function is deployed.
-To decode these addresses, `jstz` employs its own URL scheme `tezos://`.
-An example URL for a `jstz` smart function would therefore be `tezos://KT19mYzcaYk55KttezwP4TbMrGCDpVuPW3Jw/`.
+To decode these addresses, `jstz` employs its own URL scheme `jstz://`.
+An example URL for a `jstz` smart function would therefore be `jstz://KT19mYzcaYk55KttezwP4TbMrGCDpVuPW3Jw/`.
 
 It's important to note that if the base URL or the resulting URL is not valid, the constructor will raise a `TypeError` exception.
 To check whether URLs can be parsed correctly, you can use the static method [`URL.canParse()`](#canParse).
@@ -31,17 +31,17 @@ if (URL.canParse(relativePath, baseUrl)) {
 You can also modify a URL by setting its properties.
 
 ```typescript
-let url = new URL("tezos://KT19mYzcaYk55KttezwP4TbMrGCDpVuPW3Jw/"); // not a valid address, we'll have to change it
+let url = new URL("jstz://KT19mYzcaYk55KttezwP4TbMrGCDpVuPW3Jw/"); // not a valid address, we'll have to change it
 url.hostname = Ledger.selfAddress;
 url.pathname = "accounts";
 url.hash = "#id";
-console.log(url.href); // tezos://KT1../accounts#id
+console.log(url.href); // jstz://KT1../accounts#id
 ```
 
 The [`URLSearchParams`](./url_search_params.md) API may be used to build and manipulate search parameters. To get the search parameters from the URL, you can make use of the `.searchParams` instance property.
 
 ```typescript
-let url = new URL(`tezos://${address}/?first_name=Dave`);
+let url = new URL(`jstz://${address}/?first_name=Dave`);
 switch (url.searchParams.get("first_name")) {
   case "Jim":
     url.searchParams.set("last_name", "Jones");

--- a/docs/architecture/accounts.md
+++ b/docs/architecture/accounts.md
@@ -74,7 +74,7 @@ jstz account -a <ALIAS_OR_ADDRESS> -n dev
 To call a smart function from the command line, use the `jstz run` command and pass the address or alias, as in this example from the [Quick start](/quick_start):
 
 ```bash
-jstz run tezos://<ALIAS_OR_ADDRESS>/ --data '{"message":"Give me tez now."}' -n dev
+jstz run jstz://<ALIAS_OR_ADDRESS>/ --data '{"message":"Give me tez now."}' -n dev
 ```
 
 The Jstz command-line client sends the command from the active local user account.

--- a/docs/architecture/bridge.md
+++ b/docs/architecture/bridge.md
@@ -56,7 +56,7 @@ jstz bridge withdraw --to tz1faswCTDciRzE4oJ9jn2Vm2dvjeyA9fUzU \
 will output the following response on success:
 
 ```bash
-Running function at tezos://jstz/withdraw
+Running function at jstz://jstz/withdraw
 Status code: 200 OK
 Headers: {}
 ```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -8,6 +8,7 @@ This guide will instruct through how to use the command line interface for `jstz
 - [bridge](#bridge) - Interact with the XTZ asset bridge between Tezos and `jstz`.
 - [deploy](#deploy) - Deploy your smart function.
 - [run](#run) - Run your smart function.
+- [transfer](#transfer) - Transfer XTZ across `jstz` accounts.
 - [repl](#repl) - Enter an interactive REPL for the `jstz` runtime.
 
 ::: tip
@@ -161,7 +162,11 @@ jstz run [OPTIONS] <URL>
 
 - `--data (-d) <data>`: Defines the JSON data to be included in the request body.
 
+- `--amount (-a) <data>`: The amount in XTZ to transfer.
+
 - `--network (-n) <NETWORK>`: Specifies the network from the config file. Use `dev` for the local sandbox.
+
+- `--include (-i)`: Include response headers in the output.
 
 - `--trace (-t)`: Flag to show the logs of the function.
 
@@ -169,10 +174,10 @@ jstz run [OPTIONS] <URL>
 
 ```bash
 $ export counter=tz4CYGgcFtphw3AXS2Mx2CMmfj6voV5mPc9b # Address of the previously deployed smart function examples/counter.js
-$ jstz run --trace "tezos://${counter}/"
-$ jstz run --trace "tezos://${counter}/"
-$ jstz run --trace "tezos://${counter}/"
-$ jstz run --trace "tezos://${counter}/"
+$ jstz run --trace "jstz://${counter}/"
+$ jstz run --trace "jstz://${counter}/"
+$ jstz run --trace "jstz://${counter}/"
+$ jstz run --trace "jstz://${counter}/"
 ```
 
 You should be able to see an output of the counter smart function looking like this:
@@ -182,6 +187,36 @@ You should be able to see an output of the counter smart function looking like t
 [🪵] Counter: 0
 [🪵] Counter: 1
 [🪵] Counter: 2
+```
+
+## Transfer
+
+Transfer XTZ.
+
+### Usage:
+
+```bash
+jstz transfer [OPTIONS] <AMOUNT> <ADDRESS|ALIAS>
+```
+
+### Arguments:
+
+- `<AMOUNT>`: The amount in XTZ to transfer.
+
+- `<ADDRESS|ALIAS>`: Destination address or alias of the account (user or smart function).
+
+### Options:
+
+- `--gas-limit (-g) <GAS_LIMIT>`: The maximum amount of gas to be used. Default is `100000`.
+
+- `--network (-n) <NETWORK>`: Specifies the network from the config file. Use `dev` for the local sandbox.
+
+- `--include (-i)`: Include response headers in the output.
+
+### Example
+
+```bash
+$ jstz transfer 2 KT1CexuXoXuShARedvKSmxwDTLxRHNcvxqKR
 ```
 
 ## REPL

--- a/docs/functions/calling.md
+++ b/docs/functions/calling.md
@@ -7,7 +7,7 @@ Here is an example of calling another contract:
 const targetContract: Address = "KT1L8ZzGDzaXZSTmzHkoF2azQRf7dCAfxtqx";
 
 const response = await SmartFunction.call(
-  new Request(`tezos://${targetContract}`, {
+  new Request(`jstz://${targetContract}`, {
     method: "POST",
     body: JSON.stringify({ message: "hello" }),
   }),
@@ -15,7 +15,7 @@ const response = await SmartFunction.call(
 console.log(await response.json());
 ```
 
-The URL for the [`Request`](/api/request) object must be `tezos://` followed by the address of a Jstz smart function.
+The URL for the [`Request`](/api/request) object must be `jstz://` followed by the address of a Jstz smart function.
 Smart functions cannot call external APIs or Tezos smart contracts directly.
 You can set the method in the `Request` object but you cannot set the `Referer` header because it automatically becomes the address of the smart function.
 

--- a/docs/functions/requests.md
+++ b/docs/functions/requests.md
@@ -40,7 +40,7 @@ const handler = async (request: Request): Promise<Response> => {
 
 You can branch the code of the smart function based on any of this information.
 For example, you can parse the URL that the request went to and allow callers to call different URLs as though they were API endpoints.
-For example, this code parses the URL and does different things based on whether the request came to the URL `tezos://<ADDRESS>/ping` or `tezos://<ADDRESS>/marco`:
+For example, this code parses the URL and does different things based on whether the request came to the URL `jstz://<ADDRESS>/ping` or `jstz://<ADDRESS>/marco`:
 
 ```typescript
 const handler = async (request: Request): Promise<Response> => {

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -249,7 +249,7 @@ Follow these instructions to deploy the sample smart function to a local sandbox
     Logged in to account alan with address tz1N8BsvfrSjGdomFi5V9RwwYLasgD8s4pxF
 
     Smart function deployed by alan at address: KT1FZuQ4SDP7ahLRyybtNnNxNnRskBGyAXVw
-    Run with `jstz run tezos://KT1FZuQ4SDP7ahLRyybtNnNxNnRskBGyAXVw/ --data <args> --trace`
+    Run with `jstz run jstz://KT1FZuQ4SDP7ahLRyybtNnNxNnRskBGyAXVw/ --data <args> --trace`
 
     </code>
     </pre>
@@ -259,7 +259,7 @@ Follow these instructions to deploy the sample smart function to a local sandbox
     This address is its identifier, similar to an IP address or a smart contract address.
 
     In the example above, the smart function was deployed to the address `KT1FZuQ4SDP7ahLRyybtNnNxNnRskBGyAXVw`.
-    Now the smart function is accessible through a URL of the format `tezos://KT1FZuQ4SDP7ahLRyybtNnNxNnRskBGyAXVw/`.
+    Now the smart function is accessible through a URL of the format `jstz://KT1FZuQ4SDP7ahLRyybtNnNxNnRskBGyAXVw/`.
 
     After you deploy the smart function, you cannot delete it or change it.
 
@@ -280,7 +280,7 @@ After a successful deployment, you can call the smart function in a way similar 
 1. Ask the smart function for tez in an impolite way by running this command, with your smart function's address:
 
    ```sh
-   jstz run tezos://<ADDRESS>/ --data '{"message":"Give me tez now."}' -n dev
+   jstz run jstz://<ADDRESS>/ --data '{"message":"Give me tez now."}' -n dev
    ```
 
    The smart function returns the message "Sorry, I only fulfill polite requests."
@@ -288,7 +288,7 @@ After a successful deployment, you can call the smart function in a way similar 
 1. Ask the smart function politely by running this command, which includes the word "please" in the message:
 
    ```sh
-   jstz run tezos://<ADDRESS>/ --data '{"message":"Please, give me some tez."}' -n dev
+   jstz run jstz://<ADDRESS>/ --data '{"message":"Please, give me some tez."}' -n dev
    ```
 
    The function returns the message "Thank you for your polite request. You received 1 tez!"
@@ -360,7 +360,7 @@ Follow these steps to build and run this application:
 
    The CLI accepts two commands.
    If you input the text `show`, it prints the history of commands.
-   If you input any other text, it sends that text as a request to the smart function, as in the command you ran earlier: `jstz run tezos://<ADDRESS>/ --data '{"message":"Please, give me some tez."}' -n dev`.
+   If you input any other text, it sends that text as a request to the smart function, as in the command you ran earlier: `jstz run jstz://<ADDRESS>/ --data '{"message":"Please, give me some tez."}' -n dev`.
 
 1. Send a request that includes the word "please" and see that the smart function sends you one tez.
 
@@ -404,7 +404,7 @@ Essentially, it is a WASM program directly compiled from the core Jstz Rust code
 Although it is semantically correct, do not use this library in production because it involves copying users' secret keys, which is not secure.
 :::
 
-The `buildRequest` function constructs a `RunFunction` operation that calls the smart function by its `tezos://<ADDRESS>` URL.
+The `buildRequest` function constructs a `RunFunction` operation that calls the smart function by its `jstz://<ADDRESS>` URL.
 
 ```typescript
 function buildRequest(
@@ -423,7 +423,7 @@ function buildRequest(
     gas_limit: 55000,
     headers: {},
     method: "GET",
-    uri: `tezos://${contractAddress}`,
+    uri: `jstz://${contractAddress}`,
   };
 }
 ```

--- a/docs/transfer.md
+++ b/docs/transfer.md
@@ -1,0 +1,95 @@
+# 💰 Transfer
+
+This guide explains how to transfer XTZ between accounts using request and response headers. Transfers can be made to both smart functions and user addresses.
+
+## 1. Transfer via Request Headers
+
+Smart functions can transfer XTZ using the `X-JSTZ-TRANSFER` header in requests. The recipient can access the transferred amount via the `X-JSTZ-AMOUNT` header.
+
+**Smart function A (Sender)**
+
+```typescript
+const ONE_TEZ = "1000000"; // 1 XTZ in mutez
+
+const handler = async (request) => {
+  // Transfer 1 XTZ to smart function B
+  const smartFunctionB = "KT1TxqZ8QtKvLu3V3JH7Gx58n7Co8pgtpQU5";
+  const call_request = new Request(`jstz://${smartFunctionB}`, {
+    headers: {
+      "X-JSTZ-TRANSFER": ONE_TEZ,
+    },
+  });
+  await fetch(call_request);
+
+  return new Response();
+};
+
+export default handler;
+```
+
+**Smart function B (Recipient)**
+
+```typescript
+const handler = async (request) => {
+  const transferred_amount = request.headers.get("X-JSTZ-AMOUNT");
+  console.log(`Received ${transferred_amount} mutez`); // Output: Received 1000000 mutez
+  return new Response();
+};
+
+export default handler;
+```
+
+## 2. Refund via Response Headers
+
+Smart functions can refund XTZ using the `X-JSTZ-TRANSFER` header in responses. The original sender can access the refunded amount via the `X-JSTZ-AMOUNT` header in the response.
+
+**Smart function A (Sender)**
+
+```typescript
+const ONE_TEZ = "1000000"; // 1 XTZ in mutez
+
+const handler = async (request) => {
+  // Transfer 1 XTZ to smart function B
+  const smartFunctionB = "KT1TxqZ8QtKvLu3V3JH7Gx58n7Co8pgtpQU5";
+  const call_request = new Request(`jstz://${smartFunctionB}`, {
+    headers: {
+      "X-JSTZ-TRANSFER": ONE_TEZ,
+    },
+  });
+
+  const response = await fetch(call_request);
+  const refund_amount = response.headers.get("X-JSTZ-AMOUNT");
+  console.log(`Received ${refund_amount} mutez back`); // Output: Received 500000 mutez back
+  return new Response();
+};
+
+export default handler;
+```
+
+**Smart function B (Refunder)**
+
+```typescript
+const HALF_TEZ = "500000"; // 0.5 XTZ in mutez
+
+const handler = async (request) => {
+  const transferred_amount = request.headers.get("X-JSTZ-AMOUNT");
+  console.log(`Received ${transferred_amount} mutez`); // Output: Received 1000000 mutez
+
+  // Refund 0.5 XTZ to the sender
+  return new Response(null, {
+    headers: {
+      "X-JSTZ-TRANSFER": HALF_TEZ,
+    },
+  });
+};
+
+export default handler;
+```
+
+## Important Notes
+
+1. All amounts are specified in mutez (1 XTZ = 1,000,000 mutez)
+2. Transfers can be made to:
+   - Smart function addresses (KT1...)
+   - User addresses (tz1...)
+3. Ensure sufficient balance before initiating transfers

--- a/examples/500_nested_counter.js
+++ b/examples/500_nested_counter.js
@@ -16,7 +16,7 @@ const handler = async (request) => {
   if (n > 0) {
     console.log(`Nested transaction: ${n}`);
     // Nested transaction
-    await fetch(new Request(`tezos://${Ledger.selfAddress}/?n=${n - 1}`));
+    await fetch(new Request(`jstz://${Ledger.selfAddress}/?n=${n - 1}`));
   }
 
   // Cause an error at the most nested level

--- a/examples/benchmark.js
+++ b/examples/benchmark.js
@@ -4,7 +4,7 @@ async function fa2_balance_of(fa2, minter, token_id) {
   const encodedRequests = btoa(JSON.stringify(balance_request));
 
   const response = await fetch(
-    new Request(`tezos://${fa2}/balance_of?requests=${encodedRequests}`),
+    new Request(`jstz://${fa2}/balance_of?requests=${encodedRequests}`),
   );
   const balances = await response.json();
   console.log(
@@ -24,7 +24,7 @@ async function handler(request) {
   const tokens = [{ token_id, owner: minter, amount: n }];
 
   await SmartFunction.call(
-    new Request(`tezos://${fa2}/mint_new`, {
+    new Request(`jstz://${fa2}/mint_new`, {
       method: "POST",
       body: JSON.stringify(tokens),
     }),
@@ -41,7 +41,7 @@ async function handler(request) {
 
   for (let i = 0; i < n; i++) {
     await SmartFunction.call(
-      new Request(`tezos://${fa2}/transfer`, {
+      new Request(`jstz://${fa2}/transfer`, {
         method: "POST",
         body: JSON.stringify(transfers),
       }),

--- a/examples/call-from-web/src/main.jsx
+++ b/examples/call-from-web/src/main.jsx
@@ -12,7 +12,7 @@ function buildRequest(contractAddress, path) {
     gas_limit: 55000,
     headers: {},
     method: "GET",
-    uri: `tezos://${contractAddress}${path}`,
+    uri: `jstz://${contractAddress}${path}`,
   };
 }
 

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -14,7 +14,7 @@ Follow these steps to use it:
 4. Call the smart function with the Jstz CLI by running this command, replacing `<ADDRESS>` with the address of the deployed smart function:
 
 ```shell
-jstz run tezos://<ADDRESS>/increment --network dev
+jstz run jstz://<ADDRESS>/increment --network dev
 ```
 
 The response shows that the number in storage was incremented and what the current number is.

--- a/examples/deploy.js
+++ b/examples/deploy.js
@@ -34,7 +34,7 @@ pub fn default (request: Request) -> Response {
   }
 
   await fetch(
-    new Request(`tezos://${smartFunctionAddress}/`, {
+    new Request(`jstz://${smartFunctionAddress}/`, {
       method: "POST",
       body: "Hello World",
     }),

--- a/examples/error_nested_counter.js
+++ b/examples/error_nested_counter.js
@@ -16,7 +16,7 @@ const handler = async (request) => {
   if (n > 0) {
     console.log(`Nested transaction: ${n}`);
     // Nested transaction
-    await fetch(new Request(`tezos://${Ledger.selfAddress}/?n=${n - 1}`));
+    await fetch(new Request(`jstz://${Ledger.selfAddress}/?n=${n - 1}`));
   }
 
   // Throw an error at the most nested level

--- a/examples/fa2/README.md
+++ b/examples/fa2/README.md
@@ -51,5 +51,5 @@ npm run build:test
 fa2=tz1...
 jstz deploy dist/test/index.js
 scenario=tz1...
-jstz run "tezos://$scenario/?fa2=$fa2"
+jstz run "jstz://$scenario/?fa2=$fa2"
 ```

--- a/examples/fa2/test/actor.ts
+++ b/examples/fa2/test/actor.ts
@@ -21,7 +21,7 @@ async function handler(request: Request): Promise<Response> {
         ];
 
         return await SmartFunction.call(
-          new Request(`tezos://${target}/transfer`, {
+          new Request(`jstz://${target}/transfer`, {
             method: "POST",
             body: JSON.stringify(transfers),
           }),
@@ -42,7 +42,7 @@ async function handler(request: Request): Promise<Response> {
         }));
 
         return await fetch(
-          new Request(`tezos://${target}/update_operators`, {
+          new Request(`jstz://${target}/update_operators`, {
             method: "PUT",
             body: JSON.stringify(body),
           }),

--- a/examples/fa2/test/index.ts
+++ b/examples/fa2/test/index.ts
@@ -2,7 +2,7 @@ import type { BalanceRequest, BalanceResponse, MintNew } from "../src/index";
 
 // NOTE: When updating actor smart function, make sure to update the `ACTOR_FUNCTION_CODE` below
 const ACTOR_FUNCTION_CODE =
-  'async function u(c){let e=new URL(c.url),l=e.pathname;try{switch(l){case"/ping":return console.log("Hello from child smart function \u{1F44B}"),new Response("Pong!");case"/transfer":{let t=e.searchParams.get("to"),a=+e.searchParams.get("token_id"),s=+e.searchParams.get("amount"),o=e.searchParams.get("fa2"),n=[{from:Ledger.selfAddress,transfers:[{to:t,token_id:a,amount:s}]}];return await SmartFunction.call(new Request(`tezos://${o}/transfer`,{method:"POST",body:JSON.stringify(n)}))}case"/add_operator":{let t=e.searchParams.get("fa2"),a=JSON.parse(e.searchParams.get("tokens")),s=c.headers.get("Referer"),o=Ledger.selfAddress,n=a.map(d=>({operation:"add_operator",owner:o,operator:s,token_id:d}));return await SmartFunction.call(new Request(`tezos://${t}/update_operators`,{method:"PUT",body:JSON.stringify(n)}))}default:let r=`Unrecognised entrypoint ${l}`;return console.error(r),new Response(r,{status:404})}}catch(r){return console.error(r),Response.error()}}var g=u;export{g as default};';
+  'async function u(c){let e=new URL(c.url),l=e.pathname;try{switch(l){case"/ping":return console.log("Hello from child smart function \u{1F44B}"),new Response("Pong!");case"/transfer":{let t=e.searchParams.get("to"),a=+e.searchParams.get("token_id"),s=+e.searchParams.get("amount"),o=e.searchParams.get("fa2"),n=[{from:Ledger.selfAddress,transfers:[{to:t,token_id:a,amount:s}]}];return await SmartFunction.call(new Request(`jstz://${o}/transfer`,{method:"POST",body:JSON.stringify(n)}))}case"/add_operator":{let t=e.searchParams.get("fa2"),a=JSON.parse(e.searchParams.get("tokens")),s=c.headers.get("Referer"),o=Ledger.selfAddress,n=a.map(d=>({operation:"add_operator",owner:o,operator:s,token_id:d}));return await SmartFunction.call(new Request(`jstz://${t}/update_operators`,{method:"PUT",body:JSON.stringify(n)}))}default:let r=`Unrecognised entrypoint ${l}`;return console.error(r),new Response(r,{status:404})}}catch(r){return console.error(r),Response.error()}}var g=u;export{g as default};';
 
 async function createActors(n: number): Promise<Address[]> {
   let promises = new Array(n)
@@ -21,7 +21,7 @@ async function logBalances(fa2: Address, actor: Address[], tokens: number[]) {
   let encodedRequests = btoa(JSON.stringify(requests));
 
   let response = await fetch(
-    new Request(`tezos://${fa2}/balance_of?requests=${encodedRequests}`),
+    new Request(`jstz://${fa2}/balance_of?requests=${encodedRequests}`),
   );
 
   let balances = await response.json();
@@ -43,7 +43,7 @@ async function addSelfAsOperator(
   let promises = actors.map((actor) =>
     fetch(
       new Request(
-        `tezos://${actor}/add_operator?fa2=${fa2}&tokens=${JSON.stringify(
+        `jstz://${actor}/add_operator?fa2=${fa2}&tokens=${JSON.stringify(
           tokens,
         )}`,
       ),
@@ -57,7 +57,7 @@ async function mintTokens(
   ...tokens: MintNew[]
 ): Promise<Response> {
   return await fetch(
-    new Request(`tezos://${fa2}/mint_new`, {
+    new Request(`jstz://${fa2}/mint_new`, {
       method: "POST",
       body: JSON.stringify(tokens),
     }),
@@ -73,7 +73,7 @@ async function transfer(
 ): Promise<Response> {
   return await fetch(
     new Request(
-      `tezos://${from}/transfer?fa2=${fa2}&to=${to}&token_id=${token_id}&amount=${amount}`,
+      `jstz://${from}/transfer?fa2=${fa2}&to=${to}&token_id=${token_id}&amount=${amount}`,
     ),
   );
 }
@@ -95,7 +95,7 @@ async function steal(
 
   // 2. Attempt to transfer the tokens
   return await fetch(
-    new Request(`tezos://${fa2}/transfer`, {
+    new Request(`jstz://${fa2}/transfer`, {
       method: "POST",
       body: JSON.stringify(transfers),
     }),

--- a/examples/hello_world.js
+++ b/examples/hello_world.js
@@ -19,7 +19,7 @@ const handler = async () => {
   try {
     const newSmartFunction = await SmartFunction.create(smartFunctionCode);
     console.log("created new smart function with address", newSmartFunction);
-    const url = `tezos://${newSmartFunction}/myEndPoint`;
+    const url = `jstz://${newSmartFunction}/myEndPoint`;
     const request = new Request(url, {
       method: "POST",
       body: "Hello from child smart function 👋",

--- a/examples/kv.js
+++ b/examples/kv.js
@@ -27,7 +27,7 @@ const handler = async (request) => {
         if (!functionAddress) {
           throw `${name} does not exist`;
         }
-        await fetch(new Request(`tezos://${functionAddress}`));
+        await fetch(new Request(`jstz://${functionAddress}`));
         console.log(`Incremened account ${name} at ${functionAddress}`);
         break;
       default:

--- a/examples/long_function.js
+++ b/examples/long_function.js
@@ -76,7 +76,7 @@ export default (request) => {
   const smartFunctionAddress = await SmartFunction.create(code);
   console.log("created", smartFunctionAddress);
 
-  await fetch(new Request(`tezos://${smartFunctionAddress}/`));
+  await fetch(new Request(`jstz://${smartFunctionAddress}/`));
 
   return new Response();
 }

--- a/examples/nested_counter.js
+++ b/examples/nested_counter.js
@@ -16,7 +16,7 @@ const handler = async (request) => {
   if (n > 0) {
     console.log(`Nested transaction: ${n}`);
     // Nested transaction
-    await fetch(new Request(`tezos://${Ledger.selfAddress}/?n=${n - 1}`));
+    await fetch(new Request(`jstz://${Ledger.selfAddress}/?n=${n - 1}`));
   }
 
   return new Response();

--- a/examples/nested_transactions.js
+++ b/examples/nested_transactions.js
@@ -28,7 +28,7 @@ async function handler() {
       let smartFunctionAddress = await SmartFunction.create(nested_code2);
 
       await fetch(
-        new Request(\`tezos://\${smartFunctionAddress}/\`, {
+        new Request(\`jstz://\${smartFunctionAddress}/\`, {
           method: \`POST\`,
           body: \`Hello World\`,
         }),
@@ -51,7 +51,7 @@ async function handler() {
   const smartFunctionAddress = await SmartFunction.create(nested_code1);
 
   await fetch(
-    new Request(`tezos://${smartFunctionAddress}/`, {
+    new Request(`jstz://${smartFunctionAddress}/`, {
       method: `POST`,
       body: `Hello World`,
     }),

--- a/examples/response.js
+++ b/examples/response.js
@@ -35,7 +35,7 @@ const handler = async () => {
 
   // Redirect
   {
-    const myResponse = Response.redirect(`tezos://${Ledger.selfAddress}`);
+    const myResponse = Response.redirect(`jstz://${Ledger.selfAddress}`);
     console.log(myResponse.url);
   }
 

--- a/examples/show-tez/src/index.ts
+++ b/examples/show-tez/src/index.ts
@@ -27,7 +27,7 @@ function buildRequest(
     gas_limit: 55000,
     headers: {},
     method: "GET",
-    uri: `tezos://${contractAddress}`,
+    uri: `jstz://${contractAddress}`,
   };
 }
 

--- a/examples/url_shortener/README.md
+++ b/examples/url_shortener/README.md
@@ -70,7 +70,7 @@ const handler = async (request: Request): Promise<Response> => {
     const { originalUrl } = await request.json();
     const shortCode = await shortenUrl(originalUrl);
     return new Response(
-      JSON.stringify({ shortUrl: `tezos://${url.host}/${shortCode}` }),
+      JSON.stringify({ shortUrl: `jstz://${url.host}/${shortCode}` }),
       {
         headers: { "Content-Type": "application/json" },
       },
@@ -128,7 +128,7 @@ jstz deploy dist/index.js -n dev
 Replace `<your-smart-function-address>` with the address returned after deployment.
 
 ```sh
-jstz run tezos://<your-smart-function-address>/shorten --data '{"originalUrl":"https://beata.com"}' -n dev --request POST
+jstz run jstz://<your-smart-function-address>/shorten --data '{"originalUrl":"https://beata.com"}' -n dev --request POST
 ```
 
 ## Retrieve the Original URL
@@ -136,7 +136,7 @@ jstz run tezos://<your-smart-function-address>/shorten --data '{"originalUrl":"h
 Replace `<your-smart-function-address>` and `/<shortCode>` with the actual values:
 
 ```sh
-jstz run tezos://<your-smart-function-address>/<shortCode> -n dev
+jstz run jstz://<your-smart-function-address>/<shortCode> -n dev
 ```
 
 ## Summary

--- a/examples/url_shortener/index.ts
+++ b/examples/url_shortener/index.ts
@@ -27,7 +27,7 @@ const handler = async (request: Request): Promise<Response> => {
     const { originalUrl } = await request.json();
     const shortCode = shortenUrl(originalUrl);
     return new Response(
-      JSON.stringify({ shortUrl: `tezos://${url.host}/${shortCode}` }),
+      JSON.stringify({ shortUrl: `jstz://${url.host}/${shortCode}` }),
       {
         headers: { "Content-Type": "application/json" },
       },

--- a/examples/workshop_transactions/get_tez_with_tax/get_tez.js
+++ b/examples/workshop_transactions/get_tez_with_tax/get_tez.js
@@ -37,7 +37,7 @@ export default async function (request) {
 
   // Pay taxes on the gift by calling a nested smart function.
   let response = await fetch(
-    new Request(`tezos://tz1coZprAPigHYAjDxnxvyzQscdrpBy5EBgq/`, {
+    new Request(`jstz://tz1coZprAPigHYAjDxnxvyzQscdrpBy5EBgq/`, {
       method: `POST`,
       body: `{ "amount": 1000000, "address": "${requester_address}"}`,
     }),

--- a/examples/workshop_transactions/nested_counter.js
+++ b/examples/workshop_transactions/nested_counter.js
@@ -16,7 +16,7 @@ const handler = async (request) => {
 
   if (n > 1) {
     // Nested transaction
-    await fetch(new Request(`tezos://${Ledger.selfAddress}/?n=${n - 1}`));
+    await fetch(new Request(`jstz://${Ledger.selfAddress}/?n=${n - 1}`));
   }
 
   return new Response();

--- a/examples/workshop_transactions/nested_transactions.js
+++ b/examples/workshop_transactions/nested_transactions.js
@@ -28,7 +28,7 @@ async function handler() {
       let smartFunctionAddress = await SmartFunction.create(nested_code2);
 
       await fetch(
-        new Request(\`tezos://\${smartFunctionAddress}/\`, {
+        new Request(\`jstz://\${smartFunctionAddress}/\`, {
           method: \`POST\`,
           body: \`Hello World\`,
         }),
@@ -51,7 +51,7 @@ async function handler() {
   const smartFunctionAddress = await SmartFunction.create(nested_code1);
 
   await fetch(
-    new Request(`tezos://${smartFunctionAddress}/`, {
+    new Request(`jstz://${smartFunctionAddress}/`, {
       method: `POST`,
       body: `Hello World`,
     }),


### PR DESCRIPTION
# Context

#933 was created to block updates in docs for changes that were not yet released. Now we can revert it since the release 0.1.1-alpha.1 is created and covers all relevant changes.

# Description

Revert changes in #933, specifically
* Replace `tezos://` with `jstz://`
* Add back the content for transferring tez in jstz

# Manually testing the PR

N/A
