### PR TITLE
chore(nix): make fmt ignore unsupported files

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -232,8 +232,20 @@
               # Dot files
               [".direnv"]
               ++
+              # Toml files (the only formatter available is toml-sort but it's problematic with Cargo.toml)
+              ["*.toml"]
+              ++
+              # Test files
+              ["crates/jstzd/tests/toy_rollup/**" "crates/jstzd/tests/resources/rollup/sr1Uuiucg1wk5aovEY2dj1ZBsqjwxndrSaao/**"]
+              ++
+              # Resource files
+              ["crates/octez/resources/protocol_parameters/sandbox/**" "crates/jstz_node/src/services/logs/create_db.sql" "crates/jstz_wpt/hosts" "crates/jstz_wpt/wpt" "*.png" "*.umdx"]
+              ++
+              # Miscellaneous files
+              ["*/**/.gitignore" "Makefile" "LICENSE" ".dockerignore" ".env.example" ".prettierignore" ".prettierrc"]
+              ++
               # Unsupported languages (LIGO, Docker)
-              ["contracts/**" "Dockerfile"];
+              ["contracts/**" "*/**/Dockerfile"];
           };
 
           mkFrameworkFlags = frameworks:


### PR DESCRIPTION
# Context

Completes JSTZ-372.
[JSTZ-372](https://linear.app/tezos/issue/JSTZ-372/remove-warn-no-formatter-logs-from-nix-fmt)

# Description

Make `nix fmt` ignore files without formatters. Note that toml files can actually be formatted with `toml-sort`, but it kind of messes up `Cargo.toml` files, even if it does sort dependencies.

# Manually testing the PR

```
$ nix --accept-flake-config -L --extra-experimental-features nix-command --extra-experimental-features flakes fmt
treefmt.toml> 
2025/05/01 11:35:39 INFO using config file: /nix/store/dpl77vgzks5r8jcbp46rczxs5ybw55y2-treefmt.toml
traversed 520 files                                                                
emitted 407 files for processing                                                   
formatted 1 files (0 changed) in 55ms
```

No more warnings.
