### PR TITLE
chore: update tezos crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5532,7 +5532,7 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 [[package]]
 name = "tezos-smart-rollup"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git?rev=9642a3e9b8e8bc3c71cbcd6f513616d4310f7552#9642a3e9b8e8bc3c71cbcd6f513616d4310f7552"
+source = "git+https://github.com/jstz-dev/tezos?rev=20b60e2b25cb9669bd9afff2a53a910f2d34bafa#20b60e2b25cb9669bd9afff2a53a910f2d34bafa"
 dependencies = [
  "hermit",
  "hex",
@@ -5554,7 +5554,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-build-utils"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git?rev=9642a3e9b8e8bc3c71cbcd6f513616d4310f7552#9642a3e9b8e8bc3c71cbcd6f513616d4310f7552"
+source = "git+https://github.com/jstz-dev/tezos?rev=20b60e2b25cb9669bd9afff2a53a910f2d34bafa#20b60e2b25cb9669bd9afff2a53a910f2d34bafa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5564,12 +5564,12 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-constants"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git?rev=9642a3e9b8e8bc3c71cbcd6f513616d4310f7552#9642a3e9b8e8bc3c71cbcd6f513616d4310f7552"
+source = "git+https://github.com/jstz-dev/tezos?rev=20b60e2b25cb9669bd9afff2a53a910f2d34bafa#20b60e2b25cb9669bd9afff2a53a910f2d34bafa"
 
 [[package]]
 name = "tezos-smart-rollup-core"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git?rev=9642a3e9b8e8bc3c71cbcd6f513616d4310f7552#9642a3e9b8e8bc3c71cbcd6f513616d4310f7552"
+source = "git+https://github.com/jstz-dev/tezos?rev=20b60e2b25cb9669bd9afff2a53a910f2d34bafa#20b60e2b25cb9669bd9afff2a53a910f2d34bafa"
 dependencies = [
  "tezos-smart-rollup-build-utils",
  "tezos-smart-rollup-constants",
@@ -5578,7 +5578,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-debug"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git?rev=9642a3e9b8e8bc3c71cbcd6f513616d4310f7552#9642a3e9b8e8bc3c71cbcd6f513616d4310f7552"
+source = "git+https://github.com/jstz-dev/tezos?rev=20b60e2b25cb9669bd9afff2a53a910f2d34bafa#20b60e2b25cb9669bd9afff2a53a910f2d34bafa"
 dependencies = [
  "tezos-smart-rollup-core",
  "tezos-smart-rollup-host",
@@ -5587,7 +5587,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-encoding"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git?rev=9642a3e9b8e8bc3c71cbcd6f513616d4310f7552#9642a3e9b8e8bc3c71cbcd6f513616d4310f7552"
+source = "git+https://github.com/jstz-dev/tezos?rev=20b60e2b25cb9669bd9afff2a53a910f2d34bafa#20b60e2b25cb9669bd9afff2a53a910f2d34bafa"
 dependencies = [
  "hex",
  "nom",
@@ -5606,7 +5606,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-entrypoint"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git?rev=9642a3e9b8e8bc3c71cbcd6f513616d4310f7552#9642a3e9b8e8bc3c71cbcd6f513616d4310f7552"
+source = "git+https://github.com/jstz-dev/tezos?rev=20b60e2b25cb9669bd9afff2a53a910f2d34bafa#20b60e2b25cb9669bd9afff2a53a910f2d34bafa"
 dependencies = [
  "cfg-if",
  "dlmalloc",
@@ -5622,7 +5622,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-host"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git?rev=9642a3e9b8e8bc3c71cbcd6f513616d4310f7552#9642a3e9b8e8bc3c71cbcd6f513616d4310f7552"
+source = "git+https://github.com/jstz-dev/tezos?rev=20b60e2b25cb9669bd9afff2a53a910f2d34bafa#20b60e2b25cb9669bd9afff2a53a910f2d34bafa"
 dependencies = [
  "tezos-smart-rollup-build-utils",
  "tezos-smart-rollup-core",
@@ -5669,7 +5669,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-macros"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git?rev=9642a3e9b8e8bc3c71cbcd6f513616d4310f7552#9642a3e9b8e8bc3c71cbcd6f513616d4310f7552"
+source = "git+https://github.com/jstz-dev/tezos?rev=20b60e2b25cb9669bd9afff2a53a910f2d34bafa#20b60e2b25cb9669bd9afff2a53a910f2d34bafa"
 dependencies = [
  "proc-macro-error2",
  "quote",
@@ -5681,7 +5681,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-mock"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git?rev=9642a3e9b8e8bc3c71cbcd6f513616d4310f7552#9642a3e9b8e8bc3c71cbcd6f513616d4310f7552"
+source = "git+https://github.com/jstz-dev/tezos?rev=20b60e2b25cb9669bd9afff2a53a910f2d34bafa#20b60e2b25cb9669bd9afff2a53a910f2d34bafa"
 dependencies = [
  "hex",
  "tezos-smart-rollup-core",
@@ -5694,7 +5694,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-panic-hook"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git?rev=9642a3e9b8e8bc3c71cbcd6f513616d4310f7552#9642a3e9b8e8bc3c71cbcd6f513616d4310f7552"
+source = "git+https://github.com/jstz-dev/tezos?rev=20b60e2b25cb9669bd9afff2a53a910f2d34bafa#20b60e2b25cb9669bd9afff2a53a910f2d34bafa"
 dependencies = [
  "rustversion",
  "tezos-smart-rollup-build-utils",
@@ -5704,7 +5704,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-storage"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git?rev=9642a3e9b8e8bc3c71cbcd6f513616d4310f7552#9642a3e9b8e8bc3c71cbcd6f513616d4310f7552"
+source = "git+https://github.com/jstz-dev/tezos?rev=20b60e2b25cb9669bd9afff2a53a910f2d34bafa#20b60e2b25cb9669bd9afff2a53a910f2d34bafa"
 dependencies = [
  "tezos-smart-rollup-core",
  "tezos-smart-rollup-debug",
@@ -5716,7 +5716,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-utils"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git?rev=9642a3e9b8e8bc3c71cbcd6f513616d4310f7552#9642a3e9b8e8bc3c71cbcd6f513616d4310f7552"
+source = "git+https://github.com/jstz-dev/tezos?rev=20b60e2b25cb9669bd9afff2a53a910f2d34bafa#20b60e2b25cb9669bd9afff2a53a910f2d34bafa"
 dependencies = [
  "clap 4.5.20",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,15 +183,15 @@ git = "https://github.com/jstz-dev/deno"
 branch = "v2.1.10-jstz"
 
 [patch.crates-io]
-tezos-smart-rollup = { git = "https://gitlab.com/tezos/tezos.git", rev = "9642a3e9b8e8bc3c71cbcd6f513616d4310f7552" }
-tezos-smart-rollup-host = { git = "https://gitlab.com/tezos/tezos.git", rev = "9642a3e9b8e8bc3c71cbcd6f513616d4310f7552" }
-tezos-smart-rollup-core = { git = "https://gitlab.com/tezos/tezos.git", rev = "9642a3e9b8e8bc3c71cbcd6f513616d4310f7552" }
-tezos-smart-rollup-mock = { git = "https://gitlab.com/tezos/tezos.git", rev = "9642a3e9b8e8bc3c71cbcd6f513616d4310f7552" }
-tezos-smart-rollup-encoding = { git = "https://gitlab.com/tezos/tezos.git", rev = "9642a3e9b8e8bc3c71cbcd6f513616d4310f7552" }
-tezos-smart-rollup-entrypoint = { git = "https://gitlab.com/tezos/tezos.git", rev = "9642a3e9b8e8bc3c71cbcd6f513616d4310f7552" }
-tezos-smart-rollup-debug = { git = "https://gitlab.com/tezos/tezos.git", rev = "9642a3e9b8e8bc3c71cbcd6f513616d4310f7552" }
-tezos-smart-rollup-panic-hook = { git = "https://gitlab.com/tezos/tezos.git", rev = "9642a3e9b8e8bc3c71cbcd6f513616d4310f7552" }
-tezos-smart-rollup-storage = { git = "https://gitlab.com/tezos/tezos.git", rev = "9642a3e9b8e8bc3c71cbcd6f513616d4310f7552" }
+tezos-smart-rollup = { git = "https://github.com/jstz-dev/tezos", rev = "20b60e2b25cb9669bd9afff2a53a910f2d34bafa" }
+tezos-smart-rollup-core = { git = "https://github.com/jstz-dev/tezos", rev = "20b60e2b25cb9669bd9afff2a53a910f2d34bafa" }
+tezos-smart-rollup-debug = { git = "https://github.com/jstz-dev/tezos", rev = "20b60e2b25cb9669bd9afff2a53a910f2d34bafa" }
+tezos-smart-rollup-encoding = { git = "https://github.com/jstz-dev/tezos", rev = "20b60e2b25cb9669bd9afff2a53a910f2d34bafa" }
+tezos-smart-rollup-entrypoint = { git = "https://github.com/jstz-dev/tezos", rev = "20b60e2b25cb9669bd9afff2a53a910f2d34bafa" }
+tezos-smart-rollup-host = { git = "https://github.com/jstz-dev/tezos", rev = "20b60e2b25cb9669bd9afff2a53a910f2d34bafa" }
+tezos-smart-rollup-mock = { git = "https://github.com/jstz-dev/tezos", rev = "20b60e2b25cb9669bd9afff2a53a910f2d34bafa" }
+tezos-smart-rollup-panic-hook = { git = "https://github.com/jstz-dev/tezos", rev = "20b60e2b25cb9669bd9afff2a53a910f2d34bafa" }
+tezos-smart-rollup-storage = { git = "https://github.com/jstz-dev/tezos", rev = "20b60e2b25cb9669bd9afff2a53a910f2d34bafa" }
 boa_ast = { git = "https://github.com/trilitech/boa.git", branch = "ajob410@fix/remove-wasm-bindgen-from-time" }
 boa_engine = { git = "https://github.com/trilitech/boa.git", branch = "ajob410@fix/remove-wasm-bindgen-from-time" }
 boa_gc = { git = "https://github.com/trilitech/boa.git", branch = "ajob410@fix/remove-wasm-bindgen-from-time" }


### PR DESCRIPTION
# Context

The `installer.wasm` file was missing in the installer client under the kernel_sdk in tezos repo , which made jstz's build process flaky.

Another part of this PR involves changes to the [tezos repo](https://github.com/jstz-dev/tezos) where the `installer.wasm` file under the installer client was added (check out branch `jstz-9642a3e9`). This branch is branched off from the same tezos commit hash jstz depends on (9642a3e9b8e8bc3c71cbcd6f513616d4310f7552)

# Description
* updated cargo.toml to use the new commit hash with updated installer.wasm file

# Manually testing the PR

make build
make test
