### PR TITLE
refactor: create jstz_utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3118,6 +3118,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jstz_utils"
+version = "0.1.1-alpha.1"
+dependencies = [
+ "anyhow",
+ "reqwest",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "jstz_wpt"
 version = "0.1.1-alpha.1"
 dependencies = [
@@ -3156,6 +3166,7 @@ dependencies = [
  "jstz_crypto",
  "jstz_kernel",
  "jstz_node",
+ "jstz_utils",
  "octez",
  "predicates",
  "prettytable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "crates/jstz_rollup",
   "crates/jstz_sdk",
   "crates/jstz_tps_bench",
+  "crates/jstz_utils",
   "crates/jstz_wpt",
   "crates/jstzd",
   "crates/octez",

--- a/crates/jstz_utils/Cargo.toml
+++ b/crates/jstz_utils/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "jstz_utils"
+edition.workspace = true
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+readme.workspace = true
+license-file.workspace = true
+description = "Utility functions"
+
+[dependencies]
+anyhow.workspace = true
+reqwest.workspace = true
+serde_json.workspace = true
+tokio.workspace = true

--- a/crates/jstz_utils/src/lib.rs
+++ b/crates/jstz_utils/src/lib.rs
@@ -1,0 +1,59 @@
+pub async fn poll<'a, F, T>(
+    max_attempts: u16,
+    interval_ms: u64,
+    f: impl Fn() -> F,
+) -> Option<T>
+where
+    F: std::future::Future<Output = Option<T>> + Send + 'a,
+{
+    let duration = tokio::time::Duration::from_millis(interval_ms);
+    for _ in 0..max_attempts {
+        tokio::time::sleep(duration).await;
+        if let Some(v) = f().await {
+            return Some(v);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    #[tokio::test]
+    async fn poll() {
+        async fn check(locked: Arc<Mutex<i32>>, result: bool) -> Option<bool> {
+            let mut v = locked.lock().await;
+            if *v == 5 {
+                return Some(result);
+            }
+            *v += 1;
+            None
+        }
+
+        // poll till the end and get a positive result
+        let locked = Arc::new(Mutex::new(1));
+        assert!(
+            super::poll(5, 1, || async { check(locked.clone(), true).await })
+                .await
+                .unwrap()
+        );
+
+        // poll till the end and get a negative result
+        let locked = Arc::new(Mutex::new(1));
+        assert!(
+            !super::poll(5, 1, || async { check(locked.clone(), false).await })
+                .await
+                .unwrap()
+        );
+
+        // not waiting long enough
+        let locked = Arc::new(Mutex::new(1));
+        assert!(
+            super::poll(2, 1, || async { check(locked.clone(), true).await })
+                .await
+                .is_none()
+        );
+    }
+}

--- a/crates/jstzd/Cargo.toml
+++ b/crates/jstzd/Cargo.toml
@@ -20,6 +20,7 @@ http.workspace = true
 indicatif.workspace = true
 jstz_crypto = { path = "../jstz_crypto" }
 jstz_node = {path = "../jstz_node"}
+jstz_utils = { path = "../jstz_utils" }
 octez = { path = "../octez" }
 prettytable.workspace = true
 regex.workspace = true

--- a/crates/jstzd/src/task/utils.rs
+++ b/crates/jstzd/src/task/utils.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, Result};
+use jstz_utils::poll;
 use serde_json::Value;
 
 pub async fn retry<'a, F>(
@@ -19,24 +20,6 @@ where
     })
     .await
     .unwrap_or(false)
-}
-
-pub async fn poll<'a, F, T>(
-    max_attempts: u16,
-    interval_ms: u64,
-    f: impl Fn() -> F,
-) -> Option<T>
-where
-    F: std::future::Future<Output = Option<T>> + Send + 'a,
-{
-    let duration = tokio::time::Duration::from_millis(interval_ms);
-    for _ in 0..max_attempts {
-        tokio::time::sleep(duration).await;
-        if let Some(v) = f().await {
-            return Some(v);
-        }
-    }
-    None
 }
 
 pub async fn get_block_level(rpc_endpoint: &str) -> Result<i64> {
@@ -82,42 +65,6 @@ mod tests {
         let locked = Arc::new(Mutex::new(1));
         assert!(
             !super::retry(2, 1, || async { check(locked.clone(), true).await }).await
-        );
-    }
-
-    #[tokio::test]
-    async fn poll() {
-        async fn check(locked: Arc<Mutex<i32>>, result: bool) -> Option<bool> {
-            let mut v = locked.lock().await;
-            if *v == 5 {
-                return Some(result);
-            }
-            *v += 1;
-            None
-        }
-
-        // poll till the end and get a positive result
-        let locked = Arc::new(Mutex::new(1));
-        assert!(
-            super::poll(5, 1, || async { check(locked.clone(), true).await })
-                .await
-                .unwrap()
-        );
-
-        // poll till the end and get a negative result
-        let locked = Arc::new(Mutex::new(1));
-        assert!(
-            !super::poll(5, 1, || async { check(locked.clone(), false).await })
-                .await
-                .unwrap()
-        );
-
-        // not waiting long enough
-        let locked = Arc::new(Mutex::new(1));
-        assert!(
-            super::poll(2, 1, || async { check(locked.clone(), true).await })
-                .await
-                .is_none()
         );
     }
 }

--- a/crates/jstzd/tests/octez_client_test.rs
+++ b/crates/jstzd/tests/octez_client_test.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 use jstz_crypto::{hash::Hash, public_key_hash::PublicKeyHash};
-use jstzd::task::{utils::poll, Task};
+use jstz_utils::poll;
+use jstzd::task::Task;
 use octez::r#async::{
     client::{OctezClient, OctezClientConfigBuilder, Signature},
     endpoint::Endpoint,


### PR DESCRIPTION
# Context

Part of JSTZ-544.
[JSTZ-544](https://linear.app/tezos/issue/JSTZ-544/create-sequencer-mode)

In preparation for #990.

# Description

Created a new crate `jstz_utils` that covers helper functions used across crates. For now only `poll` is moved to this crate because it's needed soon. The new crate is named `jstz_utils` instead of simply `utils` because each crate possibly has its own `utils` module and dealing with the naming conflict is a bit annoying.

# Manually testing the PR

CI passes.
