### PR TITLE
fix(docs): add info on the components of Jstz

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -17,3 +17,40 @@ For more information about how Smart Rollups nodes work, see [Smart Rollups](htt
 This diagram summarizes the interaction between Jstz Smart Rollup nodes and clients:
 
 ![Diagram showing clients sending transactions to Smart Rollup nodes, which run smart function code and publish commitments to Tezos](/img/architecture.png)
+
+## Jstz components
+
+Jstz has several components that provide functionality to different elements of the Jstz ecosystem:
+
+### Jstz CLI
+
+The [Jstz CLI](/cli), available as the package [`@jstz-dev/cli`](https://www.npmjs.com/package/@jstz-dev/cli) provides commands that you can use to deploy and interact with smart functions and the sandbox locally.
+
+### Smart function SDK
+
+Smart functions must be built with the Jstz smart function SDK, [`jstz_sdk`](https://www.npmjs.com/package/jstz_sdk), to be deployed on Jstz.
+The SDK allows them to receive requests, return responses, and access the Jstz [API](/api/).
+
+### Client SDK
+
+The Jstz client SDK, [`@jstz-dev/jstz-client`](https://www.npmjs.com/package/@jstz-dev/jstz-client), is a JavaScript/TypeScript SDK that allows applications outside Jstz to:
+
+- Send requests to Jstz smart functions
+- Inspect the state of Jstz, such as getting account balances and values from the key-value store
+- Deploy smart functions
+
+### Development wallet
+
+The [Jstz dev wallet](https://github.com/jstz-dev/dev-wallet) is a web browser extension that works as a wallet, signing transactions with an account's private key.
+You can use this extension as a wallet to sign transactions on web applications for the purposes of development, but it is not yet a secure wallet to use in production applications.
+
+### `jstzd` daemon
+
+The `jstzd` daemon runs services that are necessary to run the Jstz sandbox, including:
+
+- The layer 1 bootstrap accounts that you can use to fund accounts in Jstz
+- The [bridge](/architecture/bridge) that you can use to move tez from those accounts to your Jstz accounts
+- A local version of the Jstz runtime
+
+You can use the Jstz CLI to run the sandbox or use the `jstzd` daemon directly.
+For more information, see [Sandbox](/sandbox).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,6 +5,11 @@ sidebar_label: Installation
 
 ## Download and Install
 
+Jstz has several [components](/architecture/overview#components), but the primary tool that you need to develop on Jstz is the [Jstz CLI](/cli), which is available as the package [`@jstz-dev/cli`](https://www.npmjs.com/package/@jstz-dev/cli).
+It allows you to start the Jstz sandbox, deploy smart functions to it, and interact with them.
+
+Follow these instructions to install the Jstz CLI:
+
 :::danger
 ⚠️ `jstz` is only available on Unix-based systems. ⚠️
 :::


### PR DESCRIPTION
# Context

We got some feedback that the installation instructions were confusing because it wasn't clear what specific part of Jstz you were installing.

# Description

Clarifies that you are installing the CLI and adds info that covers the main components of Jstz.

Manual rebase of https://github.com/jstz-dev/jstz/pull/954.