### PR TITLE
refactor(proto): asynchronify executor::execute_operation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3009,6 +3009,7 @@ dependencies = [
  "derive_more",
  "dirs 3.0.2",
  "env_logger",
+ "futures",
  "futures-util",
  "hex",
  "jstz_api",

--- a/crates/jstz_kernel/src/inbox.rs
+++ b/crates/jstz_kernel/src/inbox.rs
@@ -195,7 +195,7 @@ fn read_transfer(
                     amount,
                     receiver,
                 };
-                logger.write_debug("Deposit: {content:?}\n");
+                logger.write_debug(format!("Deposit: {content:?}\n").as_str());
                 Some(Message::Internal(InternalMessage::Deposit(content)))
             } else {
                 None

--- a/crates/jstz_kernel/src/inbox.rs
+++ b/crates/jstz_kernel/src/inbox.rs
@@ -231,7 +231,7 @@ mod test {
     };
     use jstz_proto::{
         context::account::{Address, Addressable},
-        operation::{internal, Content, InternalOperation},
+        operation::{internal, Content, InternalOperation, Operation},
     };
     use tezos_crypto_rs::hash::{ContractKt1Hash, HashTrait, SmartRollupHash};
     use tezos_smart_rollup::types::SmartRollupAddress;
@@ -368,7 +368,8 @@ mod test {
             panic!("Expected external message, got internal message");
         };
 
-        let operation = signed.verify().expect("Failed to verify signed operation");
+        signed.verify().expect("Failed to verify signed operation");
+        let operation: Operation = signed.into();
         assert!(
             matches!(operation.content, Content::RunFunction(..)),
             "Expected RunFunction operation, got {:?}",

--- a/crates/jstz_kernel/src/lib.rs
+++ b/crates/jstz_kernel/src/lib.rs
@@ -44,7 +44,8 @@ async fn handle_message(
                 signed_operation,
                 ticketer,
                 injector,
-            );
+            )
+            .await;
             debug_msg!(hrt, "Receipt: {receipt:?}\n");
             receipt.write(hrt, tx)?
         }

--- a/crates/jstz_node/Cargo.toml
+++ b/crates/jstz_node/Cargo.toml
@@ -25,6 +25,7 @@ clap.workspace = true
 dirs.workspace = true
 derive_more.workspace = true
 env_logger.workspace = true
+futures.workspace = true
 futures-util.workspace = true
 hex.workspace = true
 jstz_api = { path = "../jstz_api" }

