### PR TITLE
feat(sequencer): get subkeys

### DIFF
--- a/crates/jstz_node/src/sequencer/host.rs
+++ b/crates/jstz_node/src/sequencer/host.rs
@@ -380,9 +380,6 @@ mod tests {
         // store_has
         assert!(host.store_has(&path).unwrap().is_none());
 
-        // store_count_subkeys when prefix does not exist
-        assert!(host.store_count_subkeys(&path).is_err());
-
         // store_write
         let expected: [u8; 3] = [1, 2, 3];
         host.store_write(&path, &expected, 0).unwrap();
@@ -399,6 +396,33 @@ mod tests {
         assert_eq!(host.store_count_subkeys(&path).unwrap(), 1);
         host.store_write_all(&subkey_path, &[1, 2, 3]).unwrap();
         assert_eq!(host.store_count_subkeys(&path).unwrap(), 2);
+        for key in ["/a", "/a/b", "/a/c", "/a/d", "/a/d/e", "/b", "/c/d/e"] {
+            host.store_write_all(&RefPath::assert_from(key.as_bytes()), &[0])
+                .unwrap();
+        }
+        assert_eq!(
+            host.store_count_subkeys(&RefPath::assert_from(b"/a"))
+                .unwrap(),
+            4
+        );
+        assert_eq!(
+            host.store_count_subkeys(&RefPath::assert_from(b"/a/d"))
+                .unwrap(),
+            2
+        );
+        assert_eq!(
+            host.store_count_subkeys(&RefPath::assert_from(b"/b"))
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            host.store_count_subkeys(&RefPath::assert_from(b"/c"))
+                .unwrap(),
+            1
+        );
+        assert!(host
+            .store_count_subkeys(&RefPath::assert_from(b"/d"))
+            .is_err());
 
         // store_read
         let v = host.store_read(&path, 2, 100000).unwrap();


### PR DESCRIPTION
# Context

Part of JSTZ-601.
[JSTZ-601](https://linear.app/tezos/issue/JSTZ-601/expose-runtime-db-with-jstz-node-api)

Jstz node API needs to return data from runtime db when jstz node runs in sequencer mode.

# Description

Implemented one method `get_subkeys` to return subkeys from the runtime database and fixed the method `count_subkeys`.

I missed out some details in the previous implementation and realised that the query needs to be more complicated. For instance, for query key `/a`,

|key|should select|output|
|---|---|---|
|`/a`|Y|`""`|
|`/a/b`|Y|`"b"`|
|`/ab`|N|-
|`/b/a`|N|-
|`/a/c/d`|Y|`"c"`|

assuming that keys never have a trailing slash (not allowed in a host setup.) This means the query should select
* the target key itself
* keys with the target key as their prefix with one additional level
* keys with the target key as their prefix with two or more additional levels

and extract the immediate children. The previous `count_subkeys` query selects all keys prefixed with the target key, which essentially counts all children in the subtree and therefore is not correct.

Comments added to the method should explain how the query achieves this.

# Manually testing the PR

* Unit testing: added tests
