### PR TITLE
fix(docs): replace ~/.jstz

### DIFF
--- a/docs/architecture/accounts.md
+++ b/docs/architecture/accounts.md
@@ -8,7 +8,7 @@ Jstz works with two kinds of accounts:
 
 ## Working with user accounts
 
-User accounts are stored in the local file `~/.jstz/config.json`, including the alias, address, public key, and secret key for each account.
+User accounts are stored in the local file `~/.config/jstz/config.json`, including the alias, address, public key, and secret key for each account.
 
 ::: warning
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -21,7 +21,7 @@ This guide will instruct through how to use the command line interface for `jstz
 
 # Config
 
-<!-- In order to run `jstz` cli, you need to create a setup file in `~/.jstz/config.json` that looks as follows: -->
+<!-- In order to run `jstz` cli, you need to create a setup file in `~/.config/jstz/config.json` that looks as follows: -->
 
 ::: danger
 ⚠️ Under construction ⚠️

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -171,7 +171,7 @@ Follow these instructions to deploy the sample smart function to a local sandbox
     jstz sandbox --container start
     ```
 
-    If you see an error that says that the configuration file is improperly configured, delete the `~/.jstz/` folder and try to start the sandbox again.
+    If you see an error that says that the configuration file is improperly configured, delete the `~/.config/jstz/` folder and try to start the sandbox again.
 
     ::: tip
 

--- a/examples/call-from-web/README.md
+++ b/examples/call-from-web/README.md
@@ -21,7 +21,7 @@ Follow these steps to use it:
 
 6. Fill in the address of the deployed counter smart contract.
 
-7. Fill in the information for your Jstz account, which you can find locally at `~/.jstz/config.json`.
+7. Fill in the information for your Jstz account, which you can find locally at `~/.config/jstz/config.json`.
 
 8. Click the **Get**, **Increment**, and **Decrement** buttons and wait for the response from the smart function to appear below the buttons.
 

--- a/examples/show-tez/src/index.ts
+++ b/examples/show-tez/src/index.ts
@@ -44,7 +44,7 @@ async function main() {
     timeout: 6000,
   });
   const config = JSON.parse(
-    readFileSync(untildify("~/.jstz/config.json"), "utf-8"),
+    readFileSync(untildify("~/.config/jstz/config.json"), "utf-8"),
   );
 
   if (!config.current_alias) {


### PR DESCRIPTION
# Context

Completes JSTZ-586.
[JSTZ-586](https://linear.app/tezos/issue/JSTZ-586/replace-jstz-in-docs)

Closes #1008.

# Description

Replaced all references to `~/.jstz` with `~/.config/jstz` as the home directory for jstz has been updated. Should have been done in #923.

# Manually testing the PR

N/A
