### PR TITLE
feat(sequencer): make worker read from queue

### DIFF
--- a/crates/jstz_node/src/sequencer/mod.rs
+++ b/crates/jstz_node/src/sequencer/mod.rs
@@ -1,2 +1,36 @@
 pub mod queue;
 pub mod worker;
+
+#[cfg(test)]
+pub mod tests {
+    use axum::http::{HeaderMap, Method, Uri};
+    use jstz_crypto::{public_key::PublicKey, signature::Signature};
+    use jstz_proto::{
+        context::account::Nonce,
+        operation::{Content, Operation, RunFunction, SignedOperation},
+    };
+    use tezos_crypto_rs::hash::{Ed25519Signature, PublicKeyEd25519};
+
+    pub fn dummy_op() -> SignedOperation {
+        SignedOperation::new(
+        Signature::Ed25519(Ed25519Signature::from_base58_check("edsigtbD6jADoivxf1iho6mDYPGiVvXw4Hnurn6VzDLG1boyMmmHEAykSrUJjJpvEsHHjQNvLWfm9PdyMBfJ8CX7jSEkh3yrB6m").unwrap().into()),
+        Operation {
+            public_key: PublicKey::Ed25519(
+                PublicKeyEd25519::from_base58_check(
+                    "edpkuUXUFt2E51TkMjRarDEVWXGB4kLKoTryMDyMhNyxFCRTsPDd1K",
+                )
+                .unwrap()
+                .into(),
+            ),
+            nonce: Nonce(0),
+            content: Content::RunFunction(RunFunction {
+                uri: Uri::from_static("http://http://"),
+                method: Method::HEAD,
+                headers: HeaderMap::new(),
+                body: None,
+                gas_limit: 0,
+            }),
+        },
+    )
+    }
+}

--- a/crates/jstz_node/src/sequencer/queue.rs
+++ b/crates/jstz_node/src/sequencer/queue.rs
@@ -40,38 +40,8 @@ impl OperationQueue {
 
 #[cfg(test)]
 mod tests {
-    use axum::http::{HeaderMap, Method, Uri};
-    use jstz_crypto::{public_key::PublicKey, signature::Signature};
-    use jstz_proto::{
-        context::account::Nonce,
-        operation::{Content, Operation, RunFunction, SignedOperation},
-    };
-    use tezos_crypto_rs::hash::{Ed25519Signature, PublicKeyEd25519};
-
     use super::OperationQueue;
-
-    fn dummy_op() -> SignedOperation {
-        SignedOperation::new(
-            Signature::Ed25519(Ed25519Signature::from_base58_check("edsigtbD6jADoivxf1iho6mDYPGiVvXw4Hnurn6VzDLG1boyMmmHEAykSrUJjJpvEsHHjQNvLWfm9PdyMBfJ8CX7jSEkh3yrB6m").unwrap().into()),
-            Operation {
-                public_key: PublicKey::Ed25519(
-                    PublicKeyEd25519::from_base58_check(
-                        "edpkuUXUFt2E51TkMjRarDEVWXGB4kLKoTryMDyMhNyxFCRTsPDd1K",
-                    )
-                    .unwrap()
-                    .into(),
-                ),
-                nonce: Nonce(0),
-                content: Content::RunFunction(RunFunction {
-                    uri: Uri::from_static("http://http://"),
-                    method: Method::HEAD,
-                    headers: HeaderMap::new(),
-                    body: None,
-                    gas_limit: 0,
-                }),
-            },
-        )
-    }
+    use crate::sequencer::tests::dummy_op;
 
     #[test]
     fn new_queue() {


### PR DESCRIPTION
# Context

Part of JSTZ-551.

[JSTZ-551](https://linear.app/tezos/issue/JSTZ-551/create-worker)

# Description

Made the worker read from the operation queue. For now it does nothing to the operations because the runtime is not yet set up.

Also moved `dummy_op` to the sequencer module level so that it can be shared across test modules.

# Manually testing the PR

* Unit testing: added test cases
