### PR TITLE
feat(sequencer): insert operations to queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3003,6 +3003,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tower",
  "tower-http",
  "utoipa",
  "utoipa-axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,7 @@ tl = "0.7.7"
 tokio = { version = "1.36.0", features = ["full"] }
 tokio-stream = "0.1.14"
 tokio-util = "0.7.10"
+tower = "0.5.2"
 tower-http = { version = "0.6.1", features = ["cors"] }
 url = "2.4.1"
 urlpattern = "0.2.0"

--- a/crates/jstz_node/Cargo.toml
+++ b/crates/jstz_node/Cargo.toml
@@ -48,6 +48,7 @@ thiserror.workspace = true
 tokio-stream.workspace = true
 tokio-util.workspace = true
 tokio.workspace = true
+tower.workspace = true
 tower-http.workspace = true
 utoipa.workspace = true
 utoipa-axum.workspace = true

--- a/crates/jstz_node/src/sequencer/queue.rs
+++ b/crates/jstz_node/src/sequencer/queue.rs
@@ -1,4 +1,3 @@
-#![allow(unused)]
 use std::collections::VecDeque;
 
 use jstz_proto::operation::SignedOperation;
@@ -31,6 +30,11 @@ impl OperationQueue {
 
     pub fn is_full(&self) -> bool {
         self.queue.len() >= self.capacity
+    }
+
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.queue.len()
     }
 }
 

--- a/crates/jstz_node/src/services/error.rs
+++ b/crates/jstz_node/src/services/error.rs
@@ -12,6 +12,7 @@ pub enum ServiceError {
     NotFound,
     BadRequest(String),
     PersistentLogsDisabled,
+    ServiceUnavailable(Option<anyhow::Error>),
 }
 
 pub type ServiceResult<T> = anyhow::Result<T, ServiceError>;
@@ -30,6 +31,12 @@ impl IntoResponse for ServiceError {
                 ServiceError::BadRequest("Persistent logs disabled".to_string())
                     .into_response()
             }
+            ServiceError::ServiceUnavailable(error) => match error {
+                Some(e) => {
+                    (StatusCode::SERVICE_UNAVAILABLE, error_body(e)).into_response()
+                }
+                None => StatusCode::SERVICE_UNAVAILABLE.into_response(),
+            },
         }
     }
 }
@@ -37,4 +44,27 @@ impl IntoResponse for ServiceError {
 fn error_body(e: impl ToString) -> Body {
     let json = json!({ "error": e.to_string() });
     Body::from(serde_json::to_vec(&json).unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{body::to_bytes, response::IntoResponse};
+
+    use super::ServiceError;
+
+    #[tokio::test]
+    async fn service_unavailable() {
+        async fn check(inner: Option<anyhow::Error>, expected: &str) {
+            let res = ServiceError::ServiceUnavailable(inner).into_response();
+            assert_eq!(res.status(), 503);
+            let body = String::from_utf8(
+                to_bytes(res.into_body(), 1000).await.unwrap().to_vec(),
+            )
+            .unwrap();
+            assert_eq!(body, expected);
+        }
+
+        check(None, "").await;
+        check(Some(anyhow::anyhow!("foobar")), "{\"error\":\"foobar\"}").await;
+    }
 }


### PR DESCRIPTION
# Context

Part of JSTZ-546.
[JSTZ-546](https://linear.app/tezos/issue/JSTZ-546/set-up-operation-queue)

When a signed operation to be injected arrives at the sequencer, the operation should be placed in a queue and wait to be processed. If the queue still has space, the response code would be 200 as usual. If the queue is full, the response code would be 503.

# Description

Made the sequencer insert incoming signed operations into the queue.

# Manually testing the PR

* Unit testing: added tests for both the new error and the API handler.
