### PR TITLE
feat(sequencer): support native deposit

### DIFF
--- a/crates/jstz_node/src/sequencer/inbox/parsing.rs
+++ b/crates/jstz_node/src/sequencer/inbox/parsing.rs
@@ -27,7 +27,7 @@ pub use tezos_smart_rollup::{
 pub type ExternalMessage = SignedOperation;
 pub type InternalMessage = InternalOperation;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Message {
     External(ExternalMessage),
     Internal(InternalMessage),

--- a/crates/jstz_node/src/sequencer/mod.rs
+++ b/crates/jstz_node/src/sequencer/mod.rs
@@ -15,10 +15,12 @@ pub mod tests {
     };
     use tezos_crypto_rs::hash::{Ed25519Signature, PublicKeyEd25519};
 
-    pub fn dummy_op() -> SignedOperation {
-        SignedOperation::new(
+    use crate::sequencer::inbox::parsing::Message;
+
+    pub fn dummy_op() -> Message {
+        let inner = SignedOperation::new(
         Signature::Ed25519(Ed25519Signature::from_base58_check("edsigtbD6jADoivxf1iho6mDYPGiVvXw4Hnurn6VzDLG1boyMmmHEAykSrUJjJpvEsHHjQNvLWfm9PdyMBfJ8CX7jSEkh3yrB6m").unwrap().into()),
-        Operation {
+         Operation {
             public_key: PublicKey::Ed25519(
                 PublicKeyEd25519::from_base58_check(
                     "edpkuUXUFt2E51TkMjRarDEVWXGB4kLKoTryMDyMhNyxFCRTsPDd1K",
@@ -35,6 +37,8 @@ pub mod tests {
                 gas_limit: 0,
             }),
         },
-    )
+    );
+
+        Message::External(inner)
     }
 }

--- a/crates/jstz_node/src/sequencer/queue.rs
+++ b/crates/jstz_node/src/sequencer/queue.rs
@@ -1,10 +1,10 @@
 use std::collections::VecDeque;
 
-use jstz_proto::operation::SignedOperation;
+use crate::sequencer::inbox::parsing::Message;
 
 pub struct OperationQueue {
     capacity: usize,
-    queue: VecDeque<SignedOperation>,
+    queue: VecDeque<Message>,
 }
 
 impl OperationQueue {
@@ -15,7 +15,7 @@ impl OperationQueue {
         }
     }
 
-    pub fn insert(&mut self, op: SignedOperation) -> anyhow::Result<()> {
+    pub fn insert(&mut self, op: Message) -> anyhow::Result<()> {
         if self.is_full() {
             anyhow::bail!("queue is full")
         } else {
@@ -24,7 +24,7 @@ impl OperationQueue {
         }
     }
 
-    pub fn insert_ref(&mut self, op: &SignedOperation) -> anyhow::Result<()> {
+    pub fn insert_ref(&mut self, op: &Message) -> anyhow::Result<()> {
         if self.is_full() {
             anyhow::bail!("queue is full")
         } else {
@@ -33,7 +33,7 @@ impl OperationQueue {
         }
     }
 
-    pub fn pop(&mut self) -> Option<SignedOperation> {
+    pub fn pop(&mut self) -> Option<Message> {
         self.queue.pop_front()
     }
 

--- a/crates/jstz_node/src/sequencer/runtime.rs
+++ b/crates/jstz_node/src/sequencer/runtime.rs
@@ -5,11 +5,16 @@ use jstz_core::kv::{Storage, Transaction};
 use jstz_crypto::{
     hash::Hash, public_key::PublicKey, smart_function_hash::SmartFunctionHash,
 };
-use jstz_proto::{executor::execute_operation, operation::SignedOperation};
+use jstz_proto::{
+    executor::{deposit, execute_operation},
+    operation::InternalOperation,
+};
 use tezos_smart_rollup::{
     prelude::{debug_msg, Runtime},
     storage::path::RefPath,
 };
+
+use crate::sequencer::inbox::parsing::Message;
 
 use super::db::Db;
 
@@ -53,14 +58,24 @@ fn read_injector(rt: &impl Runtime) -> Option<PublicKey> {
     Storage::get(rt, &INJECTOR_PATH).ok()?
 }
 
-pub fn process_message(rt: &mut impl Runtime, op: SignedOperation) -> anyhow::Result<()> {
+pub fn process_message(rt: &mut impl Runtime, op: Message) -> anyhow::Result<()> {
     let ticketer = read_ticketer(rt).ok_or(anyhow!("Ticketer not found"))?;
     let injector = read_injector(rt).ok_or(anyhow!("Revealer not found"))?;
     let mut tx = Transaction::default();
     tx.begin();
-    let receipt = futures::executor::block_on(execute_operation(
-        rt, &mut tx, op, &ticketer, &injector,
-    ));
+    let receipt = match op {
+        Message::External(op) => futures::executor::block_on(execute_operation(
+            rt, &mut tx, op, &ticketer, &injector,
+        )),
+        Message::Internal(op) => match op {
+            InternalOperation::Deposit(op) => deposit::execute(rt, &mut tx, op),
+            _ => {
+                // TODO: handle fa deposit
+                // https://linear.app/tezos/issue/JSTZ-640/fa-deposit
+                bail!("FA deposit not supported");
+            }
+        },
+    };
     receipt
         .write(rt, &mut tx)
         .map_err(|e| anyhow!("failed to write receipt: {e}"))?;
@@ -87,14 +102,14 @@ mod tests {
         smart_function_hash::{Kt1Hash, SmartFunctionHash},
     };
     use jstz_proto::{
-        context::account::{Account, Nonce, UserAccount},
+        context::account::{Account, Address, Nonce, UserAccount},
         operation::{
-            Content, DeployFunction, Operation, RevealLargePayload, RunFunction,
-            SignedOperation,
+            internal::Deposit, Content, DeployFunction, Operation, RevealLargePayload,
+            RunFunction, SignedOperation,
         },
         receipt::{
-            DeployFunctionReceipt, Receipt, ReceiptContent, ReceiptResult,
-            RunFunctionReceipt,
+            DeployFunctionReceipt, DepositReceipt, Receipt, ReceiptContent,
+            ReceiptResult, RunFunctionReceipt,
         },
         runtime::ParsedCode,
     };
@@ -124,6 +139,15 @@ mod tests {
                 content,
             },
         )
+    }
+
+    fn dummy_int_op(amount: u64, receiver: Address) -> Message {
+        let inner = InternalOperation::Deposit(Deposit {
+            inbox_id: 1,
+            amount,
+            receiver,
+        });
+        Message::Internal(inner)
     }
 
     #[test]
@@ -174,7 +198,7 @@ mod tests {
         .unwrap();
 
         // Deploy smart function
-        super::process_message(&mut h, deploy_op).unwrap();
+        super::process_message(&mut h, Message::External(deploy_op)).unwrap();
         let v = Receipt::decode(&h.store_read_all(&RefPath::assert_from(b"/jstz_receipt/843a8438af97d97e134ae10bdcf10b5a6bcbf8c7d4912e65bacf1be26a5a73c3")).unwrap()).unwrap();
         assert!(matches!(
             v.result,
@@ -184,7 +208,7 @@ mod tests {
         ));
 
         // Call smart function
-        super::process_message(&mut h, call_op).unwrap();
+        super::process_message(&mut h, Message::External(call_op)).unwrap();
         let v = Receipt::decode(&h.store_read_all(&RefPath::assert_from(b"/jstz_receipt/9b15976cc8162fe39458739de340a1a95c59a9bcff73bd3c83402fad6352396e")).unwrap()).unwrap();
         assert!(matches!(
             v.result,
@@ -208,6 +232,59 @@ mod tests {
     }
 
     #[test]
+    fn process_message_deposit() {
+        // Using a slightly complicated scenario here to check if transaction works properly.
+        let db_file = NamedTempFile::new().unwrap();
+        let db = Db::init(Some(db_file.path().to_str().unwrap())).unwrap();
+        let mut h = super::init_host(db, PathBuf::new()).unwrap();
+
+        let receiver =
+            Address::from_base58("tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx").unwrap();
+
+        let deposit_op = dummy_int_op(10, receiver);
+
+        let dst_account_path =
+            RefPath::assert_from(b"/jstz_account/tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx");
+
+        // The destination account should not exist yet
+        assert!(h.store_has(&dst_account_path).unwrap().is_none());
+
+        // Initialise the receiver account
+        h.store_write_all(
+            &RefPath::assert_from(b"/jstz_account/tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx"),
+            &Account::User(UserAccount {
+                amount: 0,
+                nonce: Nonce(0),
+            })
+            .encode()
+            .unwrap(),
+        )
+        .unwrap();
+
+        // Execute the deposit
+        super::process_message(&mut h, deposit_op).unwrap();
+        let v = Receipt::decode(&h.store_read_all(&RefPath::assert_from(b"/jstz_receipt/270c07945707b0a86fdbd6930e7bb3cae8978a3bcfb6659e8062ef39ec58c32a")).unwrap()).unwrap();
+        assert!(matches!(
+            v.result,
+            ReceiptResult::Success(ReceiptContent::Deposit(DepositReceipt {
+                updated_balance: 10,
+                ..
+            }))
+        ));
+
+        // Check if transfer is performed by the smart function
+        let account =
+            Account::decode(&h.store_read_all(&dst_account_path).unwrap()).unwrap();
+        assert!(matches!(
+            account,
+            Account::User(UserAccount {
+                amount: 10,
+                nonce: Nonce(0),
+            })
+        ));
+    }
+
+    #[test]
     fn process_message_large_payload() {
         let db_file = NamedTempFile::new().unwrap();
         let db = Db::init(Some(db_file.path().to_str().unwrap())).unwrap();
@@ -221,7 +298,7 @@ mod tests {
 
         let deploy_op = dummy_op("edsigtpNrm3AoevvFfdboe5kijt5KpQWgXeaTqDNhAYD5dta8JWXHFW6afyEeCj6QsrxXg8WdRQhxaG9TDzaQx1mnC6vyMDSJ3B", super::INJECTOR_PK,0, Content::RevealLargePayload(RevealLargePayload { root_hash: PreimageHash([0, 63, 239, 31, 253, 161, 70, 12, 58, 91, 115, 140, 145, 182, 11, 3, 108, 26, 138, 103, 65, 187, 95, 21, 194, 61, 120, 71, 168, 9, 180, 68, 117]), reveal_type: jstz_proto::operation::RevealType::DeployFunction, original_op_hash: Blake2b::try_parse("aa8216661480132414f3ddd4bccc61fffd1db9961b259efb4d4d6597d3f7f6aa".to_string()).unwrap() }));
 
-        super::process_message(&mut h, deploy_op).unwrap();
+        super::process_message(&mut h, Message::External(deploy_op)).unwrap();
         let v = Receipt::decode(&h.store_read_all(&RefPath::assert_from(b"/jstz_receipt/aa8216661480132414f3ddd4bccc61fffd1db9961b259efb4d4d6597d3f7f6aa")).unwrap()).unwrap();
         assert!(matches!(
             v.result,
@@ -232,7 +309,7 @@ mod tests {
 
         let user_public_key = "edpkuXD2CqRpWoTT8p4exrMPQYR2NqsYH3jTMeJMijHdgQqkMkzvnz";
         let call_op = dummy_op("edsigtnvb4e2nPcfadUt7VbdMgFZByP1SUAmEWVfaLAerBGazZuVqCWZ4wjNJRxZhbjnzUfdMihXuH62APQv169xQvQvkEYQKQX", user_public_key, 1, Content::RunFunction(RunFunction { uri: Uri::from_static("jstz://KT1CkPcKaAKLX1eibkkTLub84nf1uXT7FYjG/"), method: Method::GET, headers: HeaderMap::new(), body: None, gas_limit: 550000 }));
-        super::process_message(&mut h, call_op).unwrap();
+        super::process_message(&mut h, Message::External(call_op)).unwrap();
         let v = Receipt::decode(&h.store_read_all(&RefPath::assert_from(b"/jstz_receipt/e6f9a74841205885f6dd1d639afcb39de14a2350d01519edf792631e39403b75")).unwrap()).unwrap();
         assert!(matches!(
             v.result,

--- a/crates/jstz_node/src/sequencer/worker.rs
+++ b/crates/jstz_node/src/sequencer/worker.rs
@@ -79,9 +79,9 @@ mod tests {
         time::Duration,
     };
 
-    use tempfile::NamedTempFile;
-
+    use crate::sequencer::inbox::test_utils::hash_of;
     use crate::sequencer::{db::Db, queue::OperationQueue, tests::dummy_op};
+    use tempfile::NamedTempFile;
 
     #[test]
     fn worker_drop() {
@@ -106,7 +106,7 @@ mod tests {
         let db = Db::init(Some(db_file.path().to_str().unwrap())).unwrap();
         let mut q = OperationQueue::new(1);
         let op = dummy_op();
-        let receipt_key = format!("/jstz_receipt/{}", op.hash());
+        let receipt_key = format!("/jstz_receipt/{}", hash_of(&op));
         q.insert(op.clone()).unwrap();
         assert_eq!(q.len(), 1);
         assert!(!db.key_exists(&receipt_key).unwrap());

--- a/crates/jstz_node/src/services/operations.rs
+++ b/crates/jstz_node/src/services/operations.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::sync::RwLock;
 
 use crate::config::KeyPair;
+use crate::sequencer::inbox::parsing::Message;
 use crate::sequencer::queue::OperationQueue;
 use crate::services::accounts::get_account_nonce;
 use crate::RunMode;
@@ -186,7 +187,7 @@ async fn insert_operation_queue(
                 "failed to insert operation to the queue: {e}"
             ))
         })?
-        .insert(operation)
+        .insert(Message::External(operation))
         .map_err(|e| ServiceError::ServiceUnavailable(Some(e)))?;
     Ok(())
 }
@@ -290,6 +291,7 @@ mod tests {
     use tezos_crypto_rs::hash::ContractKt1Hash;
     use tower::ServiceExt;
 
+    use crate::sequencer::inbox::parsing::Message;
     use crate::services::utils::StoreWrapper;
     use crate::{
         config::KeyPair,
@@ -562,7 +564,10 @@ mod tests {
             .unwrap();
         assert_eq!(res.status(), 200);
         assert_eq!(queue.read().unwrap().len(), 1);
-        let injected_op = queue.write().unwrap().pop().unwrap();
+        let injected_op = match queue.write().unwrap().pop().unwrap() {
+            Message::External(op) => op,
+            Message::Internal(_) => panic!("invalid message type"),
+        };
         let inner = injected_op.verify_ref().unwrap();
         matches!(
             &inner.content,

--- a/crates/jstz_proto/src/operation.rs
+++ b/crates/jstz_proto/src/operation.rs
@@ -251,7 +251,7 @@ pub mod internal {
 
     use super::*;
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+    #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
     pub struct Deposit {
         // Inbox message id is unique to each message and
         // suitable as a nonce
@@ -262,7 +262,7 @@ pub mod internal {
         pub receiver: Address,
     }
 
-    #[derive(Debug, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq, Clone)]
     pub struct FaDeposit {
         // Inbox message id is unique to each message and
         // suitable as a nonce
@@ -298,7 +298,7 @@ pub mod internal {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum InternalOperation {
     Deposit(internal::Deposit),
     FaDeposit(internal::FaDeposit),


### PR DESCRIPTION
# Context

[task link](https://linear.app/tezos/issue/JSTZ-640/fa-deposit)

part of the processing inbox msgs. For now we only add support for native deposit as there is an issue with async runtime (fa deposit is async)


# Description

add support for native deposit operation. 

* make the queue take `Message` instead of `SignedOperation`. `Message` includes both External operations and Internal operations
* make the Internal operation clonable
* add unit test and integration test

# Manually testing the PR

cargo test --package jstz_node 
