### PR TITLE
JSTZ-495-3: Move js logger to v1

### DIFF
--- a/crates/jstz_cli/src/logs/trace.rs
+++ b/crates/jstz_cli/src/logs/trace.rs
@@ -1,6 +1,6 @@
 use futures_util::{stream::StreamExt, Future};
 use jstz_api::js_log::LogLevel;
-use jstz_proto::js_logger::LogRecord;
+use jstz_proto::runtime::LogRecord;
 use log::{debug, error, info};
 use reqwest_eventsource::{Event, EventSource};
 

--- a/crates/jstz_node/src/services/logs/mod.rs
+++ b/crates/jstz_node/src/services/logs/mod.rs
@@ -8,11 +8,11 @@ use axum::{
 };
 use broadcaster::InfallibleSSeStream;
 use jstz_crypto::{hash::Hash, smart_function_hash::SmartFunctionHash};
-use jstz_proto::js_logger::{LogRecord, LOG_PREFIX};
 #[cfg(feature = "persistent-logging")]
 use jstz_proto::request_logger::{
     RequestEvent, REQUEST_END_PREFIX, REQUEST_START_PREFIX,
 };
+use jstz_proto::runtime::{LogRecord, LOG_PREFIX};
 use serde::Deserialize;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;

--- a/crates/jstz_proto/src/lib.rs
+++ b/crates/jstz_proto/src/lib.rs
@@ -2,7 +2,6 @@ mod error;
 
 pub mod context;
 pub mod executor;
-pub mod js_logger;
 pub mod operation;
 pub mod receipt;
 pub mod request_logger;

--- a/crates/jstz_proto/src/runtime/mod.rs
+++ b/crates/jstz_proto/src/runtime/mod.rs
@@ -1,6 +1,6 @@
 pub mod v1;
 
-pub use v1::{Kv, KvValue, ParsedCode, ProtocolData};
+pub use v1::{Kv, KvValue, LogRecord, ParsedCode, ProtocolData, LOG_PREFIX};
 
 #[cfg(feature = "riscv")]
 pub mod v2;

--- a/crates/jstz_proto/src/runtime/v1/js_logger.rs
+++ b/crates/jstz_proto/src/runtime/v1/js_logger.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-use crate::runtime::ProtocolData;
+use crate::runtime::v1::api::ProtocolData;
 
 pub use jstz_api::js_log::{JsLog, LogData, LogLevel};
 

--- a/crates/jstz_proto/src/runtime/v1/mod.rs
+++ b/crates/jstz_proto/src/runtime/v1/mod.rs
@@ -1,9 +1,11 @@
 mod api;
 mod fetch_handler;
+mod js_logger;
 mod script;
 
 pub use api::{Kv, KvValue, ProtocolApi, ProtocolData, WebApi};
 pub use fetch_handler::{
     fetch, response_from_run_receipt, runtime_and_request_from_run_operation,
 };
+pub use js_logger::{LogRecord, LOG_PREFIX};
 pub use script::ParsedCode;

--- a/crates/jstz_proto/src/runtime/v1/script.rs
+++ b/crates/jstz_proto/src/runtime/v1/script.rs
@@ -16,7 +16,7 @@ use jstz_core::{Module, Realm};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-use crate::js_logger::JsonLogger;
+use super::js_logger::JsonLogger;
 
 // Invariant: if code is present it parses successfully
 #[derive(


### PR DESCRIPTION
# Context
Since we need to support both boa and v8 in the interim, the code depending to each runtime should be factored out to allow as much re-use of runtime independent code as possible

<!-- **Related Tasks**: [Task name](Task url) -->
Part of https://linear.app/tezos/issue/JSTZ-495/move-boa-runtime-to-v1-in-jstz-proto

Depends on https://github.com/jstz-dev/jstz/pull/1007
# Description
Moves js logger into `runtime::v1`
<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
`make build && make test`
<!-- Describe how reviewers and approvers can test this PR. -->
