### PR TITLE
feat(sequencer): push inbox msgs into the queue

### DIFF
--- a/crates/jstz_node/src/lib.rs
+++ b/crates/jstz_node/src/lib.rs
@@ -31,7 +31,7 @@ use utoipa::OpenApi;
 use utoipa_axum::router::OpenApiRouter;
 use utoipa_scalar::{Scalar, Servable};
 pub mod config;
-mod sequencer;
+pub mod sequencer;
 
 #[derive(Clone)]
 pub struct AppState {

--- a/crates/jstz_node/src/sequencer/inbox/api.rs
+++ b/crates/jstz_node/src/sequencer/inbox/api.rs
@@ -1,9 +1,7 @@
 #![allow(dead_code)]
 use anyhow::Result;
 use futures_util::{Stream, StreamExt, TryStreamExt};
-use serde::Deserialize;
-#[cfg(test)]
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::io;
 use std::time::Duration;
 use tokio_util::codec::{FramedRead, LinesCodec};
@@ -11,8 +9,7 @@ use tokio_util::io::StreamReader;
 
 /// Response structure for block data containing inbox messages.
 /// Each message in the inbox is represented as a hex-encoded string.
-#[derive(Debug, Deserialize)]
-#[cfg_attr(test, derive(Serialize))]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct BlockResponse {
     pub messages: Vec<String>,
 }

--- a/crates/jstz_node/src/sequencer/inbox/mod.rs
+++ b/crates/jstz_node/src/sequencer/inbox/mod.rs
@@ -1,19 +1,26 @@
+#![allow(unused_variables)]
+#![allow(unreachable_code)]
 use std::sync::{Arc, RwLock};
 
-#[cfg(not(test))]
 use std::time::Duration;
 
 use crate::sequencer::queue::OperationQueue;
+use crate::sequencer::runtime::{JSTZ_ROLLUP_ADDRESS, TICKETER};
 use anyhow::Result;
+use api::BlockResponse;
 use async_dropper_simple::AsyncDrop;
 use async_trait::async_trait;
+use jstz_core::host::WriteDebug;
+use log::{debug, error};
+use parsing::{parse_inbox_message_hex, Message};
 #[cfg(test)]
 use std::future::Future;
+use tezos_crypto_rs::hash::{ContractKt1Hash, SmartRollupHash};
 use tokio::{select, task::JoinHandle};
 use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 
-mod api;
+pub mod api;
 mod parsing;
 
 #[derive(Default)]
@@ -38,13 +45,20 @@ impl AsyncDrop for Monitor {
     }
 }
 
