### PR TITLE
feat(proto): add v2 run_toplevel_fetch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2971,6 +2971,7 @@ dependencies = [
  "jstz_crypto",
  "jstz_mock",
  "jstz_proto",
+ "jstz_utils",
  "num-traits",
  "serde",
  "tezos-smart-rollup",

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ all: build test check
 build: build-cli-kernel build-jstzd-kernel
 	@cargo build $(PROFILE_OPT)
 
-build-riscv: build-cli-kernel build-jstzd-kernel
-	@cargo build $(PROFILE_OPT) --features riscv
+build-v2: build-cli-kernel build-jstzd-kernel
+	@cargo build $(PROFILE_OPT) --features riscv,v2_runtime
 
 .PHONY: build-bridge
 build-bridge:
@@ -74,6 +74,9 @@ riscv-runtime:
 .PHONY: test
 test: test-unit test-int
 
+.PHONY: test-v2
+test-v2: test-unit-v2 test-int-v2
+
 .PHONY: test-unit
 test-unit:
 # --lib only runs unit tests in library crates
@@ -85,7 +88,19 @@ test-int:
 # --test only runs a specified integration test (a test in /tests).
 #        the glob pattern is used to match all integration tests
 # --exclude excludes the jstz_api wpt test
-	@cargo nextest run --test "*" --workspace --exclude "jstz_api" --features skip-wpt,skip-rollup-tests
+	@cargo nextest run --test "*" --workspace --exclude "jstz_api" --features riscv,skip-wpt,skip-rollup-tests
+
+test-unit-v2:
+# --lib only runs unit tests in library crates
+# --bins only runs unit tests in binary crates
+	@cargo nextest run --lib --bins --workspace --exclude "jstz_tps_bench" --features riscv,v2_runtime,skip-wpt,skip-rollup-tests --config-file .config/nextest.toml
+
+.PHONY: test-int
+test-int-v2:
+# --test only runs a specified integration test (a test in /tests).
+#        the glob pattern is used to match all integration tests
+# --exclude excludes the jstz_api wpt test
+	@cargo nextest run --test "*" --workspace --exclude "jstz_api" --features riscv,v2_runtime,skip-wpt,skip-rollup-tests
 
 .PHONY: cov
 cov:

--- a/crates/jstz_api/src/http/response.rs
+++ b/crates/jstz_api/src/http/response.rs
@@ -268,6 +268,21 @@ impl ResponseBuilder {
         //
         // FIXME: jstz only supports status, body and headers here.
         // FIXME: http::Response won't support 0 as a status code
+        let status = 400;
+        let body = Body::null();
+        let headers = Headers::new();
+
+        Ok(Response {
+            response: InnerResponse::builder()
+                .status(status)
+                .body(body)
+                .expect("fixed inputs should never fail"),
+            headers: JsNativeObject::new::<HeadersClass>(headers, context)?,
+            url: None,
+        })
+    }
+
+    pub fn internal_server_error(context: &mut Context) -> JsResult<Response> {
         let status = 500;
         let body = Body::null();
         let headers = Headers::new();

--- a/crates/jstz_kernel/Cargo.toml
+++ b/crates/jstz_kernel/Cargo.toml
@@ -32,3 +32,4 @@ tezos_data_encoding = "0.6.0"
 
 [dev-dependencies]
 jstz_mock = { path = "../jstz_mock" }
+jstz_utils = { path = "../jstz_utils" }

--- a/crates/jstz_kernel/src/lib.rs
+++ b/crates/jstz_kernel/src/lib.rs
@@ -56,28 +56,30 @@ async fn handle_message(
 // kernel entry
 #[entrypoint::main]
 pub fn entry(rt: &mut impl Runtime) {
-    futures::executor::block_on(async {
-        // TODO: we should organize protocol consts into a struct
-        // https://linear.app/tezos/issue/JSTZ-459/organize-protocol-consts-into-a-struct
-        let ticketer = read_ticketer(rt).expect("Ticketer not found");
-        let injector = read_injector(rt).expect("Revealer not found");
-        let mut tx = Transaction::default();
-        tx.begin();
-        if let Some(message) = read_message(rt, &ticketer) {
-            handle_message(rt, message, &ticketer, &mut tx, &injector)
-                .await
-                .unwrap_or_else(|err| debug_msg!(rt, "[🔴] {err:?}\n"));
-        }
-        if let Err(commit_error) = tx.commit(rt) {
-            debug_msg!(rt, "Failed to commit transaction: {commit_error:?}\n");
-        }
-    })
+    futures::executor::block_on(run(rt))
+}
+
+pub async fn run(rt: &mut impl Runtime) {
+    // TODO: we should organize protocol consts into a struct
+    // https://linear.app/tezos/issue/JSTZ-459/organize-protocol-consts-into-a-struct
+    let ticketer = read_ticketer(rt).expect("Ticketer not found");
+    let injector = read_injector(rt).expect("Revealer not found");
+    let mut tx = Transaction::default();
+    tx.begin();
+    if let Some(message) = read_message(rt, &ticketer) {
+        handle_message(rt, message, &ticketer, &mut tx, &injector)
+            .await
+            .unwrap_or_else(|err| debug_msg!(rt, "[🔴] {err:?}\n"));
+    }
+    if let Err(commit_error) = tx.commit(rt) {
+        debug_msg!(rt, "Failed to commit transaction: {commit_error:?}\n");
+    }
 }
 
 #[cfg(test)]
 mod test {
 
-    use jstz_core::kv::Transaction;
+    use jstz_core::{host::HostRuntime, kv::Transaction};
     use jstz_crypto::hash::Hash;
     use jstz_mock::{
         host::{JstzMockHost, MOCK_SOURCE},
@@ -91,9 +93,14 @@ mod test {
         executor::smart_function,
         runtime::ParsedCode,
     };
+    use jstz_utils::test_util::TOKIO_MULTI_THREAD;
     use tezos_smart_rollup::types::{Contract, PublicKeyHash};
 
-    use crate::{entry, parsing::try_parse_contract, read_ticketer};
+    use crate::{parsing::try_parse_contract, read_ticketer, run};
+
+    fn wrapped_run(rt: &mut impl HostRuntime) {
+        TOKIO_MULTI_THREAD.block_on(run(rt));
+    }
 
     #[test]
     fn read_ticketer_succeeds() {
@@ -108,7 +115,7 @@ mod test {
         let mut host = JstzMockHost::default();
         let deposit = MockNativeDeposit::default();
         host.add_internal_message(&deposit);
-        host.rt().run_level(entry);
+        host.rt().run_level(wrapped_run);
         let tx = &mut Transaction::default();
         tx.begin();
         match deposit.receiver {
@@ -151,7 +158,7 @@ mod test {
         };
 
         host.add_internal_message(&deposit);
-        host.rt().run_level(entry);
+        host.rt().run_level(wrapped_run);
         let ticket_hash = deposit.ticket_hash();
         match deposit.proxy_contract {
             Some(proxy) => {
@@ -180,7 +187,7 @@ mod test {
         let deposit = MockFaDeposit::default();
 
         host.add_internal_message(&deposit);
-        host.rt().run_level(entry);
+        host.rt().run_level(wrapped_run);
         let ticket_hash = deposit.ticket_hash();
         match deposit.proxy_contract {
             Some(proxy) => {

--- a/crates/jstz_node/src/sequencer/runtime.rs
+++ b/crates/jstz_node/src/sequencer/runtime.rs
@@ -58,12 +58,13 @@ fn read_injector(rt: &impl Runtime) -> Option<PublicKey> {
     Storage::get(rt, &INJECTOR_PATH).ok()?
 }
 
-pub fn process_message(rt: &mut impl Runtime, op: Message) -> anyhow::Result<()> {
+pub fn process_message(
+    tokio: &tokio::runtime::Runtime,
+    rt: &mut impl Runtime,
+    op: Message,
+) -> anyhow::Result<()> {
     let ticketer = read_ticketer(rt).ok_or(anyhow!("Ticketer not found"))?;
     let injector = read_injector(rt).ok_or(anyhow!("Revealer not found"))?;
-    let tokio = tokio::runtime::Builder::new_current_thread()
-        .build()
-        .unwrap();
     let mut tx = Transaction::default();
     tx.begin();
     let receipt = match op {
@@ -97,10 +98,11 @@ mod tests {
     use std::{io::Write, path::PathBuf};
 
     use axum::http::{HeaderMap, Method, StatusCode, Uri};
-    use jstz_core::{host::HostRuntime, reveal_data::PreimageHash, BinEncodable};
+    use jstz_core::{host::HostRuntime, reveal_data::RevealData, BinEncodable};
     use jstz_crypto::{
-        hash::{Blake2b, Hash},
+        hash::Hash,
         public_key::PublicKey,
+        secret_key::SecretKey,
         signature::Signature,
         smart_function_hash::{Kt1Hash, SmartFunctionHash},
     };
@@ -116,9 +118,10 @@ mod tests {
         },
         runtime::ParsedCode,
     };
+    use jstz_utils::test_util::TOKIO_MULTI_THREAD;
     use tempfile::{NamedTempFile, TempDir};
     use tezos_crypto_rs::hash::{Ed25519Signature, PublicKeyEd25519};
-    use tezos_smart_rollup::storage::path::RefPath;
+    use tezos_smart_rollup::storage::path::{OwnedPath, RefPath};
 
     use crate::sequencer::db::Db;
 
@@ -201,7 +204,8 @@ mod tests {
         .unwrap();
 
         // Deploy smart function
-        super::process_message(&mut h, Message::External(deploy_op)).unwrap();
+        super::process_message(&TOKIO_MULTI_THREAD, &mut h, Message::External(deploy_op))
+            .unwrap();
         let v = Receipt::decode(&h.store_read_all(&RefPath::assert_from(b"/jstz_receipt/843a8438af97d97e134ae10bdcf10b5a6bcbf8c7d4912e65bacf1be26a5a73c3")).unwrap()).unwrap();
         assert!(matches!(
             v.result,
@@ -211,7 +215,8 @@ mod tests {
         ));
 
         // Call smart function
-        super::process_message(&mut h, Message::External(call_op)).unwrap();
+        super::process_message(&TOKIO_MULTI_THREAD, &mut h, Message::External(call_op))
+            .unwrap();
         let v = Receipt::decode(&h.store_read_all(&RefPath::assert_from(b"/jstz_receipt/9b15976cc8162fe39458739de340a1a95c59a9bcff73bd3c83402fad6352396e")).unwrap()).unwrap();
         assert!(matches!(
             v.result,
@@ -265,7 +270,7 @@ mod tests {
         .unwrap();
 
         // Execute the deposit
-        super::process_message(&mut h, deposit_op).unwrap();
+        super::process_message(&TOKIO_MULTI_THREAD, &mut h, deposit_op).unwrap();
         let v = Receipt::decode(&h.store_read_all(&RefPath::assert_from(b"/jstz_receipt/270c07945707b0a86fdbd6930e7bb3cae8978a3bcfb6659e8062ef39ec58c32a")).unwrap()).unwrap();
         assert!(matches!(
             v.result,
@@ -294,26 +299,109 @@ mod tests {
         let preimage_dir = TempDir::new().unwrap();
         let path = preimage_dir.path().to_path_buf();
 
-        // This is a smart function that has a lot of useless a's in its source and simply returns
-        // a text response "this is a big function". Just large enough to fit in one preimage file.
-        std::fs::File::create(path.join("003fef1ffda1460c3a5b738c91b60b036c1a8a6741bb5f15c23d7847a809b44475")).unwrap().write_all(&hex::decode(format!("0000000fe00000000040000000000000008ee52d6db7fdd691405e7ac0ad1a8c2b5d071244f3c0e01bd5fdd88302ee6f8d267a883d2c18f5e2aa29c1851463348b8c140adceabc719933ee84f724388e0600000000200000000000000073c4126614137d8c738a14a5602c5d798b24b21c179a0c70c51ee53ec1a82e450000000000000000000000004c0f000000000000636f6e73742068616e646c6572203d206173796e63202829203d3e207b20636f6e73742073203d2022{}223b2072657475726e206e657720526573706f6e73652822746869732069732061206269672066756e6374696f6e22293b207d3b206578706f72742064656661756c742068616e646c65723b0000000000000000", "61".repeat(3799))).unwrap()).unwrap();
+        let injector_sk = SecretKey::from_base58(
+            "edsk3gUfUPyBSfrS9CCgmCiQsTCHGkviBDusMxDJstFtojtc1zcpsh",
+        )
+        .unwrap();
+
+        // Deploy large smart function
+        let deploy_fn = Operation {
+            public_key: PublicKey::from_base58(INJECTOR_PK).unwrap(),
+            nonce: 1.into(),
+            content: DeployFunction {
+                // # Safety: Ok in test
+                function_code:
+                    ParsedCode::try_from(format!(
+                        "const handler = (request) => {{ let x = '{}'; return new Response('this is a big function'); }}; export default handler;",
+                        "a".repeat(5000))).unwrap()
+                ,
+                account_credit: 0,
+            }
+            .into(),
+        };
+        let deploy_op_hash = hex::encode(deploy_fn.hash());
+        let signature = injector_sk.sign(deploy_fn.hash()).unwrap();
+        let signed_deploy_fn = SignedOperation::new(signature, deploy_fn);
+
+        let preimage_hash =
+            // 5345 bytes, 3 pages
+            RevealData::encode_and_prepare_preimages(&signed_deploy_fn, |hash, data| {
+                std::fs::File::create(path.join(hash.to_string()))
+                    .unwrap()
+                    .write_all(&data)
+                    .unwrap();
+            })
+            .unwrap();
+
+        let large_payload = Operation {
+            public_key: PublicKey::from_base58(INJECTOR_PK).unwrap(),
+            nonce: 0.into(),
+            content: RevealLargePayload {
+                root_hash: preimage_hash,
+                reveal_type: jstz_proto::operation::RevealType::DeployFunction,
+                original_op_hash: signed_deploy_fn.hash(),
+            }
+            .into(),
+        };
+
+        let signature = injector_sk.sign(large_payload.hash()).unwrap();
+        let signed_large_payload = SignedOperation::new(signature, large_payload);
+
         let mut h = super::init_host(db, path).unwrap();
 
-        let deploy_op = dummy_op("edsigtpNrm3AoevvFfdboe5kijt5KpQWgXeaTqDNhAYD5dta8JWXHFW6afyEeCj6QsrxXg8WdRQhxaG9TDzaQx1mnC6vyMDSJ3B", super::INJECTOR_PK,0, Content::RevealLargePayload(RevealLargePayload { root_hash: PreimageHash([0, 63, 239, 31, 253, 161, 70, 12, 58, 91, 115, 140, 145, 182, 11, 3, 108, 26, 138, 103, 65, 187, 95, 21, 194, 61, 120, 71, 168, 9, 180, 68, 117]), reveal_type: jstz_proto::operation::RevealType::DeployFunction, original_op_hash: Blake2b::try_parse("aa8216661480132414f3ddd4bccc61fffd1db9961b259efb4d4d6597d3f7f6aa".to_string()).unwrap() }));
-
-        super::process_message(&mut h, Message::External(deploy_op)).unwrap();
-        let v = Receipt::decode(&h.store_read_all(&RefPath::assert_from(b"/jstz_receipt/aa8216661480132414f3ddd4bccc61fffd1db9961b259efb4d4d6597d3f7f6aa")).unwrap()).unwrap();
+        super::process_message(
+            &TOKIO_MULTI_THREAD,
+            &mut h,
+            Message::External(signed_large_payload),
+        )
+        .unwrap();
+        let v = Receipt::decode(
+            &h.store_read_all(
+                &OwnedPath::try_from(format!("/jstz_receipt/{}", deploy_op_hash))
+                    .unwrap(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
         assert!(matches!(
             v.result,
             ReceiptResult::Success(ReceiptContent::DeployFunction(
                 DeployFunctionReceipt { address: SmartFunctionHash(Kt1Hash(addr)) }
-            )) if addr.to_base58_check() == "KT1CkPcKaAKLX1eibkkTLub84nf1uXT7FYjG"
+            )) if addr.to_base58_check() == "KT1FTckranMJ2on3TDufWqJumzSyRUd1tQf2"
         ));
 
-        let user_public_key = "edpkuXD2CqRpWoTT8p4exrMPQYR2NqsYH3jTMeJMijHdgQqkMkzvnz";
-        let call_op = dummy_op("edsigtnvb4e2nPcfadUt7VbdMgFZByP1SUAmEWVfaLAerBGazZuVqCWZ4wjNJRxZhbjnzUfdMihXuH62APQv169xQvQvkEYQKQX", user_public_key, 1, Content::RunFunction(RunFunction { uri: Uri::from_static("jstz://KT1CkPcKaAKLX1eibkkTLub84nf1uXT7FYjG/"), method: Method::GET, headers: HeaderMap::new(), body: None, gas_limit: 550000 }));
-        super::process_message(&mut h, Message::External(call_op)).unwrap();
-        let v = Receipt::decode(&h.store_read_all(&RefPath::assert_from(b"/jstz_receipt/e6f9a74841205885f6dd1d639afcb39de14a2350d01519edf792631e39403b75")).unwrap()).unwrap();
+        let run_op = Operation {
+            public_key: PublicKey::from_base58(
+                "edpkuERbaNDzoXLskejBgBtySZxFN84t4iBKoSHYKRfzbK74HoP1zX",
+            )
+            .unwrap(),
+            nonce: 0.into(),
+            content: Content::RunFunction(RunFunction {
+                uri: Uri::from_static("jstz://KT1FTckranMJ2on3TDufWqJumzSyRUd1tQf2/"),
+                method: Method::GET,
+                headers: HeaderMap::new(),
+                body: None,
+                gas_limit: 550000,
+            }),
+        };
+        let sk = SecretKey::from_base58(
+            "edsk4aBPdyDUC4V7RJ5dFTKDTpzMP2sGbAfXSRMPYGdFmXorj9RAYp",
+        )
+        .unwrap();
+        let signature = sk.sign(run_op.hash()).unwrap();
+        let signed = SignedOperation::new(signature, run_op);
+
+        let op_hash = signed.hash();
+
+        super::process_message(&TOKIO_MULTI_THREAD, &mut h, Message::External(signed))
+            .unwrap();
+        let v = Receipt::decode(
+            &h.store_read_all(
+                &OwnedPath::try_from(format!("/jstz_receipt/{}", op_hash)).unwrap(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
         assert!(matches!(
             v.result,
             ReceiptResult::Success(ReceiptContent::RunFunction(RunFunctionReceipt {

--- a/crates/jstz_proto/src/context/account.rs
+++ b/crates/jstz_proto/src/context/account.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use bincode::{Decode, Encode};
 use boa_gc::{empty_trace, Finalize, Trace};
+use derive_more::From;
 use jstz_core::kv::transaction::{Guarded, GuardedMut};
 use jstz_core::{
     host::HostRuntime,
@@ -32,6 +33,7 @@ pub type Amount = u64;
     Debug,
     PartialEq,
     Eq,
+    From,
     Serialize,
     Deserialize,
     ToSchema,

--- a/crates/jstz_proto/src/error.rs
+++ b/crates/jstz_proto/src/error.rs
@@ -47,6 +47,8 @@ pub enum Error {
     RevealTypeMismatch,
     RevealNotSupported,
     InvalidInjector,
+    #[cfg(feature = "riscv")]
+    V2Error(crate::runtime::v2::Error),
 }
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -132,6 +134,10 @@ impl From<Error> for JsError {
             }
             Error::InvalidScheme => {
                 JsNativeError::eval().with_message("InvalidScheme").into()
+            }
+            #[cfg(feature = "riscv")]
+            Error::V2Error(_) => {
+                unimplemented!("V2 runtime errors are not supported in boa")
             }
         }
     }

--- a/crates/jstz_proto/src/executor/fa_deposit.rs
+++ b/crates/jstz_proto/src/executor/fa_deposit.rs
@@ -400,7 +400,7 @@ mod test {
                 ticket_balance,
                 run_function,
             })) => {
-                assert_eq!(500, run_function.unwrap().status_code);
+                assert_eq!(400, run_function.unwrap().status_code);
                 assert_eq!(expected_receiver, receiver);
                 assert_eq!(42, ticket_balance);
                 let proxy_balance = TicketTable::get_balance(

--- a/crates/jstz_proto/src/operation.rs
+++ b/crates/jstz_proto/src/operation.rs
@@ -4,7 +4,7 @@ use crate::{
     Error, Result,
 };
 use bincode::{Decode, Encode};
-use derive_more::{Deref, Display};
+use derive_more::{Deref, Display, From};
 use http::{HeaderMap, Method, Uri};
 use jstz_api::http::body::HttpBody;
 use jstz_core::{host::HostRuntime, kv::Transaction, reveal_data::PreimageHash};
@@ -180,7 +180,7 @@ pub struct RevealLargePayload {
 }
 
 #[derive(
-    Debug, Serialize, Deserialize, PartialEq, Eq, Clone, ToSchema, Encode, Decode,
+    Debug, From, Serialize, Deserialize, PartialEq, Eq, Clone, ToSchema, Encode, Decode,
 )]
 #[serde(tag = "_type")]
 pub enum Content {

--- a/crates/jstz_proto/src/runtime/mod.rs
+++ b/crates/jstz_proto/src/runtime/mod.rs
@@ -1,7 +1,11 @@
 pub mod v1;
+pub use v1::{Kv, KvValue, LogRecord, ParsedCode, ProtocolData, LOG_PREFIX};
 
-pub use v1::{
-    run_toplevel_fetch, Kv, KvValue, LogRecord, ParsedCode, ProtocolData, LOG_PREFIX,
-};
 #[cfg(feature = "riscv")]
 pub mod v2;
+
+#[cfg(not(feature = "v2_runtime"))]
+pub use v1::run_toplevel_fetch;
+
+#[cfg(feature = "v2_runtime")]
+pub use v2::run_toplevel_fetch;

--- a/crates/jstz_proto/src/runtime/v1/fetch_handler.rs
+++ b/crates/jstz_proto/src/runtime/v1/fetch_handler.rs
@@ -118,7 +118,7 @@ fn handle_transfer_or_rollback_and_return_response(
         runtime::with_js_tx(|tx| tx.rollback())?;
         Ok(Some(
             JsNativeObject::new::<ResponseClass>(
-                ResponseBuilder::error(context)?,
+                ResponseBuilder::internal_server_error(context)?,
                 context,
             )?
             .into(),

--- a/crates/jstz_proto/src/runtime/v2/fetch/fetch_handler.rs
+++ b/crates/jstz_proto/src/runtime/v2/fetch/fetch_handler.rs
@@ -204,7 +204,12 @@ async fn dispatch_run(
     let mut headers = process_headers_and_transfer(tx, host, headers, &from, &to)?;
     headers.push((REFERRER_HEADER_KEY.clone(), from.to_base58().into()));
     match to.kind() {
-        AddressKind::User => todo!(),
+        AddressKind::User => Ok(Response {
+            status: 200,
+            status_text: "OK".into(),
+            headers,
+            body: Body::Vector(Vec::with_capacity(0)),
+        }),
         AddressKind::SmartFunction => {
             let address = to.as_smart_function().unwrap();
             let run_result = load_and_run(
@@ -483,7 +488,7 @@ mod test {
         hash::Hash, public_key_hash::PublicKeyHash,
         smart_function_hash::SmartFunctionHash,
     };
-    use jstz_utils::TOKIO;
+    use jstz_utils::test_util::TOKIO;
 
     use serde_json::{json, Value as JsonValue};
     use url::Url;

--- a/crates/jstz_proto/src/runtime/v2/fetch/mod.rs
+++ b/crates/jstz_proto/src/runtime/v2/fetch/mod.rs
@@ -1,5 +1,7 @@
-mod error;
-mod fetch_handler;
-mod host_script;
 mod http;
+pub(crate) use http::*;
+mod error;
+pub(super) use error::*;
+mod fetch_handler;
+pub(crate) use fetch_handler::*;
 mod resources;

--- a/crates/jstz_proto/src/runtime/v2/mod.rs
+++ b/crates/jstz_proto/src/runtime/v2/mod.rs
@@ -1,1 +1,58 @@
+use fetch::{convert_header_map, process_and_dispatch_request, Body, FetchError};
+use jstz_core::{
+    host::{HostRuntime, JsHostRuntime},
+    kv::Transaction,
+};
+use url::Url;
+
+use crate::{
+    context::account::Addressable,
+    operation::{OperationHash, RunFunction},
+    receipt::RunFunctionReceipt,
+};
+
 pub mod fetch;
+
+pub async fn run_toplevel_fetch(
+    hrt: &mut impl HostRuntime,
+    tx: &mut Transaction,
+    source_address: &(impl Addressable + 'static),
+    run_operation: RunFunction,
+    _operation_hash: OperationHash,
+) -> Result<RunFunctionReceipt, crate::Error> {
+    Ok(run(hrt, tx, source_address, run_operation, _operation_hash).await?)
+}
+
+async fn run(
+    hrt: &mut impl HostRuntime,
+    tx: &mut Transaction,
+    source_address: &(impl Addressable + 'static),
+    run_operation: RunFunction,
+    _operation_hash: OperationHash,
+) -> Result<RunFunctionReceipt, Error> {
+    let url =
+        Url::parse(run_operation.uri.to_string().as_str()).map_err(FetchError::from)?;
+    let body = run_operation.body.map(Body::Vector);
+    let response: http::Response<Option<Vec<u8>>> = process_and_dispatch_request(
+        JsHostRuntime::new(hrt),
+        tx.clone(),
+        source_address.clone().into(),
+        run_operation.method.to_string().into(),
+        url,
+        convert_header_map(run_operation.headers),
+        body,
+    )
+    .await
+    .into();
+    Ok(RunFunctionReceipt {
+        body: response.body().clone(),
+        status_code: response.status().clone(),
+        headers: response.headers().clone(),
+    })
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    FetchError(#[from] fetch::FetchError),
+}

--- a/crates/jstz_runtime/src/runtime.rs
+++ b/crates/jstz_runtime/src/runtime.rs
@@ -304,7 +304,7 @@ mod test {
 
     use crate::{error::RuntimeError, init_test_setup};
 
-    use jstz_utils::TOKIO;
+    use jstz_utils::test_util::TOKIO;
 
     #[test]
     fn test_init_jstz_runtime() {

--- a/crates/jstz_runtime/src/sys/interfaces/request.rs
+++ b/crates/jstz_runtime/src/sys/interfaces/request.rs
@@ -64,7 +64,7 @@ mod test {
         init_test_setup,
         sys::js::convert::{FromV8, ToV8},
     };
-    use jstz_utils::TOKIO;
+    use jstz_utils::test_util::TOKIO;
 
     #[test]
     fn test_new() {

--- a/crates/jstz_runtime/src/sys/interfaces/response.rs
+++ b/crates/jstz_runtime/src/sys/interfaces/response.rs
@@ -111,7 +111,7 @@ mod test {
         init_test_setup,
         sys::js::convert::{FromV8, ToV8},
     };
-    use jstz_utils::TOKIO;
+    use jstz_utils::test_util::TOKIO;
 
     #[test]
     fn test_new() {

--- a/crates/jstz_utils/src/lib.rs
+++ b/crates/jstz_utils/src/lib.rs
@@ -1,5 +1,3 @@
-use std::sync::LazyLock;
-
 pub async fn poll<'a, F, T>(
     max_attempts: u16,
     interval_ms: u64,
@@ -18,12 +16,21 @@ where
     None
 }
 
-// Global tokio instance to prevent races among v2 runtime tests
-pub static TOKIO: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
-    tokio::runtime::Builder::new_current_thread()
-        .build()
-        .unwrap()
-});
+// WARNING: Should only be used in tests!
+pub mod test_util {
+    // Global tokio instance to prevent races among v2 runtime tests
+    pub static TOKIO: std::sync::LazyLock<tokio::runtime::Runtime> =
+        std::sync::LazyLock::new(|| {
+            tokio::runtime::Builder::new_current_thread()
+                .build()
+                .unwrap()
+        });
+
+    pub static TOKIO_MULTI_THREAD: std::sync::LazyLock<tokio::runtime::Runtime> =
+        std::sync::LazyLock::new(|| {
+            tokio::runtime::Builder::new_multi_thread().build().unwrap()
+        });
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
# Context
Part of https://linear.app/tezos/issue/JSTZ-599/integrate-v2-fetch 
Closes https://linear.app/tezos/issue/JSTZ-650/add-run-toplevel-fetch 

Add  `run_toplevel_fetch` for v2 runtime
<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
* Removed execute_v2 and related code
* Wraps `process_and_dispatch_request` with `run_toplevel_fetch`
* Extends proto error with `V2Error`
* Add`make test-v2` to run with "v2_runtime" enabled
* V1 - Changed `Response.error` to have status code 400 instead of 500 
* V1 - Introduced `internal_server_error` for internal errors in V1
* Fixed up tests
* Ignore withdrawal tests for v2 as HostScript not yet implemented
* Ignore test that tests strictness of header hygiene for v2 as v2 fetch cleans bad headers instead of failing
* Ignore noop fetch tests for v2 as it is not yet implemented
* Adds tokio runtime to sequencer worker thread

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
`make test && make test-v2`
<!-- Describe how reviewers and approvers can test this PR. -->
