### PR TITLE
Make sequencer worker async

### DIFF
--- a/crates/jstz_node/src/lib.rs
+++ b/crates/jstz_node/src/lib.rs
@@ -14,12 +14,10 @@ use services::{
     operations::OperationsService,
     utils,
 };
-use std::{
-    path::PathBuf,
-    sync::{Arc, RwLock},
-};
+use std::{path::PathBuf, sync::Arc};
 use tempfile::NamedTempFile;
 use tokio::net::TcpListener;
+use tokio::sync::RwLock;
 use tower_http::cors::{Any, CorsLayer};
 
 mod api_doc;

--- a/crates/jstz_node/src/lib.rs
+++ b/crates/jstz_node/src/lib.rs
@@ -31,7 +31,7 @@ use utoipa::OpenApi;
 use utoipa_axum::router::OpenApiRouter;
 use utoipa_scalar::{Scalar, Servable};
 pub mod config;
-mod sequencer;
+pub mod sequencer;
 
 #[derive(Clone)]
 pub struct AppState {

--- a/crates/jstz_node/src/sequencer/inbox/api.rs
+++ b/crates/jstz_node/src/sequencer/inbox/api.rs
@@ -1,9 +1,7 @@
 #![allow(dead_code)]
 use anyhow::Result;
 use futures_util::{Stream, StreamExt, TryStreamExt};
-use serde::Deserialize;
-#[cfg(test)]
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::io;
 use std::time::Duration;
 use tokio_util::codec::{FramedRead, LinesCodec};
@@ -11,8 +9,7 @@ use tokio_util::io::StreamReader;
 
 /// Response structure for block data containing inbox messages.
 /// Each message in the inbox is represented as a hex-encoded string.
-#[derive(Debug, Deserialize)]
-#[cfg_attr(test, derive(Serialize))]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct BlockResponse {
     pub messages: Vec<String>,
 }

--- a/crates/jstz_node/src/sequencer/inbox/mod.rs
+++ b/crates/jstz_node/src/sequencer/inbox/mod.rs
@@ -1,19 +1,26 @@
+#![allow(unused_variables)]
+#![allow(unreachable_code)]
 use std::sync::{Arc, RwLock};
 
-#[cfg(not(test))]
 use std::time::Duration;
 
 use crate::sequencer::queue::OperationQueue;
+use crate::sequencer::runtime::{JSTZ_ROLLUP_ADDRESS, TICKETER};
 use anyhow::Result;
+use api::BlockResponse;
 use async_dropper_simple::AsyncDrop;
 use async_trait::async_trait;
+use jstz_core::host::WriteDebug;
+use log::{debug, error};
+use parsing::{parse_inbox_message_hex, Message};
 #[cfg(test)]
 use std::future::Future;
+use tezos_crypto_rs::hash::{ContractKt1Hash, SmartRollupHash};
 use tokio::{select, task::JoinHandle};
 use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 
-mod api;
+pub mod api;
 mod parsing;
 
 #[derive(Default)]
@@ -38,13 +45,20 @@ impl AsyncDrop for Monitor {
     }
 }
 
