### PR TITLE
feat(sequencer): add queue to node

### DIFF
--- a/crates/jstz_node/src/config.rs
+++ b/crates/jstz_node/src/config.rs
@@ -39,6 +39,8 @@ pub struct JstzNodeConfig {
     pub injector: KeyPair,
     /// The mode in which the rollup node will run.
     pub mode: RunMode,
+    /// Capacity of the operation queue.
+    pub capacity: usize,
 }
 
 impl JstzNodeConfig {
@@ -52,6 +54,7 @@ impl JstzNodeConfig {
         kernel_log_file: &Path,
         injector: KeyPair,
         mode: RunMode,
+        capacity: usize,
     ) -> Self {
         Self {
             endpoint: endpoint.clone(),
@@ -60,6 +63,7 @@ impl JstzNodeConfig {
             kernel_log_file: kernel_log_file.to_path_buf(),
             injector,
             mode,
+            capacity,
         }
     }
 }
@@ -86,6 +90,7 @@ mod tests {
                 .unwrap(),
             ),
             RunMode::Default,
+            0,
         );
 
         let json = serde_json::to_value(&config).unwrap();
@@ -113,6 +118,7 @@ mod tests {
             Path::new("/tmp/kernel.log"),
             KeyPair::default(),
             RunMode::Default,
+            0,
         );
 
         assert_eq!(config.injector, KeyPair::default());

--- a/crates/jstzd/src/config.rs
+++ b/crates/jstzd/src/config.rs
@@ -146,6 +146,7 @@ pub(crate) async fn build_config(
         &kernel_debug_file_path,
         KeyPair::default(),
         jstz_node::RunMode::Default,
+        0,
     );
 
     let server_port = config.server_port.unwrap_or(DEFAULT_JSTZD_SERVER_PORT);

--- a/crates/jstzd/src/task/jstzd.rs
+++ b/crates/jstzd/src/task/jstzd.rs
@@ -775,6 +775,7 @@ mod tests {
                 &PathBuf::from("/foo"),
                 KeyPair::default(),
                 jstz_node::RunMode::Default,
+                0,
             ),
             ProtocolParameterBuilder::new()
                 .set_bootstrap_accounts([BootstrapAccount::new(

--- a/crates/jstzd/tests/jstz_node_test.rs
+++ b/crates/jstzd/tests/jstz_node_test.rs
@@ -18,6 +18,7 @@ async fn jstz_node_test() {
         &path,
         KeyPair::default(),
         jstz_node::RunMode::Default,
+        0,
     );
     let mut jstz_node = jstzd::task::jstz_node::JstzNode::spawn(jstz_node_config)
         .await

--- a/crates/jstzd/tests/jstzd_test.rs
+++ b/crates/jstzd/tests/jstzd_test.rs
@@ -175,6 +175,7 @@ async fn create_jstzd_server(
         &kernel_debug_file_path,
         KeyPair::default(),
         jstz_node::RunMode::Default,
+        0,
     );
     let config = JstzdConfig::new(
         octez_node_config,


### PR DESCRIPTION
# Context

Part of JSTZ-546.
[JSTZ-546](https://linear.app/tezos/issue/JSTZ-546/set-up-operation-queue)

When a signed operation to be injected arrives at the sequencer, the operation should be placed in a queue and wait to be processed.

# Description

Added a queue to jstz node and made its capacity configurable.

Also created a struct `RunOptions` that collects all values passed into `run` because the linter complained about that method having too many arguments.

# Manually testing the PR

Existing tests should pass. This is trivial so I'm leaving the actual tests to #993.