+struct Logger;
+impl WriteDebug for Logger {
+    fn write_debug(&self, msg: &str) {
+        debug!("{msg}");
+    }
+}
+
 /// Spawn a future that monitors the L1 blocks, parses inbox messages and pushes them into the queue.
 pub async fn spawn_monitor<
     #[cfg(test)] Fut: Future<Output = ()> + 'static + Send,
     #[cfg(test)] F: Fn(u32) -> Fut + Send + 'static,
 >(
     rollup_endpoint: String,
-    _queue: Arc<RwLock<OperationQueue>>,
+    queue: Arc<RwLock<OperationQueue>>,
     #[cfg(test)] on_new_block: F,
 ) -> Result<Monitor> {
     // temp fix for jstzd to run locally.
@@ -55,6 +69,8 @@ pub async fn spawn_monitor<
     let kill_sig_clone = kill_sig.clone();
     let mut block_stream = api::monitor_blocks(&rollup_endpoint).await?;
     let handle = tokio::spawn(async move {
+        let ticketer = ContractKt1Hash::from_base58_check(TICKETER).unwrap();
+        let jstz = SmartRollupHash::from_base58_check(JSTZ_ROLLUP_ADDRESS).unwrap();
         loop {
             select! {
                 _ = kill_sig_clone.cancelled() => {
@@ -63,15 +79,18 @@ pub async fn spawn_monitor<
                 result = block_stream.next() => {
                     match result {
                         Some(Ok(block)) => {
-                            //TODO: fetch inbox messages and place into the queue
-                            println!("block level: {}\n", block.level);
                             #[cfg(test)]
-                            on_new_block(block.level).await;
+                            {
+                                on_new_block(block.level).await;
+                                continue;
+                            }
+                            let block_content = retry_fetch_block(&rollup_endpoint, block.level).await;
+                            process_inbox_messages(block_content, queue.clone(), &ticketer, &jstz).await;
                         }
                         _ => {
                             //TODO: handle the case when the stream ended/errored
                             // https://linear.app/tezos/issue/JSTZ-622/handle-retrial-when-stream-connection-is-lost
-                            println!("`monitor_blocks` stream connection lost");
+                            error!("`monitor_blocks` stream connection lost");
                             break;
                         }
                     }
@@ -86,6 +105,72 @@ pub async fn spawn_monitor<
     })
 }
 
+/// Process the inbox messages of the given block and push them into the queue.
+async fn process_inbox_messages(
+    block_content: BlockResponse,
+    queue: Arc<RwLock<OperationQueue>>,
+    ticketer: &ContractKt1Hash,
+    jstz: &SmartRollupHash,
+) {
+    let mut ops = parse_inbox_messages(block_content, ticketer, jstz);
+    while let Some(op) = ops.pop() {
+        match op {
+            Message::External(op) => loop {
+                let success = queue.write().is_ok_and(|mut q| q.insert_ref(&op).is_ok());
+                if success {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            },
+            Message::Internal(_) => {
+                // TODO: handle internal messages (deposits)
+                // https://linear.app/tezos/issue/JSTZ-637/handle-deposit-operation
+            }
+        }
+    }
+}
+
+/// parse the inbox messages into jstz operations of the given block
+fn parse_inbox_messages(
+    block: BlockResponse,
+    ticketer: &ContractKt1Hash,
+    jstz: &SmartRollupHash,
+) -> Vec<Message> {
+    block
+        .messages
+        .iter()
+        .enumerate()
+        .filter_map(|(inbox_id, inbox_msg)| {
+            parse_inbox_message_hex(&Logger, inbox_id as u32, inbox_msg, ticketer, jstz)
+        })
+        .collect()
+}
+
+// Retry fetching the block indefinitely because:
+// 1. We cannot progress without successfully fetching the block data
+// 2. The block data must eventually become available (it's part of the chain)
+// 3. Temporary network issues or API unavailability should not stop the sequencer
+// 4. The exponential backoff ensures we don't overwhelm the API
+async fn retry_fetch_block(rollup_endpoint: &str, block_level: u32) -> BlockResponse {
+    let mut attempts = 0;
+    let mut backoff = Duration::from_millis(200);
+    const MAX_BACKOFF: Duration = Duration::from_secs(5);
+    loop {
+        match api::fetch_block(rollup_endpoint, block_level).await {
+            Ok(block) => return block,
+            Err(e) => {
+                attempts += 1;
+                error!(
+                    "Retry {}: Failed to fetch block {}: {:?}",
+                    attempts, block_level, e
+                );
+                tokio::time::sleep(backoff).await;
+                backoff = std::cmp::min(backoff * 2, MAX_BACKOFF);
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -98,6 +183,12 @@ mod tests {
     };
     use tokio::task;
     use tokio::time::sleep;
+
+    fn mock_deploy_op() -> (&'static str, &'static str) {
+        let op = "0100c3ea4c18195bcfac262dcb29e3d803ae746817390000000040000000000000002c33da9518a6fce4c22a7ba352580d9097cacc9123df767adb40871cef49cbc7efebffcb4a1021b514dca58450ac9c50e221deaeb0ed2034dd36f1ae2de11f0f00000000200000000000000073c58fbff04bb1bc965986ad626d2a233e630ea253d49e1714a0bc9610c1ef450000000000000000000000000901000000000000636f6e7374204b4559203d2022636f756e746572223b0a0a636f6e73742068616e646c6572203d202829203d3e207b0a20206c657420636f756e746572203d204b762e676574284b4559293b0a2020636f6e736f6c652e6c6f672860436f756e7465723a20247b636f756e7465727d60293b0a202069662028636f756e746572203d3d3d206e756c6c29207b0a20202020636f756e746572203d20303b0a20207d20656c7365207b0a20202020636f756e7465722b2b3b0a20207d0a20204b762e736574284b45592c20636f756e746572293b0a202072657475726e206e657720526573706f6e736528293b0a7d3b0a0a6578706f72742064656661756c742068616e646c65723b0a0000000000000000";
+        let op_hash = "eea5a17541e509914c7ebe48dd862ba5b96b878522a01132fc881080278a6b83";
+        (op_hash, op)
+    }
 
     fn make_on_new_block() -> (
         Arc<Mutex<u32>>,
@@ -147,6 +238,58 @@ mod tests {
         assert_eq!(*counter.lock().unwrap(), 123);
         sleep(Duration::from_millis(400)).await;
         assert_eq!(*counter.lock().unwrap(), 124);
+    }
+
+    #[tokio::test]
+    async fn test_parse_inbox_messages() {
+        let (op_hash, op) = mock_deploy_op();
+        let q = Arc::new(RwLock::new(OperationQueue::new(2)));
+        let ticketer = ContractKt1Hash::from_base58_check(TICKETER).unwrap();
+        let jstz = SmartRollupHash::from_base58_check(JSTZ_ROLLUP_ADDRESS).unwrap();
+        let block_content = BlockResponse {
+            messages: vec![String::from("0001"), String::from(op)],
+        };
+        let msgs = parse_inbox_messages(block_content, &ticketer, &jstz);
+        assert_eq!(msgs.len(), 1);
+        matches!(&msgs[0], Message::External(op) if op.hash().to_string() == op_hash);
+    }
+
+    #[tokio::test]
+    async fn test_process_inbox_messages() {
+        let (op_hash, op) = mock_deploy_op();
+        let q = Arc::new(RwLock::new(OperationQueue::new(1)));
+        let ticketer = ContractKt1Hash::from_base58_check(TICKETER).unwrap();
+        let jstz = SmartRollupHash::from_base58_check(JSTZ_ROLLUP_ADDRESS).unwrap();
+        let block_content = BlockResponse {
+            messages: vec![
+                String::from("0001"),
+                String::from(op),
+                String::from(op),
+                String::from("0002"),
+            ],
+        };
+
+        let queue = q.clone();
+        let handle = tokio::spawn(async move {
+            let ticketer = ticketer;
+            let jstz = jstz;
+            process_inbox_messages(block_content, queue.clone(), &ticketer, &jstz).await;
+        });
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        // only one message should be in the queue to respect the limit
+        assert_eq!(q.read().unwrap().len(), 1);
+
+        let op = q.write().unwrap().pop().unwrap();
+        assert_eq!(op.hash().to_string(), op_hash);
+        assert_eq!(q.read().unwrap().len(), 0);
+
+        // the waiting operation should be added to the queue now that the previous one is processed
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(q.read().unwrap().len(), 1);
+        assert_eq!(op.hash().to_string(), op_hash);
+
+        handle.abort();
     }
 }
 

--- a/crates/jstz_node/src/sequencer/queue.rs
+++ b/crates/jstz_node/src/sequencer/queue.rs
@@ -24,6 +24,15 @@ impl OperationQueue {
         }
     }
 
+    pub fn insert_ref(&mut self, op: &SignedOperation) -> anyhow::Result<()> {
+        if self.is_full() {
+            anyhow::bail!("queue is full")
+        } else {
+            self.queue.push_back(op.clone());
+            Ok(())
+        }
+    }
+
     pub fn pop(&mut self) -> Option<SignedOperation> {
         self.queue.pop_front()
     }
@@ -33,6 +42,7 @@ impl OperationQueue {
     }
 
     #[cfg(test)]
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.queue.len()
     }
@@ -57,6 +67,16 @@ mod tests {
         assert!(q.insert(dummy_op()).is_ok());
         assert_eq!(
             q.insert(dummy_op()).unwrap_err().to_string(),
+            "queue is full"
+        );
+    }
+
+    #[test]
+    fn insert_ref() {
+        let mut q = OperationQueue::new(1);
+        assert!(q.insert_ref(&dummy_op()).is_ok());
+        assert_eq!(
+            q.insert_ref(&dummy_op()).unwrap_err().to_string(),
             "queue is full"
         );
     }

--- a/crates/jstz_node/tests/sequencer.rs
+++ b/crates/jstz_node/tests/sequencer.rs
@@ -5,6 +5,7 @@ use jstz_crypto::{
     signature::Signature,
     smart_function_hash::{Kt1Hash, SmartFunctionHash},
 };
+use jstz_node::sequencer::inbox::api::BlockResponse;
 use jstz_proto::{
     context::account::Nonce,
     operation::{Content, DeployFunction, Operation, RunFunction, SignedOperation},
@@ -34,24 +35,9 @@ impl Drop for ChildWrapper {
     }
 }
 
-fn make_mock_monitor_blocks(
-) -> impl warp::Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
-    warp::path!("global" / "monitor_blocks").map(|| {
-        let stream = stream::once(async { Ok::<Bytes, Infallible>(Bytes::new()) });
-        warp::reply::Response::new(Body::wrap_stream(stream))
-    })
-}
-
-fn make_mock_rollup_rpc_server(url: String) -> JoinHandle<()> {
-    let filter = make_mock_monitor_blocks();
-    let addr = url.parse::<std::net::SocketAddr>().unwrap();
-    let server = warp::serve(filter).bind(addr);
-    task::spawn(server)
-}
-
 const DEFAULT_ROLLUP_NODE_RPC: &str = "127.0.0.1:8932";
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn run_sequencer() {
     let tmp_dir = TempDir::new().unwrap();
     let log_file = NamedTempFile::new().unwrap();
@@ -82,6 +68,7 @@ async fn run_sequencer() {
     check_mode(&client, &base_uri).await;
     deploy_function(&client, &base_uri).await;
     call_function(&client, &base_uri).await;
+    check_inbox_op(&client, &base_uri).await;
 }
 
 async fn check_mode(client: &Client, base_uri: &str) {
@@ -151,6 +138,10 @@ async fn submit_operation(
         200
     );
 
+    poll_receipt(client, base_uri, &hash).await
+}
+
+async fn poll_receipt(client: &Client, base_uri: &str, hash: &str) -> Receipt {
     jstz_utils::poll(10, 500, || async {
         match client
             .get(format!("{base_uri}/operations/{hash}/receipt"))
@@ -204,4 +195,53 @@ async fn call_function(client: &Client, base_uri: &str) {
             headers: _
         })) if &String::from_utf8(body.clone().unwrap()).unwrap() == "this is a big function"
     ));
+}
+
+// Check if the `DeployFunction` operation inside the inbox returned by the mock server
+// is processed by the runtime.
+async fn check_inbox_op(client: &Client, base_uri: &str) {
+    let (op_hash, _) = mock_deploy_op();
+    let receipt = poll_receipt(client, base_uri, op_hash).await;
+    assert!(matches!(
+        receipt.result,
+        ReceiptResult::Success(ReceiptContent::DeployFunction(
+            DeployFunctionReceipt { address: SmartFunctionHash(Kt1Hash(addr)) }
+        )) if addr.to_base58_check() == "KT1QRH4mZ8kgMe1HhB8FR6jadJ6zQXDfAVCE"
+    ));
+}
+
+// Mocking the rollup node rpc
+
+fn make_mock_rollup_rpc_server(url: String) -> JoinHandle<()> {
+    let filter = make_mock_monitor_blocks_filter().or(make_mock_global_block_filter());
+    let addr = url.parse::<std::net::SocketAddr>().unwrap();
+    let server = warp::serve(filter).bind(addr);
+    task::spawn(server)
+}
+
+pub(crate) fn make_mock_monitor_blocks_filter(
+) -> impl warp::Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+    warp::path!("global" / "monitor_blocks").map(|| {
+        let data_stream = stream::iter(vec![Ok::<Bytes, Infallible>(Bytes::from(
+            "{\"level\": 123}\n",
+        ))]);
+        warp::reply::Response::new(Body::wrap_stream(data_stream))
+    })
+}
+
+pub(crate) fn make_mock_global_block_filter(
+) -> impl warp::Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+    warp::path!("global" / "block" / u32).map( |_| {
+        let (_,op) = mock_deploy_op();
+        let response = BlockResponse {
+            messages: vec!["0001", "0003000000006846e8232cf8fedfbc17521b6002d572d8a8146e0b51bedefb4f2fb985a2388d9478f2ab", op, "0002"].into_iter().map(String::from).collect(),
+        };
+        warp::reply::json(&response)
+    })
+}
+
+fn mock_deploy_op() -> (&'static str, &'static str) {
+    let op = "0100c3ea4c18195bcfac262dcb29e3d803ae746817390000000040000000000000002c33da9518a6fce4c22a7ba352580d9097cacc9123df767adb40871cef49cbc7efebffcb4a1021b514dca58450ac9c50e221deaeb0ed2034dd36f1ae2de11f0f00000000200000000000000073c58fbff04bb1bc965986ad626d2a233e630ea253d49e1714a0bc9610c1ef450000000000000000000000000901000000000000636f6e7374204b4559203d2022636f756e746572223b0a0a636f6e73742068616e646c6572203d202829203d3e207b0a20206c657420636f756e746572203d204b762e676574284b4559293b0a2020636f6e736f6c652e6c6f672860436f756e7465723a20247b636f756e7465727d60293b0a202069662028636f756e746572203d3d3d206e756c6c29207b0a20202020636f756e746572203d20303b0a20207d20656c7365207b0a20202020636f756e7465722b2b3b0a20207d0a20204b762e736574284b45592c20636f756e746572293b0a202072657475726e206e657720526573706f6e736528293b0a7d3b0a0a6578706f72742064656661756c742068616e646c65723b0a0000000000000000";
+    let op_hash = "eea5a17541e509914c7ebe48dd862ba5b96b878522a01132fc881080278a6b83";
+    (op_hash, op)
 }


### PR DESCRIPTION
# Context

[task link](https://linear.app/tezos/issue/JSTZ-632/push-inbox-messages-push-into-the-queue)
Part of processing the inbox messages

Next step: handling [deposit](https://linear.app/tezos/issue/JSTZ-637/handle-deposit-operation) 
# Description

* add logic to fetch the inbox of the block from the rollup node
* add logic to push the inbox ops into the queues 
* add integration test to check if the operations in the inbox is being pushed into the q

NOTE: in case of failure, the fetch of the block and the push into the queue will be retired indefinitely.  

# Manually testing the PR

```
cargo test --package jstz_node --test sequencer -- run_sequencer --exact --show-output
```
