### PR TITLE
feat(core): remove static lifetime from transactions

### DIFF
--- a/crates/jstz_core/src/kv/transaction.rs
+++ b/crates/jstz_core/src/kv/transaction.rs
@@ -2,7 +2,6 @@ use std::{
     cell::RefCell,
     collections::{btree_map, BTreeMap, BTreeSet},
     marker::PhantomData,
-    mem,
     rc::{Rc, Weak},
     sync::Arc,
 };
@@ -735,18 +734,12 @@ impl<'a, T: ?Sized + 'a> std::ops::DerefMut for GuardedMut<'a, T> {
 
 #[derive(Debug, Deref, DerefMut)]
 pub struct JsTransaction {
-    inner: &'static mut Transaction,
+    inner: Transaction,
 }
 
 impl JsTransaction {
     pub fn new(tx: &mut Transaction) -> Self {
-        // SAFETY
-        // From the pov of the `JsTransaction` struct, it is permitted to cast
-        // the `tx` reference to `'static` since the lifetime of `JsTransaction`
-        // is always shorter than the lifetime of `tx`
-        let rt: &'static mut Transaction = unsafe { mem::transmute(tx) };
-
-        Self { inner: rt }
+        Self { inner: tx.clone() }
     }
 }
 

--- a/crates/jstz_runtime/src/ext/jstz_kv/mod.rs
+++ b/crates/jstz_runtime/src/ext/jstz_kv/mod.rs
@@ -13,8 +13,7 @@ pub(crate) mod extension {
         fn get(op_state: &mut OpState, #[string] key: &str) -> Option<serde_json::Value> {
             let ProtocolContext { host, tx, kv, .. } =
                 op_state.borrow_mut::<ProtocolContext>();
-            let mut tx = tx.lock();
-            kv.get(host, &mut tx, key).map(|v| v.0.clone())
+            kv.get(host, tx, key).map(|v| v.0.clone())
         }
 
         #[static_method]
@@ -25,8 +24,7 @@ pub(crate) mod extension {
         ) -> bool {
             let ProtocolContext { tx, kv, .. } =
                 &mut op_state.borrow_mut::<ProtocolContext>();
-            let mut tx = tx.lock();
-            kv.set(&mut tx, key, KvValue(value)).is_some()
+            kv.set(tx, key, KvValue(value)).is_some()
         }
 
         #[fast]
@@ -34,8 +32,7 @@ pub(crate) mod extension {
         fn delete(op_state: &mut OpState, #[string] key: &str) -> bool {
             let ProtocolContext { tx, kv, .. } =
                 &mut op_state.borrow_mut::<ProtocolContext>();
-            let mut tx = tx.lock();
-            kv.delete(&mut tx, key).is_some()
+            kv.delete(tx, key).is_some()
         }
 
         #[fast]
@@ -43,8 +40,7 @@ pub(crate) mod extension {
         fn contains(op_state: &mut OpState, #[string] key: &str) -> bool {
             let ProtocolContext { tx, kv, host, .. } =
                 &mut op_state.borrow_mut::<ProtocolContext>();
-            let mut tx = tx.lock();
-            kv.has(host, &mut tx, key).is_some_and(|t| t)
+            kv.has(host, tx, key).is_some_and(|t| t)
         }
     }
 

--- a/crates/jstz_runtime/src/lib.rs
+++ b/crates/jstz_runtime/src/lib.rs
@@ -84,9 +84,8 @@ mod test_utils {
         ) => {
             #[allow(unused)]
             let mut init_host = tezos_smart_rollup_mock::MockHost::default();
-            let init_tx = jstz_core::kv::Transaction::default();
+            let mut init_tx = jstz_core::kv::Transaction::default();
             init_tx.begin();
-            let init_tx = std::sync::Arc::new(parking_lot::FairMutex::new(init_tx));
             #[allow(unused)]
             let module_loader = deno_core::NoopModuleLoader;
             let init_addr =
@@ -97,7 +96,7 @@ mod test_utils {
                 let module_loader = deno_core::StaticModuleLoader::with($specifier.clone(), $code);
             )?
             #[allow(unused)]
-            let protocol  = Some($crate::ProtocolContext::new(&mut init_host, init_tx.clone(), init_addr.clone()));
+            let protocol  = Some($crate::ProtocolContext::new(&mut init_host, &mut init_tx, init_addr.clone()));
             #[allow(unused)]
             let mut $runtime = $crate::JstzRuntime::new($crate::JstzRuntimeOptions {
                 protocol,

--- a/crates/jstz_runtime/src/runtime.rs
+++ b/crates/jstz_runtime/src/runtime.rs
@@ -4,9 +4,7 @@ use jstz_core::host::JsHostRuntime;
 use jstz_core::kv::Transaction;
 use jstz_crypto::hash::Hash;
 use jstz_crypto::smart_function_hash::SmartFunctionHash;
-use parking_lot::FairMutex as Mutex;
 use std::mem::ManuallyDrop;
-use std::sync::Arc;
 use std::{
     ops::{Deref, DerefMut},
     rc::Rc,
@@ -248,7 +246,7 @@ impl DerefMut for JstzRuntime {
 
 pub struct ProtocolContext {
     pub host: JsHostRuntime<'static>,
-    pub tx: Arc<Mutex<Transaction>>,
+    pub tx: Transaction,
     pub kv: Kv,
     pub address: SmartFunctionHash,
 }
@@ -256,14 +254,14 @@ pub struct ProtocolContext {
 impl ProtocolContext {
     pub fn new(
         hrt: &mut impl HostRuntime,
-        tx: Arc<Mutex<Transaction>>,
+        tx: &mut Transaction,
         address: SmartFunctionHash,
     ) -> Self {
         let host = JsHostRuntime::new(hrt);
         ProtocolContext {
             host,
-            tx,
-            kv: Kv::new(address.clone().to_base58()),
+            tx: tx.clone(),
+            kv: Kv::new(address.to_base58()),
             address,
         }
     }


### PR DESCRIPTION
# Context
[JSTZ-375](https://linear.app/tezos/issue/JSTZ-375/replace-andmut-transaction-with-arcmutextransaction)

# Description
This PR remove static lifetime from transaction, which is now possible as the Transaction was moved within Arc<Mutex<Inner>>.

# Testing
```make```
