### PR TITLE
feat(sequencer): implement worker skeleton

### DIFF
--- a/crates/jstz_node/src/sequencer/mod.rs
+++ b/crates/jstz_node/src/sequencer/mod.rs
@@ -1,1 +1,2 @@
 pub mod queue;
+pub mod worker;

--- a/crates/jstz_node/src/sequencer/worker.rs
+++ b/crates/jstz_node/src/sequencer/worker.rs
@@ -1,0 +1,62 @@
+use std::{
+    sync::mpsc::{channel, Sender, TryRecvError},
+    thread::{self, spawn as spawn_thread, JoinHandle},
+    time::Duration,
+};
+
+pub struct Worker {
+    thread_kill_sig: Sender<()>,
+    inner: Option<JoinHandle<()>>,
+}
+
+impl Drop for Worker {
+    fn drop(&mut self) {
+        let _ = self.thread_kill_sig.send(());
+        if let Some(h) = self.inner.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+pub fn spawn(#[cfg(test)] on_exit: impl FnOnce() + Send + 'static) -> Worker {
+    let (thread_kill_sig, rx) = channel();
+    Worker {
+        thread_kill_sig,
+        inner: Some(spawn_thread(move || loop {
+            thread::sleep(Duration::from_millis(500));
+
+            match rx.try_recv() {
+                Ok(_) | Err(TryRecvError::Disconnected) => {
+                    #[cfg(test)]
+                    on_exit();
+                    break;
+                }
+                Err(TryRecvError::Empty) => {}
+            }
+        })),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{Arc, Mutex},
+        thread,
+        time::Duration,
+    };
+
+    #[test]
+    fn worker_drop() {
+        let v = Arc::new(Mutex::new(0));
+        let cp = v.clone();
+        let worker = super::spawn(move || {
+            *cp.lock().unwrap() += 1;
+        });
+
+        drop(worker);
+
+        // to ensure that the worker has enough time to pick up the signal
+        thread::sleep(Duration::from_millis(800));
+        assert_eq!(*v.lock().unwrap(), 1);
+    }
+}


### PR DESCRIPTION
# Context

Part of JSTZ-551.

[JSTZ-551](https://linear.app/tezos/issue/JSTZ-551/create-worker)

# Description

Created a skeleton of the worker. The worker only gets created in the sequencer and runs in a separate thread and does its job periodically.

# Manually testing the PR

* Unit testing: added test cases
