### PR TITLE
JSTZ-495-4: move host_script and top level fetch to v1

### DIFF
--- a/crates/jstz_proto/src/executor/smart_function/deploy.rs
+++ b/crates/jstz_proto/src/executor/smart_function/deploy.rs
@@ -2,12 +2,12 @@ use jstz_core::{host::HostRuntime, kv::Transaction};
 use jstz_crypto::smart_function_hash::SmartFunctionHash;
 use tezos_smart_rollup::prelude::debug_msg;
 
-use crate::runtime::ParsedCode;
 use crate::{
     context::account::{Account, Addressable},
     error::Result,
     operation::DeployFunction,
     receipt::DeployFunctionReceipt,
+    runtime::ParsedCode,
     Error,
 };
 
@@ -24,7 +24,7 @@ pub fn deploy_smart_function(
     Ok(address)
 }
 
-pub(crate) fn execute(
+pub fn execute(
     hrt: &mut impl HostRuntime,
     tx: &mut Transaction,
     source: &impl Addressable,

--- a/crates/jstz_proto/src/executor/smart_function/host.rs
+++ b/crates/jstz_proto/src/executor/smart_function/host.rs
@@ -1,22 +1,4 @@
-use std::num::NonZeroU64;
-
-use boa_engine::{
-    object::ErasedObject, Context, JsError, JsNativeError, JsResult, JsValue,
-};
-use boa_gc::GcRefMut;
-use http::Uri;
-use jstz_api::http::{
-    header::Headers,
-    request::Request,
-    response::{Response, ResponseClass},
-};
-use jstz_core::{native::JsNativeObject, runtime};
-
-use crate::{
-    context::account::{Account, Addressable},
-    operation::RunFunction,
-    runtime::v1::response_from_run_receipt,
-};
+use crate::{context::account::Addressable, operation::RunFunction};
 
 use jstz_core::{
     host::HostRuntime,
@@ -35,135 +17,8 @@ use crate::{
 };
 
 pub const JSTZ_HOST: &str = "jstz";
-const WITHDRAW_PATH: &str = "/withdraw";
-const FA_WITHDRAW_PATH: &str = "/fa-withdraw";
-
-pub const X_JSTZ_TRANSFER: &str = "X-JSTZ-TRANSFER";
-pub const X_JSTZ_AMOUNT: &str = "X-JSTZ-AMOUNT";
-
-pub(crate) struct HostScript;
-
-impl HostScript {
-    pub fn run(
-        self_address: &impl Addressable,
-        request: &mut GcRefMut<'_, ErasedObject, Request>,
-        context: &mut Context,
-    ) -> JsResult<JsValue> {
-        let run = run_function_from_request(request, 1)?;
-        let response = runtime::with_js_hrt_and_tx(|hrt, tx| -> JsResult<Response> {
-            // 1. Begin a new transaction
-            tx.begin();
-            // 2. Execute jstz host smart function
-            let result = execute_without_ticketer(hrt, tx, self_address, run);
-
-            // 3. Commit or rollback the transaction
-            match result {
-                Ok(run_receipt) => {
-                    if run_receipt.status_code.is_success() {
-                        tx.commit(hrt)?;
-                    } else {
-                        tx.rollback()?;
-                    }
-                    response_from_run_receipt(run_receipt, context)
-                }
-                Err(err) => {
-                    tx.rollback()?;
-                    Err(err.into())
-                }
-            }
-        })?;
-
-        let js_response = JsNativeObject::new::<ResponseClass>(response, context)?;
-        Ok(js_response.inner().clone())
-    }
-
-    /// Extracts the XTZ transfer amount from the request headers.
-    /// Returns None if the header is not present or Some(amount) if a valid amount is found.
-    pub fn extract_transfer_amount(headers: &Headers) -> JsResult<Option<NonZeroU64>> {
-        let header = headers.get(X_JSTZ_TRANSFER)?;
-
-        if header.headers.is_empty() {
-            return Ok(None);
-        }
-
-        if header.headers.len() > 1 {
-            return Err(JsError::from_native(JsNativeError::typ().with_message(
-                "Invalid transfer header: expected exactly one value",
-            )));
-        }
-
-        let amount = header.headers[0]
-            .parse::<NonZeroU64>()
-            .map(Some)
-            .map_err(|e| {
-                JsError::from_native(
-                    JsNativeError::typ()
-                        .with_message(format!("Invalid transfer amount: {}", e)),
-                )
-            })?;
-
-        Ok(amount)
-    }
-
-    fn verify_headers(headers: &Headers) -> JsResult<()> {
-        if headers.contains_key(X_JSTZ_AMOUNT) {
-            return Err(JsError::from_native(
-                JsNativeError::error()
-                    .with_message("X-JSTZ-AMOUNT header should not be present"),
-            ));
-        }
-        Ok(())
-    }
-
-    /// Transfer xtz from `src` to `dst` if the `X_JSTZ_TRANSFER` header is present & amount > 0
-    /// On success, `X_JSTZ_TRANSFER` is set to `X_JSTZ_AMOUNT`
-    /// Rejects if `X_JSTZ_AMOUNT` is already present in the headers or transfer failed
-    pub fn handle_transfer(
-        headers: &mut Headers,
-        src: &impl Addressable,
-        dst: &impl Addressable,
-    ) -> JsResult<Option<NonZeroU64>> {
-        Self::verify_headers(headers)?;
-        let amt = match Self::extract_transfer_amount(headers)? {
-            Some(a) => a,
-            None => return Ok(None),
-        };
-        runtime::with_js_hrt_and_tx(|hrt, tx| {
-            Account::transfer(hrt, tx, src, dst, amt.into())
-                .and_then(|_| {
-                    headers.remove(X_JSTZ_TRANSFER)?;
-                    headers.append(X_JSTZ_AMOUNT, &amt.to_string())?;
-                    Ok(())
-                })
-                .map_err(|e| {
-                    JsError::from_native(
-                        JsNativeError::eval()
-                            .with_message(format!("Transfer failed: {}", e)),
-                    )
-                })
-        })?;
-        Ok(Some(amt))
-    }
-}
-
-fn run_function_from_request(
-    request_deref: &mut GcRefMut<'_, ErasedObject, Request>,
-    gas_limit: usize,
-) -> JsResult<RunFunction> {
-    let method = request_deref.method().clone();
-    let uri = Uri::try_from(request_deref.url().clone().to_string()).map_err(|_| {
-        JsError::from_native(JsNativeError::error().with_message("Invalid host"))
-    })?;
-    let body = request_deref.body().clone().to_http_body();
-    let headers = request_deref.headers().deref_mut().to_http_headers();
-    Ok(RunFunction {
-        uri,
-        method,
-        body,
-        headers,
-        gas_limit,
-    })
-}
+pub const WITHDRAW_PATH: &str = "/withdraw";
+pub const FA_WITHDRAW_PATH: &str = "/fa-withdraw";
 
 fn validate_withdraw_request<'de, T>(run: &'de RunFunction) -> Result<T>
 where
@@ -244,18 +99,11 @@ pub fn execute_without_ticketer(
 
 #[cfg(test)]
 mod test {
-
-    use std::str::FromStr;
-
-    use http::{HeaderName, HeaderValue};
-    use jstz_api::http::{header::HeadersClass, request::RequestClass};
-    use jstz_core::native::register_global_class;
-
-    use super::*;
-
     use http::{header, HeaderMap, Method, Uri};
+    use jstz_core::kv::Transaction;
     use jstz_mock::host::JstzMockHost;
     use serde_json::json;
+    use tezos_crypto_rs::hash::ContractKt1Hash;
     use tezos_smart_rollup_mock::MockHost;
 
     use crate::{
@@ -263,101 +111,12 @@ mod test {
             account::{Account, Address},
             ticket_table::TicketTable,
         },
-        executor::fa_withdraw::{RoutingInfo, TicketInfo},
+        executor::fa_withdraw::{FaWithdraw, RoutingInfo, TicketInfo},
+        operation::RunFunction,
+        Error,
     };
 
-    fn create_test_request(headers: Vec<(String, String)>) -> JsResult<Request> {
-        let mut context = Context::default();
-        register_global_class::<RequestClass>(&mut context)?;
-        register_global_class::<HeadersClass>(&mut context)?;
-
-        let mut builder = http::Request::builder()
-            .method("POST")
-            .uri("jstz://test")
-            .body(Some(Vec::new()))
-            .map_err(|e| {
-                JsError::from_native(
-                    JsNativeError::error()
-                        .with_message(format!("Failed to create request: {}", e)),
-                )
-            })?;
-
-        // Set headers after building
-        let headers_map = builder.headers_mut();
-        for (key, value) in headers {
-            headers_map.insert(
-                HeaderName::from_str(&key).map_err(|e| {
-                    JsError::from_native(
-                        JsNativeError::error()
-                            .with_message(format!("Invalid header name: {}", e)),
-                    )
-                })?,
-                HeaderValue::from_str(&value).map_err(|e| {
-                    JsError::from_native(
-                        JsNativeError::error()
-                            .with_message(format!("Invalid header value: {}", e)),
-                    )
-                })?,
-            );
-        }
-
-        Request::from_http_request(builder, &mut context)
-    }
-
-    mod transfer_amount {
-        use super::*;
-        use std::ops::Deref;
-
-        struct TestRequest(Request);
-
-        impl Deref for TestRequest {
-            type Target = Request;
-
-            fn deref(&self) -> &Self::Target {
-                &self.0
-            }
-        }
-
-        fn wrap_request(request: Request) -> TestRequest {
-            TestRequest(request)
-        }
-
-        #[test]
-        fn test_valid_amount() -> JsResult<()> {
-            let request = wrap_request(create_test_request(vec![(
-                X_JSTZ_TRANSFER.to_string(),
-                "1000".to_string(),
-            )])?);
-            assert_eq!(
-                HostScript::extract_transfer_amount(&request.headers().deref())?,
-                Some(NonZeroU64::new(1000).unwrap())
-            );
-            Ok(())
-        }
-
-        #[test]
-        fn test_missing_header() -> JsResult<()> {
-            let request = wrap_request(create_test_request(vec![])?);
-            assert_eq!(
-                HostScript::extract_transfer_amount(&request.headers().deref())?,
-                None
-            );
-            Ok(())
-        }
-
-        #[test]
-        fn test_invalid_amount() -> JsResult<()> {
-            let request = wrap_request(create_test_request(vec![(
-                X_JSTZ_TRANSFER.to_string(),
-                "invalid".to_string(),
-            )])?);
-            assert!(
-                HostScript::extract_transfer_amount(&request.headers().deref()).is_err()
-            );
-            Ok(())
-        }
-    }
-
+    use super::*;
     fn withdraw_request() -> RunFunction {
         RunFunction {
             uri: Uri::try_from("jstz://jstz/withdraw").unwrap(),

--- a/crates/jstz_proto/src/executor/smart_function/mod.rs
+++ b/crates/jstz_proto/src/executor/smart_function/mod.rs
@@ -1,8 +1,8 @@
 pub(crate) mod deploy;
-pub(crate) mod host_script;
+pub(crate) mod host;
 pub(crate) mod run;
 
-pub use host_script::{JSTZ_HOST, X_JSTZ_AMOUNT, X_JSTZ_TRANSFER};
-pub use run::NOOP_PATH;
+pub use host::{FA_WITHDRAW_PATH, JSTZ_HOST, WITHDRAW_PATH};
+pub use run::{NOOP_PATH, X_JSTZ_AMOUNT, X_JSTZ_TRANSFER};
 
 pub use deploy::deploy_smart_function as deploy;

--- a/crates/jstz_proto/src/executor/smart_function/run.rs
+++ b/crates/jstz_proto/src/executor/smart_function/run.rs
@@ -1,65 +1,25 @@
-use jstz_api::http::response::Response;
-use jstz_core::{host::HostRuntime, kv::Transaction, runtime};
-use tezos_smart_rollup::prelude::debug_msg;
+use jstz_core::{host::HostRuntime, kv::Transaction};
 
-use crate::runtime::v1::{fetch, runtime_and_request_from_run_operation};
 use crate::{
     context::account::Addressable,
     error::Result,
-    operation::{OperationHash, RunFunction},
+    operation::{self, OperationHash},
     receipt::RunFunctionReceipt,
-    Error,
+    runtime,
 };
 
-/// skips the execution of the smart function for noop requests
 pub const NOOP_PATH: &str = "/-/noop";
-
-fn run_toplevel_fetch(
-    hrt: &mut impl HostRuntime,
-    tx: &mut Transaction,
-    source_address: &(impl Addressable + 'static),
-    run_operation: RunFunction,
-    operation_hash: OperationHash,
-) -> Result<RunFunctionReceipt> {
-    let gas_limit = run_operation.gas_limit;
-    let (mut rt, request) = runtime_and_request_from_run_operation(run_operation)?;
-
-    let result = {
-        let rt = &mut rt;
-        runtime::enter_js_host_context(hrt, tx, || {
-            jstz_core::future::block_on(async move {
-                let result = fetch(source_address, operation_hash, &request, rt)?;
-                rt.resolve_value(&result).await
-            })
-        })
-    }
-    .map_err(|err| {
-        if rt.instructions_remaining() == 0 {
-            Error::GasLimitExceeded
-        } else {
-            err.into()
-        }
-    })?;
-
-    debug_msg!(hrt, "🚀 Smart function executed successfully with value: {:?} (in {:?} instructions)\n", result, gas_limit - rt.instructions_remaining());
-
-    let response = Response::try_from_js(&result)?;
-    let (http_parts, body) = Response::to_http_response(&response).into_parts();
-    Ok(RunFunctionReceipt {
-        body,
-        status_code: http_parts.status,
-        headers: http_parts.headers,
-    })
-}
+pub const X_JSTZ_TRANSFER: &str = "X-JSTZ-TRANSFER";
+pub const X_JSTZ_AMOUNT: &str = "X-JSTZ-AMOUNT";
 
 pub fn execute(
     hrt: &mut impl HostRuntime,
     tx: &mut Transaction,
     source: &(impl Addressable + 'static),
-    run_operation: RunFunction,
+    run_operation: operation::RunFunction,
     operation_hash: OperationHash,
 ) -> Result<RunFunctionReceipt> {
-    run_toplevel_fetch(hrt, tx, source, run_operation, operation_hash)
+    runtime::run_toplevel_fetch(hrt, tx, source, run_operation, operation_hash)
 }
 
 #[cfg(test)]
@@ -77,10 +37,7 @@ mod test {
             account::{Account, Address},
             ticket_table::TicketTable,
         },
-        executor::smart_function::{
-            self,
-            host_script::{X_JSTZ_AMOUNT, X_JSTZ_TRANSFER},
-        },
+        executor::smart_function::{self, deploy::deploy_smart_function},
         operation::RunFunction,
         runtime::ParsedCode,
     };
@@ -104,16 +61,16 @@ mod test {
         // 1. Deploy the smart function that transfers the balance to the source
         let code = format!(
             r#"
-         const handler = async (request) => {{
-             const transferred_amount = request.headers.get("X-JSTZ-AMOUNT");
-             if (transferred_amount !== "{transfer_amount}") {{
-                 return Response.error("Invalid transferred amount");
-             }}
-             const headers = {{"X-JSTZ-TRANSFER": "{refund_amount}"}};
-             return new Response(null, {{headers}});
-         }};
-         export default handler;
-         "#
+        const handler = async (request) => {{
+            const transferred_amount = request.headers.get("X-JSTZ-AMOUNT");
+            if (transferred_amount !== "{transfer_amount}") {{
+                return Response.error("Invalid transferred amount");
+            }}
+            const headers = {{"X-JSTZ-TRANSFER": "{refund_amount}"}};
+            return new Response(null, {{headers}});
+        }};
+        export default handler;
+        "#
         );
         let parsed_code = ParsedCode::try_from(code.to_string()).unwrap();
         tx.begin();
@@ -226,14 +183,14 @@ mod test {
         // 1. Deploy the smart function that refunds the balance to the source
         let code = format!(
             r#"
-             const handler = async () => {{
-                 await fetch(new Request("jstz://{source}", {{
-                     headers: {{"X-JSTZ-TRANSFER": "{initial_balance}"}}
-                 }}));
-                 return new Response();
-             }};
-             export default handler;
-             "#
+            const handler = async () => {{
+                await fetch(new Request("jstz://{source}", {{
+                    headers: {{"X-JSTZ-TRANSFER": "{initial_balance}"}}
+                }}));
+                return new Response();
+            }};
+            export default handler;
+            "#
         );
         let parsed_code = ParsedCode::try_from(code.to_string()).unwrap();
         tx.begin();
@@ -337,17 +294,17 @@ mod test {
         tx.commit(host).unwrap();
 
         let code = r#"
-             const handler = () => {{
-                 return new Response();
-             }};
-             export default handler;
-             "#;
+            const handler = () => {{
+                return new Response();
+            }};
+            export default handler;
+            "#;
 
         // 1. Deploy smart function
         let parsed_code = ParsedCode::try_from(code.to_string()).unwrap();
         tx.begin();
         let smart_function =
-            smart_function::deploy(host, &mut tx, &source, parsed_code, 0).unwrap();
+            deploy_smart_function(host, &mut tx, &source, parsed_code, 0).unwrap();
 
         tx.commit(host).unwrap();
 
@@ -402,14 +359,14 @@ mod test {
 
         let code = format!(
             r#"
-             const handler = () => {{
-                 const headers = new Headers();
-                 return new Response(null, {{
-                     headers: {{ "X-JSTZ-AMOUNT": "{initial_balance}" }},
-                 }});
-             }};
-             export default handler;
-             "#
+            const handler = () => {{
+                const headers = new Headers();
+                return new Response(null, {{
+                    headers: {{ "X-JSTZ-AMOUNT": "{initial_balance}" }},
+                }});
+            }};
+            export default handler;
+            "#
         );
 
         // 1. Deploy smart function
@@ -445,6 +402,7 @@ mod test {
 
         assert_eq!(sf_balance_before, sf_balance_after);
         assert_eq!(source_balance_before, source_balance_after);
+
         let call_failed = match result {
             Ok(receipt) => receipt.status_code.is_server_error(),
             _ => true,
@@ -455,33 +413,33 @@ mod test {
     #[test]
     fn transfer_xtz_and_smart_function_call_is_atomic1() {
         let invalid_code = r#"
-        const handler = () => {{
-            invalid();
-        }};
-        export default handler;
-        "#;
+       const handler = () => {{
+           invalid();
+       }};
+       export default handler;
+       "#;
         transfer_xtz_and_run_erroneous_sf(invalid_code);
     }
 
     #[test]
     fn transfer_xtz_and_smart_function_call_is_atomic2() {
         let invalid_code = r#"
-        const handler = () => {{
-             return Response.error("error!");
-        }};
-        export default handler;
-        "#;
+       const handler = () => {{
+            return Response.error("error!");
+       }};
+       export default handler;
+       "#;
         transfer_xtz_and_run_erroneous_sf(invalid_code);
     }
 
     #[test]
     fn transfer_xtz_and_smart_function_call_is_atomic3() {
         let invalid_code = r#"
-        const handler = () => {{
-         return 3;
-        }};
-        export default handler;
-        "#;
+       const handler = () => {{
+        return 3;
+       }};
+       export default handler;
+       "#;
         transfer_xtz_and_run_erroneous_sf(invalid_code);
     }
 

--- a/crates/jstz_proto/src/runtime/mod.rs
+++ b/crates/jstz_proto/src/runtime/mod.rs
@@ -1,6 +1,7 @@
 pub mod v1;
 
-pub use v1::{Kv, KvValue, LogRecord, ParsedCode, ProtocolData, LOG_PREFIX};
-
+pub use v1::{
+    run_toplevel_fetch, Kv, KvValue, LogRecord, ParsedCode, ProtocolData, LOG_PREFIX,
+};
 #[cfg(feature = "riscv")]
 pub mod v2;

--- a/crates/jstz_proto/src/runtime/v1/fetch_handler.rs
+++ b/crates/jstz_proto/src/runtime/v1/fetch_handler.rs
@@ -13,7 +13,7 @@ use jstz_core::{native::JsNativeObject, runtime, Runtime};
 use crate::{
     context::account::{Account, Address, Addressable},
     error::{self, Result},
-    executor::smart_function::{host_script::HostScript, JSTZ_HOST, NOOP_PATH},
+    executor::smart_function::{JSTZ_HOST, NOOP_PATH},
     operation::{OperationHash, RunFunction},
     receipt::RunFunctionReceipt,
     request_logger::{log_request_end, log_request_start},
@@ -22,6 +22,7 @@ use crate::{
 
 use super::{
     api::{ProtocolApi, WebApi},
+    host_script::HostScript,
     script::{ParsedCode, Script},
 };
 

--- a/crates/jstz_proto/src/runtime/v1/host_script.rs
+++ b/crates/jstz_proto/src/runtime/v1/host_script.rs
@@ -1,0 +1,252 @@
+use std::num::NonZeroU64;
+
+use boa_engine::{
+    object::ErasedObject, Context, JsError, JsNativeError, JsResult, JsValue,
+};
+use boa_gc::GcRefMut;
+use http::Uri;
+use jstz_api::http::{
+    header::Headers,
+    request::Request,
+    response::{Response, ResponseClass},
+};
+use jstz_core::{native::JsNativeObject, runtime};
+
+use crate::{
+    context::account::{Account, Addressable},
+    executor::smart_function::{
+        host::execute_without_ticketer,
+        run::{X_JSTZ_AMOUNT, X_JSTZ_TRANSFER},
+    },
+    operation::RunFunction,
+};
+
+use super::fetch_handler::response_from_run_receipt;
+
+pub struct HostScript;
+
+impl HostScript {
+    pub fn run(
+        self_address: &impl Addressable,
+        request: &mut GcRefMut<'_, ErasedObject, Request>,
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        let run = run_function_from_request(request, 1)?;
+        let response = runtime::with_js_hrt_and_tx(|hrt, tx| -> JsResult<Response> {
+            // 1. Begin a new transaction
+            tx.begin();
+            // 2. Execute jstz host smart function
+            let result = execute_without_ticketer(hrt, tx, self_address, run);
+
+            // 3. Commit or rollback the transaction
+            match result {
+                Ok(run_receipt) => {
+                    if run_receipt.status_code.is_success() {
+                        tx.commit(hrt)?;
+                    } else {
+                        tx.rollback()?;
+                    }
+                    response_from_run_receipt(run_receipt, context)
+                }
+                Err(err) => {
+                    tx.rollback()?;
+                    Err(err.into())
+                }
+            }
+        })?;
+
+        let js_response = JsNativeObject::new::<ResponseClass>(response, context)?;
+        Ok(js_response.inner().clone())
+    }
+
+    /// Extracts the XTZ transfer amount from the request headers.
+    /// Returns None if the header is not present or Some(amount) if a valid amount is found.
+    pub fn extract_transfer_amount(headers: &Headers) -> JsResult<Option<NonZeroU64>> {
+        let header = headers.get(X_JSTZ_TRANSFER)?;
+
+        if header.headers.is_empty() {
+            return Ok(None);
+        }
+
+        if header.headers.len() > 1 {
+            return Err(JsError::from_native(JsNativeError::typ().with_message(
+                "Invalid transfer header: expected exactly one value",
+            )));
+        }
+
+        let amount = header.headers[0]
+            .parse::<NonZeroU64>()
+            .map(Some)
+            .map_err(|e| {
+                JsError::from_native(
+                    JsNativeError::typ()
+                        .with_message(format!("Invalid transfer amount: {}", e)),
+                )
+            })?;
+
+        Ok(amount)
+    }
+
+    fn verify_headers(headers: &Headers) -> JsResult<()> {
+        if headers.contains_key(X_JSTZ_AMOUNT) {
+            return Err(JsError::from_native(
+                JsNativeError::error()
+                    .with_message("X-JSTZ-AMOUNT header should not be present"),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Transfer xtz from `src` to `dst` if the `X_JSTZ_TRANSFER` header is present & amount > 0
+    /// On success, `X_JSTZ_TRANSFER` is set to `X_JSTZ_AMOUNT`
+    /// Rejects if `X_JSTZ_AMOUNT` is already present in the headers or transfer failed
+    pub fn handle_transfer(
+        headers: &mut Headers,
+        src: &impl Addressable,
+        dst: &impl Addressable,
+    ) -> JsResult<Option<NonZeroU64>> {
+        Self::verify_headers(headers)?;
+        let amt = match Self::extract_transfer_amount(headers)? {
+            Some(a) => a,
+            None => return Ok(None),
+        };
+        runtime::with_js_hrt_and_tx(|hrt, tx| {
+            Account::transfer(hrt, tx, src, dst, amt.into())
+                .and_then(|_| {
+                    headers.remove(X_JSTZ_TRANSFER)?;
+                    headers.append(X_JSTZ_AMOUNT, &amt.to_string())?;
+                    Ok(())
+                })
+                .map_err(|e| {
+                    JsError::from_native(
+                        JsNativeError::eval()
+                            .with_message(format!("Transfer failed: {}", e)),
+                    )
+                })
+        })?;
+        Ok(Some(amt))
+    }
+}
+
+fn run_function_from_request(
+    request_deref: &mut GcRefMut<'_, ErasedObject, Request>,
+    gas_limit: usize,
+) -> JsResult<RunFunction> {
+    let method = request_deref.method().clone();
+    let uri = Uri::try_from(request_deref.url().clone().to_string()).map_err(|_| {
+        JsError::from_native(JsNativeError::error().with_message("Invalid host"))
+    })?;
+    let body = request_deref.body().clone().to_http_body();
+    let headers = request_deref.headers().deref_mut().to_http_headers();
+    Ok(RunFunction {
+        uri,
+        method,
+        body,
+        headers,
+        gas_limit,
+    })
+}
+
+#[cfg(test)]
+mod test {
+
+    use std::str::FromStr;
+
+    use http::{HeaderName, HeaderValue};
+    use jstz_api::http::{header::HeadersClass, request::RequestClass};
+    use jstz_core::native::register_global_class;
+
+    use super::*;
+
+    fn create_test_request(headers: Vec<(String, String)>) -> JsResult<Request> {
+        let mut context = Context::default();
+        register_global_class::<RequestClass>(&mut context)?;
+        register_global_class::<HeadersClass>(&mut context)?;
+
+        let mut builder = http::Request::builder()
+            .method("POST")
+            .uri("jstz://test")
+            .body(Some(Vec::new()))
+            .map_err(|e| {
+                JsError::from_native(
+                    JsNativeError::error()
+                        .with_message(format!("Failed to create request: {}", e)),
+                )
+            })?;
+
+        // Set headers after building
+        let headers_map = builder.headers_mut();
+        for (key, value) in headers {
+            headers_map.insert(
+                HeaderName::from_str(&key).map_err(|e| {
+                    JsError::from_native(
+                        JsNativeError::error()
+                            .with_message(format!("Invalid header name: {}", e)),
+                    )
+                })?,
+                HeaderValue::from_str(&value).map_err(|e| {
+                    JsError::from_native(
+                        JsNativeError::error()
+                            .with_message(format!("Invalid header value: {}", e)),
+                    )
+                })?,
+            );
+        }
+
+        Request::from_http_request(builder, &mut context)
+    }
+
+    mod transfer_amount {
+        use super::*;
+        use std::ops::Deref;
+
+        struct TestRequest(Request);
+
+        impl Deref for TestRequest {
+            type Target = Request;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        fn wrap_request(request: Request) -> TestRequest {
+            TestRequest(request)
+        }
+
+        #[test]
+        fn test_valid_amount() -> JsResult<()> {
+            let request = wrap_request(create_test_request(vec![(
+                X_JSTZ_TRANSFER.to_string(),
+                "1000".to_string(),
+            )])?);
+            assert_eq!(
+                HostScript::extract_transfer_amount(&request.headers().deref())?,
+                Some(NonZeroU64::new(1000).unwrap())
+            );
+            Ok(())
+        }
+
+        #[test]
+        fn test_missing_header() -> JsResult<()> {
+            let request = wrap_request(create_test_request(vec![])?);
+            assert_eq!(
+                HostScript::extract_transfer_amount(&request.headers().deref())?,
+                None
+            );
+            Ok(())
+        }
+
+        #[test]
+        fn test_invalid_amount() -> JsResult<()> {
+            let request = wrap_request(create_test_request(vec![(
+                X_JSTZ_TRANSFER.to_string(),
+                "invalid".to_string(),
+            )])?);
+            assert!(
+                HostScript::extract_transfer_amount(&request.headers().deref()).is_err()
+            );
+            Ok(())
+        }
+    }
+}

--- a/crates/jstz_proto/src/runtime/v1/js_logger.rs
+++ b/crates/jstz_proto/src/runtime/v1/js_logger.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-use crate::runtime::v1::api::ProtocolData;
+use crate::runtime::ProtocolData;
 
 pub use jstz_api::js_log::{JsLog, LogData, LogLevel};
 

--- a/crates/jstz_proto/src/runtime/v1/mod.rs
+++ b/crates/jstz_proto/src/runtime/v1/mod.rs
@@ -1,11 +1,60 @@
 mod api;
 mod fetch_handler;
+mod host_script;
 mod js_logger;
 mod script;
 
 pub use api::{Kv, KvValue, ProtocolApi, ProtocolData, WebApi};
-pub use fetch_handler::{
-    fetch, response_from_run_receipt, runtime_and_request_from_run_operation,
-};
+use fetch_handler::{fetch, runtime_and_request_from_run_operation};
 pub use js_logger::{LogRecord, LOG_PREFIX};
 pub use script::ParsedCode;
+
+use jstz_api::http::response::Response;
+use jstz_core::{host::HostRuntime, kv::Transaction, runtime};
+use tezos_smart_rollup::prelude::debug_msg;
+
+use crate::{
+    context::account::Addressable,
+    error::Result,
+    operation::{OperationHash, RunFunction},
+    receipt::RunFunctionReceipt,
+    Error,
+};
+
+pub fn run_toplevel_fetch(
+    hrt: &mut impl HostRuntime,
+    tx: &mut Transaction,
+    source_address: &(impl Addressable + 'static),
+    run_operation: RunFunction,
+    operation_hash: OperationHash,
+) -> Result<RunFunctionReceipt> {
+    let gas_limit = run_operation.gas_limit;
+    let (mut rt, request) = runtime_and_request_from_run_operation(run_operation)?;
+
+    let result = {
+        let rt = &mut rt;
+        runtime::enter_js_host_context(hrt, tx, || {
+            jstz_core::future::block_on(async move {
+                let result = fetch(source_address, operation_hash, &request, rt)?;
+                rt.resolve_value(&result).await
+            })
+        })
+    }
+    .map_err(|err| {
+        if rt.instructions_remaining() == 0 {
+            Error::GasLimitExceeded
+        } else {
+            err.into()
+        }
+    })?;
+
+    debug_msg!(hrt, "🚀 Smart function executed successfully with value: {:?} (in {:?} instructions)\n", result, gas_limit - rt.instructions_remaining());
+
+    let response = Response::try_from_js(&result)?;
+    let (http_parts, body) = Response::to_http_response(&response).into_parts();
+    Ok(RunFunctionReceipt {
+        body,
+        status_code: http_parts.status,
+        headers: http_parts.headers,
+    })
+}


### PR DESCRIPTION
# Context
Since we need to support both boa and v8 in the interim, the code depending to each runtime should be factored out to allow as much re-use of runtime independent code as possible

Part of https://linear.app/tezos/issue/JSTZ-495/move-boa-runtime-to-v1-in-jstz-proto

Depends on https://github.com/jstz-dev/jstz/pull/1002
<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
Moves `host_script.rs` and `run_top_level_fetch` to v1
<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
`make build && make test`
<!-- Describe how reviewers and approvers can test this PR. -->
