### PR TITLE
fix(docs): remove emojis from doc titles

### DIFF
--- a/docs/api/console.md
+++ b/docs/api/console.md
@@ -1,5 +1,5 @@
 ---
-title: 🎮 Console
+title: Console
 sidebar_label: Console
 ---
 

--- a/docs/api/encoding.md
+++ b/docs/api/encoding.md
@@ -1,5 +1,5 @@
 ---
-title: 🔣 Encoding
+title: Encoding
 sidebar_label: Encoding
 ---
 

--- a/docs/api/headers.md
+++ b/docs/api/headers.md
@@ -1,5 +1,5 @@
 ---
-title: 📰 Headers
+title: Headers
 sidebar_label: Headers
 ---
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,5 +1,5 @@
 ---
-title: 🧰 API reference
+title: API reference
 sidebar_label: API reference
 ---
 

--- a/docs/api/kv.md
+++ b/docs/api/kv.md
@@ -1,5 +1,5 @@
 ---
-title: 🪣 KV
+title: KV
 sidebar_label: KV
 ---
 

--- a/docs/api/ledger.md
+++ b/docs/api/ledger.md
@@ -1,5 +1,5 @@
 ---
-title: 💰 Ledger
+title: Ledger
 sidebar_label: Ledger
 ---
 

--- a/docs/api/request.md
+++ b/docs/api/request.md
@@ -1,5 +1,5 @@
 ---
-title: 🙏 Request
+title: Request
 sidebar_label: Request
 ---
 

--- a/docs/api/response.md
+++ b/docs/api/response.md
@@ -1,5 +1,5 @@
 ---
-title: 🆗 Response
+title: Response
 sidebar_label: Response
 ---
 

--- a/docs/api/smart_function.md
+++ b/docs/api/smart_function.md
@@ -1,5 +1,5 @@
 ---
-title: 💡 SmartFunction
+title: SmartFunction
 sidebar_label: SmartFunction
 ---
 

--- a/docs/api/text_decoder.md
+++ b/docs/api/text_decoder.md
@@ -1,5 +1,5 @@
 ---
-title: 🔡 TextDecoder
+title: TextDecoder
 sidebar_label: TextDecoder
 ---
 

--- a/docs/api/text_encoder.md
+++ b/docs/api/text_encoder.md
@@ -1,5 +1,5 @@
 ---
-title: 🔣 TextEncoder
+title: TextEncoder
 sidebar_label: TextEncoder
 ---
 

--- a/docs/api/url.md
+++ b/docs/api/url.md
@@ -1,5 +1,5 @@
 ---
-title: 🔗 URL
+title: URL
 sidebar_label: URL
 ---
 

--- a/docs/api/url_pattern.md
+++ b/docs/api/url_pattern.md
@@ -1,5 +1,5 @@
 ---
-title: 🧩 URLPattern
+title: URLPattern
 sidebar_label: URLPattern
 ---
 

--- a/docs/api/url_search_params.md
+++ b/docs/api/url_search_params.md
@@ -1,5 +1,5 @@
 ---
-title: 🔍 URLSearchParams
+title: URLSearchParams
 sidebar_label: URLSearchParams
 ---
 

--- a/docs/architecture/bridge.md
+++ b/docs/architecture/bridge.md
@@ -1,5 +1,5 @@
 ---
-title: 💸 Asset bridge
+title: Asset bridge
 sidebar_label: Asset bridge
 ---
 

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -1,5 +1,5 @@
 ---
-title: 💻 Jstz CLI
+title: Jstz CLI
 sidebar_label: CLI
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,9 @@
 ---
-title: 👨‍⚖️ jstz
+title: jstz
 displayed_sidebar: documentationSidebar
 ---
 
-# 👨‍⚖️ Jstz
+# Jstz
 
 Jstz (pronounced "justice") is a JavaScript server runtime for Tezos [Smart Rollups](https://docs.tezos.com/architecture/smart-rollups) with a great developer experience.
 With Jstz, you can deploy JavaScript applications known as _smart functions_ that can act as the backend for web applications, including handling logic, storing data, and accepting and distributing payments.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,5 @@
 ---
-title: 📦 Installing Jstz
+title: Installing Jstz
 sidebar_label: Installation
 ---
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -1,5 +1,5 @@
 ---
-title: 🚀 Quick start
+title: Quick start
 sidebar_label: Quick start
 ---
 

--- a/docs/transfer.md
+++ b/docs/transfer.md
@@ -1,5 +1,5 @@
 ---
-title: 💰 Transfer
+title: Transfer
 sidebar_label: Transfer
 ---
 


### PR DESCRIPTION
The emojis in the doc page titles appear very large with Docusaurus and don't look great. This PR removes them.