### PR TITLE
feat(sequencer): implement inbox monitor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2221,6 +2221,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "headers-core",
+ "http 0.2.12",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http 0.2.12",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2974,6 +2998,7 @@ dependencies = [
  "axum",
  "base64 0.21.7",
  "bincode 2.0.0-rc.3",
+ "bytes",
  "clap 4.5.20",
  "derive_more",
  "dirs 3.0.2",
@@ -2983,6 +3008,7 @@ dependencies = [
  "jstz_api",
  "jstz_core",
  "jstz_crypto",
+ "jstz_kernel",
  "jstz_proto",
  "jstz_utils",
  "log",
@@ -3010,6 +3036,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "utoipa-scalar",
+ "warp",
 ]
 
 [[package]]
@@ -3368,6 +3395,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3437,6 +3474,24 @@ dependencies = [
  "serde_urlencoded",
  "similar",
  "tokio",
+]
+
+[[package]]
+name = "multer"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 0.2.12",
+ "httparse",
+ "log",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -4765,6 +4820,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4971,6 +5032,17 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -5925,6 +5997,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6023,6 +6107,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder 1.5.0",
+ "bytes",
+ "data-encoding",
+ "http 1.1.0",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.67",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6089,6 +6192,12 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-id-start"
@@ -6193,6 +6302,12 @@ dependencies = [
  "unic-ucd-ident",
  "url",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf16_iter"
@@ -6340,6 +6455,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
+]
+
+[[package]]
+name = "warp"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4378d202ff965b011c64817db11d5829506d3404edeadb61f190d111da3f231c"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "headers",
+ "http 0.2.12",
+ "hyper 0.14.31",
+ "log",
+ "mime",
+ "mime_guess",
+ "multer",
+ "percent-encoding",
+ "pin-project",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-tungstenite",
+ "tokio-util",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2995,6 +2995,8 @@ version = "0.1.1-alpha.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "async-dropper-simple",
+ "async-trait",
  "axum",
  "base64 0.21.7",
  "bincode 2.0.0-rc.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ pretty_assertions = "1.4.1"
 proptest = "1.1"
 rand = "0.8"
 regex = "1"
-reqwest = { version = "0.11.24", features = ["json", "blocking"] }
+reqwest = { version = "0.11.24", features = ["json", "blocking","stream"] }
 reqwest-eventsource = "0.5.0"
 rexpect = "0.6.0"
 rust_decimal = "1.37.1"
@@ -121,6 +121,7 @@ utoipa = { version = "5.1.3", features = ["axum_extras", "url"] }
 utoipa-axum = "0.1.1"
 utoipa-scalar = { version = "0.2.0", features = ["axum"] }
 wasm-bindgen = "0.2.92"
+warp = "0.3.7"
 
 [workspace.dependencies.deno_fetch_base]
 git = "https://github.com/jstz-dev/deno"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,8 +120,8 @@ urlpattern = "0.2.0"
 utoipa = { version = "5.1.3", features = ["axum_extras", "url"] }
 utoipa-axum = "0.1.1"
 utoipa-scalar = { version = "0.2.0", features = ["axum"] }
-wasm-bindgen = "0.2.92"
 warp = "0.3.7"
+wasm-bindgen = "0.2.92"
 
 [workspace.dependencies.deno_fetch_base]
 git = "https://github.com/jstz-dev/deno"

--- a/crates/jstz_kernel/src/inbox.rs
+++ b/crates/jstz_kernel/src/inbox.rs
@@ -1,4 +1,4 @@
-use jstz_core::BinEncodable;
+use jstz_core::{host::WriteDebug, BinEncodable};
 use jstz_proto::context::account::Address;
 use jstz_proto::operation::{external::Deposit, ExternalOperation, SignedOperation};
 use num_traits::ToPrimitive;
@@ -13,8 +13,6 @@ pub use tezos_smart_rollup::{
     prelude::{debug_msg, Runtime},
     types::{self, Contract},
 };
-
-pub use jstz_core::host::WriteDebug;
 
 use crate::parsing::try_parse_fa_deposit;
 

--- a/crates/jstz_kernel/src/inbox.rs
+++ b/crates/jstz_kernel/src/inbox.rs
@@ -1,4 +1,4 @@
-use jstz_core::{host::WriteDebug, BinEncodable};
+use jstz_core::BinEncodable;
 use jstz_proto::context::account::Address;
 use jstz_proto::operation::{external::Deposit, ExternalOperation, SignedOperation};
 use num_traits::ToPrimitive;
@@ -13,6 +13,8 @@ pub use tezos_smart_rollup::{
     prelude::{debug_msg, Runtime},
     types::{self, Contract},
 };
+
+pub use jstz_core::host::WriteDebug;
 
 use crate::parsing::try_parse_fa_deposit;
 