+struct Logger;
+impl WriteDebug for Logger {
+    fn write_debug(&self, msg: &str) {
+        debug!("{msg}");
+    }
+}
+
 /// Spawn a future that monitors the L1 blocks, parses inbox messages and pushes them into the queue.
 pub async fn spawn_monitor<
     #[cfg(test)] Fut: Future<Output = ()> + 'static + Send,
     #[cfg(test)] F: Fn(u32) -> Fut + Send + 'static,
 >(
     rollup_endpoint: String,
-    _queue: Arc<RwLock<OperationQueue>>,
+    queue: Arc<RwLock<OperationQueue>>,
     #[cfg(test)] on_new_block: F,
 ) -> Result<Monitor> {
     // temp fix for jstzd to run locally.
@@ -55,6 +69,8 @@ pub async fn spawn_monitor<
     let kill_sig_clone = kill_sig.clone();
     let mut block_stream = api::monitor_blocks(&rollup_endpoint).await?;
     let handle = tokio::spawn(async move {
+        let ticketer = ContractKt1Hash::from_base58_check(TICKETER).unwrap();
+        let jstz = SmartRollupHash::from_base58_check(JSTZ_ROLLUP_ADDRESS).unwrap();
         loop {
             select! {
                 _ = kill_sig_clone.cancelled() => {
@@ -63,15 +79,18 @@ pub async fn spawn_monitor<
                 result = block_stream.next() => {
                     match result {
                         Some(Ok(block)) => {
-                            //TODO: fetch inbox messages and place into the queue
-                            println!("block level: {}\n", block.level);
                             #[cfg(test)]
-                            on_new_block(block.level).await;
+                            {
+                                on_new_block(block.level).await;
+                                continue;
+                            }
+                            let block_content = retry_fetch_block(&rollup_endpoint, block.level).await;
+                            process_inbox_messages(block_content, queue.clone(), &ticketer, &jstz).await;
                         }
                         _ => {
                             //TODO: handle the case when the stream ended/errored
                             // https://linear.app/tezos/issue/JSTZ-622/handle-retrial-when-stream-connection-is-lost
-                            println!("`monitor_blocks` stream connection lost");
+                            error!("`monitor_blocks` stream connection lost");
                             break;
                         }
                     }
@@ -84,6 +103,73 @@ pub async fn spawn_monitor<
         inner: Some(handle),
         kill_sig,
     })
+}
+
+/// Process the inbox messages of the given block and push them into the queue.
+async fn process_inbox_messages(
+    block_content: BlockResponse,
+    queue: Arc<RwLock<OperationQueue>>,
+    ticketer: &ContractKt1Hash,
+    jstz: &SmartRollupHash,
+) {
+    let mut ops = parse_inbox_messages(block_content, ticketer, jstz);
+    while let Some(op) = ops.pop() {
+        match op {
+            Message::External(op) => loop {
+                let success = queue.write().is_ok_and(|mut q| q.insert_ref(&op).is_ok());
+                if success {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            },
+            Message::Internal(_) => {
+                // TODO: handle internal messages (deposits)
+                // https://linear.app/tezos/issue/JSTZ-637/handle-deposit-operation
+                panic!("Internal messages not supported yet");
+            }
+        }
+    }
+}
+
+/// parse the inbox messages into jstz operations of the given block
+fn parse_inbox_messages(
+    block: BlockResponse,
+    ticketer: &ContractKt1Hash,
+    jstz: &SmartRollupHash,
+) -> Vec<Message> {
+    block
+        .messages
+        .iter()
+        .enumerate()
+        .filter_map(|(inbox_id, inbox_msg)| {
+            parse_inbox_message_hex(&Logger, inbox_id as u32, inbox_msg, ticketer, jstz)
+        })
+        .collect()
+}
+
+// Retry fetching the block indefinitely because:
+// 1. We cannot progress without successfully fetching the block data
+// 2. The block data must eventually become available (it's part of the chain)
+// 3. Temporary network issues or API unavailability should not stop the sequencer
+// 4. The exponential backoff ensures we don't overwhelm the API
+async fn retry_fetch_block(rollup_endpoint: &str, block_level: u32) -> BlockResponse {
+    let mut attempts = 0;
+    let mut backoff = Duration::from_millis(200);
+    const MAX_BACKOFF: Duration = Duration::from_secs(5);
+    loop {
+        match api::fetch_block(rollup_endpoint, block_level).await {
+            Ok(block) => return block,
+            Err(e) => {
+                attempts += 1;
+                error!(
+                    "Retry {}: Failed to fetch block {}: {:?}",
+                    attempts, block_level, e
+                );
+                tokio::time::sleep(backoff).await;
+                backoff = std::cmp::min(backoff * 2, MAX_BACKOFF);
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/jstz_node/src/sequencer/queue.rs
+++ b/crates/jstz_node/src/sequencer/queue.rs
@@ -24,6 +24,15 @@ impl OperationQueue {
         }
     }
 
+    pub fn insert_ref(&mut self, op: &SignedOperation) -> anyhow::Result<()> {
+        if self.is_full() {
+            anyhow::bail!("queue is full")
+        } else {
+            self.queue.push_back(op.clone());
+            Ok(())
+        }
+    }
+
     pub fn pop(&mut self) -> Option<SignedOperation> {
         self.queue.pop_front()
     }
@@ -33,6 +42,7 @@ impl OperationQueue {
     }
 
     #[cfg(test)]
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.queue.len()
     }
@@ -57,6 +67,16 @@ mod tests {
         assert!(q.insert(dummy_op()).is_ok());
         assert_eq!(
             q.insert(dummy_op()).unwrap_err().to_string(),
+            "queue is full"
+        );
+    }
+
+    #[test]
+    fn insert_ref() {
+        let mut q = OperationQueue::new(1);
+        assert!(q.insert_ref(&dummy_op()).is_ok());
+        assert_eq!(
+            q.insert_ref(&dummy_op()).unwrap_err().to_string(),
             "queue is full"
         );
     }

--- a/crates/jstz_node/src/services/utils.rs
+++ b/crates/jstz_node/src/services/utils.rs
@@ -44,10 +44,7 @@ impl StoreWrapper {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::{
-        path::PathBuf,
-        sync::{Arc, RwLock},
-    };
+    use std::{path::PathBuf, sync::Arc};
 
     use jstz_core::BinEncodable;
     use jstz_crypto::{
@@ -61,6 +58,7 @@ pub(crate) mod tests {
     use octez::OctezRollupClient;
     use tempfile::NamedTempFile;
     use tezos_crypto_rs::{base58::ToBase58Check, hash::ContractKt1Hash};
+    use tokio::sync::RwLock;
 
     use crate::{
         config::KeyPair,


### PR DESCRIPTION
# Context

[task link](https://linear.app/tezos/issue/JSTZ-636/make-worker-spawn-async-aware)

In preparation for [supporting deposit](https://linear.app/tezos/issue/JSTZ-637/handle-deposit-operation). The FA deposit is async.



# Description

This PR makes the worker async aware and replace the blocking lock with non blocking lock from tokio. By switching to a non blocking lock, we can now avoid blocking the entire Tokio runtime thread from the worker.

* Make the worker async aware. initialized a single threaded tokio runtime within the new thread
* Replace the std::RwLock with tokio::RwLock

NOTE: In the worker, we can use the `tokio::spawn_blocking` which spawns a standalone thread that tokio is aware of instead of initializing a new tokio runtime but for simplicity we can stick to a new runtime for now

# Manually testing the PR

existing test works
