### PR TITLE
fix(ci): skip pushing dev docs when docs are not updated

### DIFF
--- a/.github/workflows/deploy-dev-docs.yml
+++ b/.github/workflows/deploy-dev-docs.yml
@@ -60,10 +60,14 @@ jobs:
           # This token should have write access to the target repo content and github pages over there
           token: ${{ secrets.DEV_DOC_REPO_TOKEN }}
           path: dest_repo
-      - name: setup git config
+      - name: push to destination repo
         run: |
           cd $GITHUB_WORKSPACE/dest_repo/ && find . -mindepth 1 -maxdepth 1 ! -name '.git' -type d -exec rm -rf {} +
           mv $GITHUB_WORKSPACE/docs/* $GITHUB_WORKSPACE/dest_repo/
+          if [[ ! `git status --porcelain` ]]; then
+            echo "No change in docs"
+            exit 0
+          fi
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
           git add .


### PR DESCRIPTION
# Context

Unlike Vitepress, Docusaurus does not create new builds when documentation is not updated. This failed the pipeline when it tried to push dev docs for commits that did not involve changes in docs.

# Description

Updated the `build-dev-docs` workflow such that it skips pushing to the dev docs repo when docs are untouched.

# Manually testing the PR

[Test run](https://github.com/jstz-dev/jstz/actions/runs/15532072101/job/43723073515)