--- a/crates/jstz_node/Cargo.toml
+++ b/crates/jstz_node/Cargo.toml
@@ -15,6 +15,8 @@ include = ["openapi.json", "src", "tests"]
 
 [dependencies]
 anyhow.workspace = true
+async-dropper-simple.workspace = true
+async-trait.workspace = true
 axum.workspace = true
 base64.workspace = true
 bincode.workspace = true

--- a/crates/jstz_node/Cargo.toml
+++ b/crates/jstz_node/Cargo.toml
@@ -18,6 +18,7 @@ anyhow.workspace = true
 axum.workspace = true
 base64.workspace = true
 bincode.workspace = true
+bytes.workspace = true
 clap.workspace = true
 dirs.workspace = true
 derive_more.workspace = true
@@ -27,6 +28,7 @@ hex.workspace = true
 jstz_api = { path = "../jstz_api" }
 jstz_core = { path = "../jstz_core" }
 jstz_crypto = { path = "../jstz_crypto" }
+jstz_kernel = { path = "../jstz_kernel" }
 jstz_proto = { path = "../jstz_proto" }
 jstz_utils = { path = "../jstz_utils" }
 log.workspace = true
@@ -57,6 +59,7 @@ utoipa-scalar.workspace = true
 [dev-dependencies]
 assert_cmd.workspace = true
 pretty_assertions.workspace = true
+warp.workspace = true
 
 [[bin]]
 name = "jstz-node"

