### PR TITLE
feat(ci): publish to AWS for jstz.tezos.com

### DIFF
--- a/.github/workflows/deploy-dev-docs.yml
+++ b/.github/workflows/deploy-dev-docs.yml
@@ -37,39 +37,13 @@ jobs:
         run: |
           DOC_URL=https://jstz-dev.github.io DOC_BASE_URL=/dev-docs/ npm run docs:build
           touch docs/build/.nojekyll
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
         with:
-          path: docs/build
-          name: built-docs
-          retention-days: 1
-  push:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download generated template
-        uses: actions/download-artifact@v4
-        with:
-          name: built-docs
-          path: docs
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          repository: jstz-dev/dev-docs
-          ref: main
-          # This token should have write access to the target repo content and github pages over there
-          token: ${{ secrets.DEV_DOC_REPO_TOKEN }}
-          path: dest_repo
-      - name: push to destination repo
-        run: |
-          cd $GITHUB_WORKSPACE/dest_repo/ && find . -mindepth 1 -maxdepth 1 ! -name '.git' -type d -exec rm -rf {} + && find . -mindepth 1 -maxdepth 1 ! -name '.git' -type f -exec rm {} +
-          mv $GITHUB_WORKSPACE/docs/* $GITHUB_WORKSPACE/dest_repo/
-          if [[ ! `git status --porcelain` ]]; then
-            echo "No change in docs"
-            exit 0
-          fi
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<>"
-          git add .
-          git commit -m "Docs built from ${{ github.sha }}"
-          git push origin main
+          aws-access-key-id: ${{ secrets.AWS_S3_DEV_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_S3_DEV_SECRET }}
+          aws-region: eu-west-1
+      - name: Upload to AWS
+        run: aws s3 sync ./docs/build ${{ secrets.AWS_S3_DEV_PATH }} --delete
+      - name: Invalidate AWS cache
+        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_DISTRIBUTION_DEV }} --paths '/*'

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -52,27 +52,19 @@ jobs:
         with:
           node-version: 18
           cache: npm
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
       - name: Install dependencies
         run: npm ci
       - name: Build
         run: |
           npm run docs:build
           touch docs/build/.nojekyll
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
         with:
-          path: docs/build
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    needs: build
-    runs-on: ubuntu-latest
-    name: Deploy
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          aws-access-key-id: ${{ secrets.AWS_S3_PRODUCTION_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_S3_PRODUCTION_SECRET }}
+          aws-region: eu-west-1
+      - name: Upload to AWS
+        run: aws s3 sync ./docs/build ${{ secrets.AWS_S3_PRODUCTION_PATH }} --delete
+      - name: Invalidate AWS cache
+        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_DISTRIBUTION_PRODUCTION }} --paths '/*'


### PR DESCRIPTION
We have jstz.tezos.com and https://next-jstz-tezos-com.tzstaging.com/ set up for Jstz docs. To make this work we need the secrets from the workflow files to be added to this repo. I can get those secrets in the hands of someone with rights to add secrets to the repo.

For reference, this code is how we publish docs.tezos.com: https://gitlab.com/tezos/docs/-/blob/main/.github/workflows/deploy-production.yml