### PR TITLE
feat(jstz_node): create sequencer mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2968,6 +2968,7 @@ name = "jstz_node"
 version = "0.1.1-alpha.1"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "axum",
  "base64 0.21.7",
  "bincode 2.0.0-rc.3",
@@ -2981,6 +2982,7 @@ dependencies = [
  "jstz_core",
  "jstz_crypto",
  "jstz_proto",
+ "jstz_utils",
  "log",
  "mockito",
  "octez",

--- a/crates/jstz_node/Cargo.toml
+++ b/crates/jstz_node/Cargo.toml
@@ -28,6 +28,7 @@ jstz_api = { path = "../jstz_api" }
 jstz_core = { path = "../jstz_core" }
 jstz_crypto = { path = "../jstz_crypto" }
 jstz_proto = { path = "../jstz_proto" }
+jstz_utils = { path = "../jstz_utils" }
 log.workspace = true
 mockito.workspace = true
 octez = { path = "../octez" }
@@ -53,6 +54,7 @@ utoipa-axum.workspace = true
 utoipa-scalar.workspace = true
 
 [dev-dependencies]
+assert_cmd.workspace = true
 pretty_assertions.workspace = true
 
 [[bin]]

--- a/crates/jstz_node/src/config.rs
+++ b/crates/jstz_node/src/config.rs
@@ -4,6 +4,8 @@ use jstz_crypto::{public_key::PublicKey, secret_key::SecretKey};
 use octez::r#async::endpoint::Endpoint;
 use serde::Serialize;
 
+use crate::RunMode;
+
 /// Jstz node's signer defaults to `bootstrap1` account
 /// Make sure to update　the `INJECTOR_PK` in `jstzd/build_config.rs` if you change this
 pub const JSTZ_NODE_DEFAULT_PK: &str =
@@ -35,6 +37,8 @@ pub struct JstzNodeConfig {
     pub kernel_log_file: PathBuf,
     /// The injector of the operation. Currently, it's used for signing `RevealLargePayload` operation.
     pub injector: KeyPair,
+    /// The mode in which the rollup node will run.
+    pub mode: RunMode,
 }
 
 impl JstzNodeConfig {
@@ -47,6 +51,7 @@ impl JstzNodeConfig {
         rollup_preimages_dir: &Path,
         kernel_log_file: &Path,
         injector: KeyPair,
+        mode: RunMode,
     ) -> Self {
         Self {
             endpoint: endpoint.clone(),
@@ -54,6 +59,7 @@ impl JstzNodeConfig {
             rollup_preimages_dir: rollup_preimages_dir.to_path_buf(),
             kernel_log_file: kernel_log_file.to_path_buf(),
             injector,
+            mode,
         }
     }
 }
@@ -79,6 +85,7 @@ mod tests {
                 )
                 .unwrap(),
             ),
+            RunMode::Default,
         );
 
         let json = serde_json::to_value(&config).unwrap();
@@ -105,6 +112,7 @@ mod tests {
             Path::new("/tmp/preimages"),
             Path::new("/tmp/kernel.log"),
             KeyPair::default(),
+            RunMode::Default,
         );
 
         assert_eq!(config.injector, KeyPair::default());

--- a/crates/jstz_node/src/main.rs
+++ b/crates/jstz_node/src/main.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use env_logger::Env;
-use jstz_node::config::KeyPair;
+use jstz_node::{config::KeyPair, RunMode};
 
 const DEFAULT_ROLLUP_NODE_RPC_ADDR: &str = "127.0.0.1";
 const DEFAULT_ROLLUP_RPC_PORT: u16 = 8932;
@@ -11,6 +11,7 @@ const DEFAULT_KERNEL_LOG_PATH: &str = "logs/kernel.log";
 // Endpoint defaults for the `jstz-node`
 const DEFAULT_JSTZ_NODE_ADDR: &str = "127.0.0.1";
 const DEFAULT_JSTZ_NODE_PORT: u16 = 8933;
+const DEFAULT_RUN_MODE: &str = "default";
 
 #[derive(Debug, Parser)]
 enum Command {
@@ -44,6 +45,9 @@ struct Args {
 
     #[arg(long)]
     preimages_dir: PathBuf,
+
+    #[arg(long, default_value = DEFAULT_RUN_MODE)]
+    mode: RunMode,
 }
 
 #[tokio::main]
@@ -65,6 +69,7 @@ async fn main() -> anyhow::Result<()> {
                 // TODO: make the keypair configurable
                 // https://linear.app/tezos/issue/JSTZ-424/make-keypair-configurable-in-jstz-main
                 KeyPair::default(),
+                args.mode,
             )
             .await
         }