--- a/crates/jstz_node/src/sequencer/inbox.rs
+++ b/crates/jstz_node/src/sequencer/inbox.rs
@@ -1,0 +1,209 @@
+use std::{
+    io,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
+
+use crate::sequencer::queue::OperationQueue;
+use anyhow::Result;
+use bytes::Bytes;
+use futures_util::{Stream, TryStreamExt};
+use serde::Deserialize;
+#[cfg(test)]
+use std::future::Future;
+use tokio::{select, task::JoinHandle};
+use tokio_stream::StreamExt;
+use tokio_util::{
+    codec::{FramedRead, LinesCodec},
+    io::StreamReader,
+    sync::CancellationToken,
+};
+
+pub struct Monitor {
+    inner: Option<JoinHandle<()>>,
+    kill_sig: CancellationToken,
+}
+
+impl Monitor {
+    pub async fn shut_down(&mut self) {
+        self.kill_sig.cancel();
+        if let Some(h) = self.inner.take() {
+            let _ = h.await;
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct MonitorBlocksResponse {
+    level: u32,
+}
+
+/// Spawn a future that monitors the L1 blocks, parse inbox messages and push into the queue.
+pub async fn spawn_monitor<
+    #[cfg(test)] Fut: Future<Output = ()> + 'static + Send,
+    #[cfg(test)] F: Fn() -> Fut + Send + 'static,
+>(
+    rollup_endpoint: String,
+    _queue: Arc<RwLock<OperationQueue>>,
+    #[cfg(test)] on_new_block: F,
+) -> Result<Monitor> {
+    // temp fix for jstzd to run locally.
+    // TODO: add logic to wait until rollup node is `healthy` in jstzd
+    #[cfg(not(test))]
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    let kill_sig = CancellationToken::new();
+    let kill_sig_clone = kill_sig.clone();
+
+    let bytes_stream = monitor_blocks(&rollup_endpoint).await?;
+    let reader = StreamReader::new(
+        bytes_stream.map_err(|e| io::Error::new(io::ErrorKind::Other, e)),
+    );
+    let mut line_stream = FramedRead::new(reader, LinesCodec::new());
+    let handle = tokio::spawn(async move {
+        loop {
+            select! {
+                _ = kill_sig_clone.cancelled() => {
+                    break;
+                }
+                result = line_stream.next() => {
+                    match result {
+                        Some(Ok(line)) => {
+                            let block = serde_json::from_str::<MonitorBlocksResponse>(&line).unwrap();
+                            //TODO: fetch inbox messages and place into the queue
+                            println!("block level: {}\n", block.level);
+                            #[cfg(test)]
+                            on_new_block().await;
+                        }
+                        Some(Err(_)) => {
+                            //TODO: handle restart logic in case there's a stream error.
+                            break;
+                        }
+                        _ => unreachable!()
+                    }
+                }
+            }
+        }
+    });
+
+    Ok(Monitor {
+        inner: Some(handle),
+        kill_sig,
+    })
+}
+
+/// Establishes a streaming connection to monitor new blocks from the rollup node.
+/// Returns a stream of bytes that can be parsed into block information.
+pub async fn monitor_blocks(
+    rollup_endpoint: &str,
+) -> Result<impl Stream<Item = Result<Bytes, reqwest::Error>> + Unpin> {
+    let url = format!("{}/global/monitor_blocks", rollup_endpoint);
+    let client = reqwest::Client::builder()
+        .tcp_keepalive(Some(Duration::from_secs(10)))
+        .build()?;
+    let response = client.get(url).send().await?;
+    Ok(response.bytes_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::stream;
+    use std::{convert::Infallible, time::Duration};
+    use std::{
+        future::Future,
+        pin::Pin,
+        sync::{Arc, Mutex, RwLock},
+    };
+    use tokio::{task, time::sleep};
+    use warp::{hyper::Body, Filter};
+
+    struct MockServer(JoinHandle<()>);
+    impl Drop for MockServer {
+        fn drop(&mut self) {
+            self.0.abort();
+        }
+    }
+
+    /// mock the /global/monitor_blocks endpoint
+    fn make_mock_monitor_blocks(
+    ) -> impl warp::Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone
+    {
+        warp::path!("global" / "monitor_blocks").map(|| {
+            let delay_stream = stream::once(async {
+                sleep(Duration::from_millis(500)).await;
+                Ok::<Bytes, Infallible>(Bytes::new())
+            });
+            let data_stream = stream::iter(vec![
+                Ok::<Bytes, Infallible>(Bytes::from("{\"level\": 123}\n")),
+                Ok::<Bytes, Infallible>(Bytes::from("{\"level\": 124}\n")),
+            ]);
+            let full_stream = delay_stream.chain(data_stream);
+            warp::reply::Response::new(Body::wrap_stream(full_stream))
+        })
+    }
+
+    fn make_mock_server() -> (String, MockServer) {
+        let filter = make_mock_monitor_blocks();
+        let (addr, server) = warp::serve(filter).bind_ephemeral(([127, 0, 0, 1], 0));
+        let url = format!("http://{}", addr);
+        (url, MockServer(task::spawn(server)))
+    }
+
+    fn make_on_new_block() -> (
+        Arc<Mutex<i32>>,
+        impl Fn() -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + 'static,
+    ) {
+        let counter = Arc::new(Mutex::new(0));
+        let counter_clone = counter.clone();
+        let on_new_block = move || {
+            let counter_clone = counter_clone.clone();
+            Box::pin(async move {
+                let mut value = counter_clone.lock().unwrap();
+                *value += 1;
+            })
+        } as Pin<Box<dyn Future<Output = ()> + Send>>;
+        (counter, on_new_block)
+    }
+
+    #[tokio::test]
+    async fn test_monitor_blocks() {
+        let (endpoint, _server) = make_mock_server();
+
+        let mut stream = monitor_blocks(&endpoint).await.unwrap();
+
+        // Read and parse first block
+        let bytes = stream.next().await.unwrap().unwrap();
+        let line = String::from_utf8(bytes.to_vec()).unwrap();
+        let block: MonitorBlocksResponse = serde_json::from_str(&line).unwrap();
+        assert_eq!(block.level, 123);
+
+        // Read and parse second block
+        let bytes = stream.next().await.unwrap().unwrap();
+        let line = String::from_utf8(bytes.to_vec()).unwrap();
+        let block: MonitorBlocksResponse = serde_json::from_str(&line).unwrap();
+        assert_eq!(block.level, 124);
+    }
+
+    #[tokio::test]
+    async fn test_spawn_shuts_down() {
+        let (endpoint, _server) = make_mock_server();
+        let q = Arc::new(RwLock::new(OperationQueue::new(0)));
+        let (counter, on_new_block) = make_on_new_block();
+        let mut monitor = spawn_monitor(endpoint.clone(), q.clone(), on_new_block)
+            .await
+            .unwrap();
+        monitor.shut_down().await;
+        assert_eq!(*counter.lock().unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_spawn() {
+        let (endpoint, _server) = make_mock_server();
+        let q = Arc::new(RwLock::new(OperationQueue::new(0)));
+        let (counter, on_new_block) = make_on_new_block();
+        // give enough time for block to progress
+        let _ = spawn_monitor(endpoint, q, on_new_block).await.unwrap();
+        sleep(Duration::from_millis(800)).await;
+        assert_eq!(*counter.lock().unwrap(), 2);
+    }
+}

--- a/crates/jstz_node/src/sequencer/mod.rs
+++ b/crates/jstz_node/src/sequencer/mod.rs
@@ -1,5 +1,6 @@
 pub mod db;
 mod host;
+pub mod inbox;
 pub mod queue;
 pub mod runtime;
 pub mod worker;


### PR DESCRIPTION
# Context

[task link](https://linear.app/tezos/issue/JSTZ-589/monitor-blocks)
Part of processing the inbox messages, we need a way to monitor blocks first

# Description

* implement `Monitor` that listenens to the L1 box via the rollup node rpc
* added `warp` to mock the http streaming for testing
* added mock rpc server to the sequencer test to return dummy value

NOTE: added unit tests for the monitor instead of the jstz node server, in the future if more logic is added we can add integration test for the jstz node server but this should be enough for now. 

# Manually testing the PR

cargo test -p jstz_node

manually ran jstzd with a sequencer mode and you will be able to see the block number being printed to the console
