### PR TITLE
feat(core): implicit locking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2903,6 +2903,7 @@ dependencies = [
  "hex",
  "jstz_crypto",
  "nom",
+ "parking_lot",
  "serde",
  "serde-big-array",
  "tezos-smart-rollup",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ mockito = "1.7.0"
 nix = { version = "^0.27.1", features = ["process", "signal"] }
 nom = "7.1.3"
 num-traits = "0.2.16"
-parking_lot = "0.12.1"
+parking_lot = { version = "0.12", features = ["arc_lock"] }
 predicates = "3.1.0"
 prettytable = "0.10.0"
 pretty_assertions = "1.4.1"

--- a/crates/jstz_cli/src/repl/debug_api/account.rs
+++ b/crates/jstz_cli/src/repl/debug_api/account.rs
@@ -70,7 +70,7 @@ impl AccountApi {
         let address = try_parse_smart_function_address(account.as_str())?;
 
         runtime::with_js_hrt_and_tx(|hrt, tx| -> JsResult<JsValue> {
-            match Account::function_code(hrt.deref(), tx, &address)?.as_str() {
+            match Account::function_code(hrt.deref(), tx, &address)?.deref() {
                 "" => Ok(JsValue::null()),
                 value => Ok(JsValue::String(value.to_string().into())),
             }

--- a/crates/jstz_core/Cargo.toml
+++ b/crates/jstz_core/Cargo.toml
@@ -20,6 +20,7 @@ erased-serde.workspace = true
 getrandom.workspace = true
 jstz_crypto = { path = "../jstz_crypto" }
 nom.workspace = true
+parking_lot.workspace = true
 serde.workspace = true
 serde-big-array.workspace = true
 tezos_crypto_rs.workspace = true

--- a/crates/jstz_core/src/error.rs
+++ b/crates/jstz_core/src/error.rs
@@ -10,6 +10,7 @@ pub enum KvError {
     DowncastFailed,
     TransactionStackEmpty,
     ExpectedLookupMapEntry,
+    LockPoisoned,
 }
 
 #[derive(Display, Debug, Error, From)]

--- a/crates/jstz_core/src/kv/transaction.rs
+++ b/crates/jstz_core/src/kv/transaction.rs
@@ -82,9 +82,11 @@ pub struct Transaction {
 
 impl Clone for Transaction {
     fn clone(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
-            guard: RefCell::new(Weak::new()),
+        let guard_weak = self.guard.borrow().clone();
+
+        Transaction {
+            inner: Arc::clone(&self.inner),
+            guard: RefCell::new(guard_weak),
         }
     }
 }

--- a/crates/jstz_core/src/kv/value.rs
+++ b/crates/jstz_core/src/kv/value.rs
@@ -52,20 +52,4 @@ impl BoxedValue {
     pub fn new(value: impl Value) -> Self {
         BoxedValue(Box::new(value))
     }
-
-    pub unsafe fn downcast_unchecked<T: Any>(self) -> Box<T> {
-        let raw: *mut dyn Value = Box::into_raw(self.0);
-        Box::from_raw(raw as *mut T)
-    }
-
-    pub fn downcast<T>(self) -> std::result::Result<Box<T>, Self>
-    where
-        T: Any,
-    {
-        if self.as_any().is::<T>() {
-            Ok(unsafe { self.downcast_unchecked() })
-        } else {
-            Err(self)
-        }
-    }
 }

--- a/crates/jstz_proto/src/context/ticket_table.rs
+++ b/crates/jstz_proto/src/context/ticket_table.rs
@@ -64,7 +64,7 @@ impl TicketTable {
                 Ok(amount)
             }
             Entry::Occupied(mut occupied) => {
-                let balance = occupied.get_mut();
+                let mut balance = occupied.get_mut();
                 let checked_balance = balance
                     .checked_add(amount)
                     .ok_or(crate::error::Error::BalanceOverflow)?;
@@ -88,7 +88,7 @@ impl TicketTable {
         match tx.entry::<Amount>(rt, path)? {
             Entry::Vacant(_) => Err(TicketTableError::AccountNotFound)?,
             Entry::Occupied(mut occupied) => {
-                let balance = occupied.get_mut();
+                let mut balance = occupied.get_mut();
                 if *balance < amount {
                     return Err(TicketTableError::InsufficientFunds)?;
                 }

--- a/crates/jstz_proto/src/operation.rs
+++ b/crates/jstz_proto/src/operation.rs
@@ -53,7 +53,7 @@ impl Operation {
         rt: &impl HostRuntime,
         tx: &mut Transaction,
     ) -> Result<()> {
-        let next_nonce = Account::nonce(rt, tx, &self.source())?;
+        let mut next_nonce = Account::nonce(rt, tx, &self.source())?;
 
         if self.nonce == *next_nonce {
             next_nonce.increment();
@@ -448,7 +448,7 @@ mod test {
         tx.begin();
 
         for (address, nonce) in nonces {
-            let stored_nonce = Account::nonce(hrt.rt(), &mut tx, address).unwrap();
+            let mut stored_nonce = Account::nonce(hrt.rt(), &mut tx, address).unwrap();
             *stored_nonce = *nonce;
         }
 

--- a/crates/jstz_proto/src/runtime/v1/api/kv.rs
+++ b/crates/jstz_proto/src/runtime/v1/api/kv.rs
@@ -7,6 +7,7 @@ use boa_engine::{
     JsError, JsNativeError, JsResult, JsString, JsValue, NativeFunction,
 };
 use boa_gc::{Finalize, Trace};
+use jstz_core::kv::transaction::Guarded;
 use jstz_core::{host::HostRuntime, kv::Transaction, runtime, Result};
 use jstz_crypto::smart_function_hash::SmartFunctionHash;
 use serde::{Deserialize, Serialize};
@@ -68,7 +69,7 @@ impl Kv {
         hrt: &impl HostRuntime,
         tx: &'a mut Transaction,
         key: &str,
-    ) -> Result<Option<&'a KvValue>> {
+    ) -> Result<Option<Guarded<'a, KvValue>>> {
         tx.get::<KvValue>(hrt, self.key_path(key)?)
     }
 

--- a/crates/jstz_proto/src/runtime/v1/fetch_handler.rs
+++ b/crates/jstz_proto/src/runtime/v1/fetch_handler.rs
@@ -9,6 +9,7 @@ use jstz_api::http::{
     response::{Response, ResponseBuilder, ResponseClass, ResponseOptions},
 };
 use jstz_core::{native::JsNativeObject, runtime, Runtime};
+use std::ops::Deref;
 
 use crate::{
     context::account::{Account, Address, Addressable},
@@ -168,7 +169,11 @@ pub fn fetch(
                     // 6. Load, init and run the smart function
                     let src_code =
                         runtime::with_js_hrt_and_tx(|hrt, tx| -> Result<ParsedCode> {
-                            Ok(Account::function_code(hrt, tx, &dest_address)?.clone())
+                            Ok(ParsedCode(
+                                Account::function_code(hrt, tx, &dest_address)?
+                                    .deref()
+                                    .to_string(),
+                            ))
                         })?;
 
                     log_request_start(dest_address.clone(), operation_hash.to_string());

--- a/crates/jstz_proto/src/runtime/v2/fetch.rs
+++ b/crates/jstz_proto/src/runtime/v2/fetch.rs
@@ -466,7 +466,7 @@ fn commit_or_rollback(
     tx: Arc<Mutex<Transaction>>,
     is_success: bool,
 ) -> Result<()> {
-    let mut tx = tx.lock();
+    let tx = tx.lock();
     let result = if is_success {
         tx.commit(host)
     } else {

--- a/crates/jstz_runtime/src/ext/jstz_kv/kv.rs
+++ b/crates/jstz_runtime/src/ext/jstz_kv/kv.rs
@@ -9,6 +9,7 @@
 use bincode::error::{DecodeError, EncodeError};
 use bincode::{de::Decoder, enc::Encoder, Decode, Encode};
 use jstz_core::host::HostRuntime;
+use jstz_core::kv::transaction::Guarded;
 use jstz_core::kv::Transaction;
 use serde::{Deserialize, Serialize};
 use tezos_smart_rollup::storage::path::{self, OwnedPath, RefPath};
@@ -69,7 +70,7 @@ impl Kv {
         hrt: &impl HostRuntime,
         tx: &'a mut Transaction,
         key: &str,
-    ) -> Option<&'a KvValue> {
+    ) -> Option<Guarded<'a, KvValue>> {
         tx.get::<KvValue>(hrt, self.key_path(key)?).ok()?
     }
 

--- a/crates/jstz_runtime/src/lib.rs
+++ b/crates/jstz_runtime/src/lib.rs
@@ -84,7 +84,7 @@ mod test_utils {
         ) => {
             #[allow(unused)]
             let mut init_host = tezos_smart_rollup_mock::MockHost::default();
-            let mut init_tx = jstz_core::kv::Transaction::default();
+            let init_tx = jstz_core::kv::Transaction::default();
             init_tx.begin();
             let init_tx = std::sync::Arc::new(parking_lot::FairMutex::new(init_tx));
             #[allow(unused)]

--- a/crates/jstz_runtime/tests/wpt.rs
+++ b/crates/jstz_runtime/tests/wpt.rs
@@ -273,7 +273,7 @@ fn init_runtime(host: &mut impl HostRuntime, tx: Transaction) -> JstzRuntime {
 }
 
 pub async fn run_wpt_test_harness(bundle: &Bundle) -> TestHarnessReport {
-    let mut tx = Transaction::default();
+    let tx = Transaction::default();
     tx.begin();
     let mut host = MockHost::default();
     host.set_debug_handler(std::io::empty());

--- a/flake.nix
+++ b/flake.nix
@@ -199,7 +199,7 @@
           riscvV8 = with pkgs; let
             tarball = fetchurl {
               url = "https://raw.githubusercontent.com/jstz-dev/rusty_v8/130.0.7/librusty_v8.tar.gz";
-              sha256 = "sha256-8cywAe9kofNPxCwdzdkegtlRPwlqqR986m25wvDWbyo=";
+              sha256 = "sha256-FORkogiYgyKZNibvQ7OH9lrSTwsx4Ed7rWgzPMIcP+w=";
             };
           in
             runCommand "fetch-riscv-v8" {} ''


### PR DESCRIPTION
# Context
[JSTZ-610](https://linear.app/tezos/issue/JSTZ-610/implement-guarded-for-implicit-locking)
# Description
In order to avoid having to lock/unlock transaction object once we use Arc<Mutex<...>> for sharing it across threads, this PR implements Guarded and GuardedMut. Guarded replaces references returned by Transaction and contains a reference counter of the guard and a pointer to a value from the Transaction object. We can use deref or deref_mut, to get references to the value within an unsafe block, whose safety is guaranteed since the lock stays alive while Guarded is alive. Lock gets dropped automatically, when all Guarded/GuardedMut get dropped. Additionally Transaction is modified to be a wrapper for sharing Arc<Mutex<Inner>> with Inner being the actual implementation. It also holds a non-owning reference to the lock which it can clone when its functions return Guarded/GuardedMut.

This is a temporary solution, as in later stages, Transaction will be rewritten to lock on keys rather than having to keep the lock of the whole object.
# Manual testing
```make```