--- a/crates/jstz_node/src/sequencer/inbox/parsing.rs
+++ b/crates/jstz_node/src/sequencer/inbox/parsing.rs
@@ -270,7 +270,7 @@ mod test {
     use jstz_crypto::smart_function_hash::SmartFunctionHash;
     use jstz_proto::context::account::{Address, Addressable};
     use jstz_proto::operation::internal::FaDeposit;
-    use jstz_proto::operation::{Content, InternalOperation};
+    use jstz_proto::operation::{Content, InternalOperation, Operation};
     use tezos_crypto_rs::hash::{ContractKt1Hash, SmartRollupHash};
     use tezos_smart_rollup::michelson::ticket::{FA2_1Ticket, Ticket};
     use tezos_smart_rollup::michelson::{
@@ -305,7 +305,8 @@ mod test {
             panic!("Expected external message, got internal message");
         };
 
-        let operation = signed.verify().expect("Failed to verify signed operation");
+        signed.verify().expect("Failed to verify signed operation");
+        let operation: Operation = signed.into();
         assert!(
             matches!(operation.content, Content::RunFunction(..)),
             "Expected RunFunction operation, got {:?}",

--- a/crates/jstz_node/src/sequencer/runtime.rs
+++ b/crates/jstz_node/src/sequencer/runtime.rs
@@ -58,7 +58,9 @@ pub fn process_message(rt: &mut impl Runtime, op: SignedOperation) -> anyhow::Re
     let injector = read_injector(rt).ok_or(anyhow!("Revealer not found"))?;
     let mut tx = Transaction::default();
     tx.begin();
-    let receipt = execute_operation(rt, &mut tx, op, &ticketer, &injector);
+    let receipt = futures::executor::block_on(execute_operation(
+        rt, &mut tx, op, &ticketer, &injector,
+    ));
     receipt
         .write(rt, &mut tx)
         .map_err(|e| anyhow!("failed to write receipt: {e}"))?;

--- a/crates/jstz_proto/src/executor/mod.rs
+++ b/crates/jstz_proto/src/executor/mod.rs
@@ -5,8 +5,9 @@ use crate::{
     receipt::{self, Receipt},
     Error, Result,
 };
+use futures::future::FutureExt;
 use jstz_core::{host::HostRuntime, kv::Transaction, reveal_data::RevealData};
-use jstz_crypto::public_key::PublicKey;
+use jstz_crypto::{hash::Blake2b, public_key::PublicKey};
 use tezos_crypto_rs::hash::ContractKt1Hash;
 pub mod deposit;
 pub mod fa_deposit;
@@ -14,7 +15,7 @@ pub mod fa_withdraw;
 pub mod smart_function;
 pub mod withdraw;
 
-fn execute_operation_inner(
+async fn execute_operation_inner(
     hrt: &mut impl HostRuntime,
     tx: &mut Transaction,
     op: Operation,
@@ -30,26 +31,22 @@ fn execute_operation_inner(
             Ok((op_hash, receipt::ReceiptContent::DeployFunction(result)))
         }
         operation::Content::RunFunction(run) => {
-            // Temporarily block on
-            let result = futures::executor::block_on(smart_function::run::execute(
-                hrt,
-                tx,
-                &source,
-                run,
-                op_hash.clone(),
-            ))?;
+            let result =
+                smart_function::run::execute(hrt, tx, &source, run, op_hash.clone())
+                    .await?;
             Ok((op_hash, receipt::ReceiptContent::RunFunction(result)))
         }
         operation::Content::RevealLargePayload(reveal) => {
             if op.public_key != *injector {
                 return Err(Error::InvalidInjector);
             }
-            let revealed_op = RevealData::reveal_and_decode::<_, SignedOperation>(
+            let signed_op = RevealData::reveal_and_decode::<_, SignedOperation>(
                 hrt,
                 &reveal.root_hash,
-            )?
-            .verify()?;
-            revealed_op.verify_nonce(hrt, tx)?;
+            )?;
+            signed_op.verify()?;
+            signed_op.verify_nonce(hrt, tx)?;
+            let revealed_op: Operation = signed_op.into();
             if reveal.reveal_type == revealed_op.content().try_into()? {
                 return execute_operation_inner(
                     hrt,
@@ -57,7 +54,9 @@ fn execute_operation_inner(
                     revealed_op,
                     _ticketer,
                     injector,
-                );
+                )
+                .boxed_local()
+                .await;
             }
             Err(Error::RevealTypeMismatch)
         }
@@ -77,32 +76,37 @@ pub async fn execute_internal_operation(
     }
 }
 
-pub fn execute_operation(
+pub async fn execute_operation(
     hrt: &mut impl HostRuntime,
     tx: &mut Transaction,
     signed_operation: SignedOperation,
     ticketer: &ContractKt1Hash,
     injector: &PublicKey,
 ) -> Receipt {
-    let op_hash = signed_operation.hash();
-    let op: std::result::Result<Operation, Error> = signed_operation.verify();
-    let op_hash = match &op {
-        // If the operation is a reveal large payload operation, use the original operation hash
-        Ok(Operation {
-            content: Content::RevealLargePayload(reveal),
-            ..
-        }) => reveal.original_op_hash.clone(),
-        _ => op_hash,
+    let validity = signed_operation
+        .verify()
+        .and_then(|_| signed_operation.verify_nonce(hrt, tx));
+    let op = signed_operation.into();
+    let op_hash = resolve_operation_hash(&op);
+    let result = match validity {
+        Ok(_) => execute_operation_inner(hrt, tx, op, ticketer, injector).await,
+        Err(err) => Err(err),
     };
-
-    op.and_then(|op| {
-        op.verify_nonce(hrt, tx)?;
-        execute_operation_inner(hrt, tx, op, ticketer, injector)
-    })
-    .map_or_else(
+    result.map_or_else(
         |e| Receipt::new(op_hash, Err(e)),
         |(hash, content)| Receipt::new(hash, Ok(content)),
     )
+}
+
+fn resolve_operation_hash(op: &Operation) -> Blake2b {
+    match &op {
+        // If the operation is a reveal large payload operation, use the original operation hash
+        Operation {
+            content: Content::RevealLargePayload(reveal),
+            ..
+        } => reveal.original_op_hash.clone(),
+        _ => op.hash(),
+    }
 }
 
 #[cfg(test)]
@@ -219,8 +223,9 @@ mod tests {
         })
         .expect("should prepare preimages")
     }
-    #[test]
-    fn reveals_large_payload_operation() {
+
+    #[tokio::test]
+    async fn reveals_large_payload_operation() {
         let mut host = MockHost::default();
         let mut tx = Transaction::default();
         tx.begin();
@@ -230,11 +235,13 @@ mod tests {
         let root_hash = make_data_available(&mut host, deploy_op.clone());
         let rdc_op = signed_rdc_op(root_hash, pk1.clone(), sk1, deploy_op.hash());
         let ticketer = ContractKt1Hash::try_from_bytes(&[0; 20]).unwrap();
-        let receipt = execute_operation(&mut host, &mut tx, rdc_op, &ticketer, &pk1);
+        let receipt =
+            execute_operation(&mut host, &mut tx, rdc_op, &ticketer, &pk1).await;
         assert!(matches!(receipt.result, ReceiptResult::Success(_)));
     }
-    #[test]
-    fn throws_error_if_reveal_type_not_supported() {
+
+    #[tokio::test]
+    async fn throws_error_if_reveal_type_not_supported() {
         let mut host = MockHost::default();
         let mut tx = Transaction::default();
         tx.begin();
@@ -244,7 +251,8 @@ mod tests {
         let root_hash = make_data_available(&mut host, run_op.clone());
         let rdc_op = signed_rdc_op(root_hash, pk1.clone(), sk1.clone(), run_op.hash());
         let ticketer = ContractKt1Hash::try_from_bytes(&[0; 20]).unwrap();
-        let receipt = execute_operation(&mut host, &mut tx, rdc_op, &ticketer, &pk1);
+        let receipt =
+            execute_operation(&mut host, &mut tx, rdc_op, &ticketer, &pk1).await;
         println!("receipt: {:?}", receipt);
         assert!(matches!(
             receipt.result,
@@ -252,8 +260,8 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn throws_if_nonce_is_invalid() {
+    #[tokio::test]
+    async fn throws_if_nonce_is_invalid() {
         let mut host = MockHost::default();
         let mut tx = Transaction::default();
         tx.begin();
@@ -261,16 +269,18 @@ mod tests {
         let deploy_op = make_signed_op(deploy_function_content(), pk.clone(), sk.clone());
         let ticketer = ContractKt1Hash::try_from_bytes(&[0; 20]).unwrap();
         let receipt =
-            execute_operation(&mut host, &mut tx, deploy_op.clone(), &ticketer, &pk);
+            execute_operation(&mut host, &mut tx, deploy_op.clone(), &ticketer, &pk)
+                .await;
         assert!(matches!(receipt.result, ReceiptResult::Success(_)));
-        let receipt = execute_operation(&mut host, &mut tx, deploy_op, &ticketer, &pk);
+        let receipt =
+            execute_operation(&mut host, &mut tx, deploy_op, &ticketer, &pk).await;
         assert!(
             matches!(receipt.result, ReceiptResult::Failed(e) if e.contains("InvalidNonce"))
         );
     }
 
-    #[test]
-    fn throws_if_injector_is_invalid() {
+    #[tokio::test]
+    async fn throws_if_injector_is_invalid() {
         let mut host = MockHost::default();
         let mut tx = Transaction::default();
         tx.begin();
@@ -281,15 +291,15 @@ mod tests {
         let rdc_op = signed_rdc_op(root_hash, pk2.clone(), sk2, deploy_op.hash());
         let ticketer = ContractKt1Hash::try_from_bytes(&[0; 20]).unwrap();
         let receipt =
-            execute_operation(&mut host, &mut tx, rdc_op.clone(), &ticketer, &pk1);
+            execute_operation(&mut host, &mut tx, rdc_op.clone(), &ticketer, &pk1).await;
         assert!(
             matches!(receipt.clone().result, ReceiptResult::Failed(e) if e.contains("InvalidInjector"))
         );
         assert_eq!(receipt.hash().to_string(), deploy_op.hash().to_string());
     }
 
-    #[test]
-    fn run_function_with_invalid_scheme_fails() {
+    #[tokio::test]
+    async fn run_function_with_invalid_scheme_fails() {
         let mut host = MockHost::default();
         let mut tx = Transaction::default();
         tx.begin();
@@ -310,7 +320,8 @@ mod tests {
         );
         let ticketer = ContractKt1Hash::try_from_bytes(&[0; 20]).unwrap();
 
-        let receipt = execute_operation(&mut host, &mut tx, run_op, &ticketer, &pk1);
+        let receipt =
+            execute_operation(&mut host, &mut tx, run_op, &ticketer, &pk1).await;
 
         assert!(
             matches!(receipt.clone().result, ReceiptResult::Failed(e) if e.contains("InvalidScheme"))

--- a/crates/jstz_proto/src/runtime/v1/mod.rs
+++ b/crates/jstz_proto/src/runtime/v1/mod.rs
@@ -34,10 +34,8 @@ pub async fn run_toplevel_fetch(
     let result = {
         let rt = &mut rt;
         runtime::enter_js_host_context(hrt, tx, || {
-            jstz_core::future::block_on(async move {
-                let result = fetch(source_address, operation_hash, &request, rt)?;
-                rt.resolve_value(&result).await
-            })
+            let result = fetch(source_address, operation_hash, &request, rt)?;
+            rt.blocking_resolve_value(&result)
         })
     }
     .map_err(|err| {


### PR DESCRIPTION
# Context
Required for async kernel. 

Reduce review burden by only refactoring `executor::execute_operation` and its dependencies only
<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
* Make proto `executor::execute_operation` async
* The second commit fixes a bug with async resolve value that doesn't get properly hooked into the local pool
<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
1. `make build && make test` 
2. `make build-jstzd-kernel && cargo build -p jstzd` then deploy the following smart function
```
const handler = async (req) => {
    return new Response("ok")
}

export default handler;
```
finally deploy and run the smart function

<!-- Describe how reviewers and approvers can test this PR. -->
