### PR TITLE
refactor(sequencer): build runtime outside of the worker thread

### DIFF
--- a/crates/jstz_node/src/sequencer/worker.rs
+++ b/crates/jstz_node/src/sequencer/worker.rs
@@ -5,18 +5,18 @@ use std::{
         mpsc::{channel, Sender, TryRecvError},
         Arc, RwLock,
     },
-    thread::{self, spawn as spawn_thread, JoinHandle},
+    thread::{spawn as spawn_thread, JoinHandle},
     time::Duration,
 };
 
-use anyhow::{anyhow, bail, Context};
+use anyhow::Context;
 use log::warn;
 
 use super::{db::Db, queue::OperationQueue};
 
 pub struct Worker {
     thread_kill_sig: Sender<()>,
-    inner: Option<JoinHandle<Result<(), std::io::Error>>>,
+    inner: Option<JoinHandle<()>>,
 }
 
 impl Drop for Worker {
@@ -36,67 +36,51 @@ pub fn spawn(
     #[cfg(test)] on_exit: impl FnOnce() + Send + 'static,
 ) -> anyhow::Result<Worker> {
     let (thread_kill_sig, rx) = channel();
-    let mut rt = init_host(db, preimage_dir).context("failed to init host")?;
+    let mut host_rt = init_host(db, preimage_dir).context("failed to init host")?;
     if let Some(p) = debug_log_path {
-        rt = rt
+        host_rt = host_rt
             .with_debug_log_file(&p)
             .context("failed to set host debug log file")?;
     }
-
+    let tokio_rt = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .context("failed to build tokio runtime")?;
     Ok(Worker {
         thread_kill_sig,
-        inner: {
-            let thread =
-                spawn_thread(move || match tokio::runtime::Builder::new_current_thread()
-                    .build()
-                {
-                    Ok(tokio) => loop {
-                        let v = {
-                            match queue.write() {
-                                Ok(mut q) => q.pop(),
-                                Err(e) => {
-                                    warn!("worker failed to read from queue: {e:?}");
-                                    None
-                                }
+        inner: Some(spawn_thread(move || {
+            tokio_rt.block_on(async {
+                loop {
+                    let v = {
+                        match queue.write() {
+                            Ok(mut q) => q.pop(),
+                            Err(e) => {
+                                warn!("worker failed to read from queue: {e:?}");
+                                None
                             }
-                        };
-
-                        match v {
-                            Some(op) => {
-                                if let Err(e) = process_message(&tokio, &mut rt, op) {
-                                    warn!("error processing message: {e:?}");
-                                }
-                            }
-                            None => thread::sleep(Duration::from_millis(100)),
-                        };
-
-                        match rx.try_recv() {
-                            Ok(_) | Err(TryRecvError::Disconnected) => {
-                                #[cfg(test)]
-                                on_exit();
-                                break Ok(());
-                            }
-                            Err(TryRecvError::Empty) => {}
                         }
-                    },
-                    Err(e) => Err(e),
-                });
+                    };
 
-            if thread.is_finished() {
-                // Thread could not start
-                let result = thread
-                    .join()
-                    .map_err(|_| anyhow!("Thread could not start"))?;
+                    match v {
+                        Some(op) => {
+                            if let Err(e) = process_message(&mut host_rt, op).await {
+                                warn!("error processing message: {e:?}");
+                            }
+                        }
+                        None => tokio::time::sleep(Duration::from_millis(100)).await,
+                    };
 
-                // Tokio failed
-                result?;
-
-                // Thread ended early
-                bail!("Thread ended early")
-            } else {
-                Some(thread)
-            }
-        },
+                    match rx.try_recv() {
+                        Ok(_) | Err(TryRecvError::Disconnected) => {
+                            #[cfg(test)]
+                            on_exit();
+                            break;
+                        }
+                        Err(TryRecvError::Empty) => {}
+                    }
+                }
+            })
+        })),
     })
 }
 


### PR DESCRIPTION
# Context

Part of: [task link](https://linear.app/tezos/issue/JSTZ-636/make-worker-spawn-async-aware)



# Description

The PR refactors the worker and initialize the tokio runtime before spawning the worker thread.

* make `runtime::process_message` into async
*  initialization the runtime outside of the worker thread, early return in case it fails


# Manually testing the PR

existing test works