--- a/crates/jstz_node/src/services/mod.rs
+++ b/crates/jstz_node/src/services/mod.rs
@@ -6,6 +6,7 @@ pub mod accounts;
 pub mod error;
 pub mod logs;
 pub mod operations;
+pub mod utils;
 
 pub trait Service {
     fn router_with_openapi() -> OpenApiRouter<AppState>;

--- a/crates/jstz_node/src/services/utils.rs
+++ b/crates/jstz_node/src/services/utils.rs
@@ -1,0 +1,8 @@
+use crate::services::AppState;
+use axum::{extract::State, response::IntoResponse};
+
+pub async fn get_mode(
+    State(AppState { mode, .. }): State<AppState>,
+) -> impl IntoResponse {
+    serde_json::to_string(&mode).unwrap().into_response()
+}

--- a/crates/jstz_node/tests/sequencer.rs
+++ b/crates/jstz_node/tests/sequencer.rs
@@ -1,0 +1,40 @@
+use octez::unused_port;
+use std::process::Command;
+use tempfile::{NamedTempFile, TempDir};
+
+#[tokio::test]
+async fn run_sequencer() {
+    let tmp_dir = TempDir::new().unwrap();
+    let log_file = NamedTempFile::new().unwrap();
+    let port = unused_port();
+
+    let bin_path = assert_cmd::cargo::cargo_bin("jstz-node");
+    let mut c = Command::new(bin_path)
+        .args([
+            "run",
+            "--port",
+            &port.to_string(),
+            "--preimages-dir",
+            tmp_dir.path().to_str().unwrap(),
+            "--kernel-log-path",
+            log_file.path().to_str().unwrap(),
+            "--mode",
+            "sequencer",
+        ])
+        .spawn()
+        .unwrap();
+
+    let res = jstz_utils::poll(10, 500, || async {
+        reqwest::get(format!("http://127.0.0.1:{}/mode", port))
+            .await
+            .ok()
+    })
+    .await
+    .expect("should get response")
+    .text()
+    .await
+    .expect("should get text body");
+
+    assert_eq!(res, "\"sequencer\"");
+    let _ = c.kill();
+}

--- a/crates/jstzd/src/config.rs
+++ b/crates/jstzd/src/config.rs
@@ -145,6 +145,7 @@ pub(crate) async fn build_config(
         &jstz_rollup_path::preimages_path(),
         &kernel_debug_file_path,
         KeyPair::default(),
+        jstz_node::RunMode::Default,
     );
 
     let server_port = config.server_port.unwrap_or(DEFAULT_JSTZD_SERVER_PORT);

--- a/crates/jstzd/src/task/jstzd.rs
+++ b/crates/jstzd/src/task/jstzd.rs
@@ -774,6 +774,7 @@ mod tests {
                 &PathBuf::from("/foo"),
                 &PathBuf::from("/foo"),
                 KeyPair::default(),
+                jstz_node::RunMode::Default,
             ),
             ProtocolParameterBuilder::new()
                 .set_bootstrap_accounts([BootstrapAccount::new(

--- a/crates/jstzd/tests/jstz_node_test.rs
+++ b/crates/jstzd/tests/jstz_node_test.rs
@@ -17,6 +17,7 @@ async fn jstz_node_test() {
         &preimages_dir_path,
         &path,
         KeyPair::default(),
+        jstz_node::RunMode::Default,
     );
     let mut jstz_node = jstzd::task::jstz_node::JstzNode::spawn(jstz_node_config)
         .await

--- a/crates/jstzd/tests/jstzd_test.rs
+++ b/crates/jstzd/tests/jstzd_test.rs
@@ -174,6 +174,7 @@ async fn create_jstzd_server(
         &preimages_dir_path,
         &kernel_debug_file_path,
         KeyPair::default(),
+        jstz_node::RunMode::Default,
     );
     let config = JstzdConfig::new(
         octez_node_config,


### PR DESCRIPTION
# Context

Completes JSTZ-544.
[JSTZ-544](https://linear.app/tezos/issue/JSTZ-544/create-sequencer-mode)

# Description

Added an enum `RunMode` to jstz node. This enum indicates the mode that jstz node will run in. `Default` means running jstz node as is and `Sequencer` means the sequencer behaviour will be activated. This mode is determined by the CLI argument `--mode` which defaults to `default`.

Also added one API route `GET /mode` which returns the node's mode for testing.

# Manually testing the PR

* Unit testing: added one test
* Integration testing: added one test
