### PR TITLE
feat(runtime): write console messages in logging format

### DIFF
--- a/crates/jstz_proto/src/runtime/v2/fetch/fetch_handler.rs
+++ b/crates/jstz_proto/src/runtime/v2/fetch/fetch_handler.rs
@@ -280,7 +280,7 @@ async fn load_and_run(
     let mut body = body;
 
     // 0. Prepare Protocol
-    let mut proto = ProtocolContext::new(host, tx, address.clone());
+    let mut proto = ProtocolContext::new(host, tx, address.clone(), String::new());
 
     // 1. Load script
     let script = { load_script(tx, &mut proto.host, &proto.address)? };
@@ -1441,7 +1441,13 @@ mod test {
 
         let mut tx = jstz_core::kv::Transaction::default();
         tx.begin();
-        let protocol = Some(ProtocolContext::new(&mut host, &mut tx, address.clone()));
+        let protocol = Some(ProtocolContext::new(
+            &mut host,
+            &mut tx,
+            address.clone(),
+            String::new(),
+        ));
+
         let source = Address::User(jstz_mock::account1());
         let fetched_script = r#"
             const handler = async (req) => {

--- a/crates/jstz_runtime/Cargo.toml
+++ b/crates/jstz_runtime/Cargo.toml
@@ -45,3 +45,4 @@ tezos-smart-rollup-mock.workspace = true
 
 [features]
 skip-wpt = []
+kernel = []

--- a/crates/jstz_runtime/src/ext/jstz_console/mod.rs
+++ b/crates/jstz_runtime/src/ext/jstz_console/mod.rs
@@ -2,6 +2,31 @@ use crate::{ext::NotSupported, runtime::ProtocolContext};
 use deno_core::*;
 use tezos_smart_rollup::prelude::debug_msg;
 
+#[cfg(feature = "kernel")]
+mod kernel {
+    use serde::{Serialize, Serializer};
+
+    pub(crate) const LOG_PREFIX: &str = "[JSTZ:SMART_FUNCTION:LOG]";
+
+    // Struct just for type validation for content to be logged. Having refs here to avoid cloning.
+    #[derive(Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub(crate) struct RefLogRecord<'a> {
+        pub address: &'a jstz_crypto::smart_function_hash::SmartFunctionHash,
+        pub request_id: &'a str,
+        #[serde(serialize_with = "serialise_level")]
+        pub level: u32,
+        pub text: &'a str,
+    }
+
+    fn serialise_level<S>(level: &u32, ser: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        str::serialize(&super::level_to_symbol(*level), ser)
+    }
+}
+
 // Level Description
 //  0    debug
 //  1    log, info
@@ -16,7 +41,20 @@ pub fn op_debug_msg(
     let proto = op_state.try_borrow_mut::<ProtocolContext>();
     match proto {
         Some(proto) => {
-            debug_msg!(proto.host, "{} {}", level_to_symbol(level), msg);
+            #[cfg(not(feature = "kernel"))]
+            debug_msg!(proto.host, "[{}] {}", level_to_symbol(level), msg);
+
+            #[cfg(feature = "kernel")]
+            {
+                let body = serde_json::to_string(&kernel::RefLogRecord {
+                    address: &proto.address,
+                    request_id: &proto.request_id,
+                    level,
+                    text: msg,
+                })
+                .unwrap_or_default();
+                debug_msg!(proto.host, "{} {}\n", kernel::LOG_PREFIX, body);
+            }
             Ok(())
         }
         None => Err(NotSupported { name: "console" }),
@@ -25,10 +63,10 @@ pub fn op_debug_msg(
 
 fn level_to_symbol(level: u32) -> &'static str {
     match level {
-        0 => "[DEBUG]",
-        1 => "[INFO]",
-        2 => "[WARN]",
-        _ => "[ERROR]",
+        0 => "DEBUG",
+        1 => "INFO",
+        2 => "WARN",
+        _ => "ERROR",
     }
 }
 
@@ -41,7 +79,7 @@ extension!(
 );
 
 #[cfg(test)]
-mod test {
+mod tests {
 
     use deno_error::JsErrorClass;
 
@@ -52,10 +90,16 @@ mod test {
         init_test_setup! {
             runtime = runtime;
             sink = sink;
+            request_id = "log_request";
         };
         let code = r#"console.log("hello")"#;
         runtime.execute(code).unwrap();
-        assert_eq!(sink.to_string(), "[INFO] hello\n");
+
+        #[cfg(feature = "kernel")]
+        let expected = "[JSTZ:SMART_FUNCTION:LOG] {\"address\":\"KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton\",\"requestId\":\"log_request\",\"level\":\"INFO\",\"text\":\"hello\\n\"}\n";
+        #[cfg(not(feature = "kernel"))]
+        let expected = "[INFO] hello\n";
+        assert_eq!(sink.to_string(), expected);
     }
 
     #[test]
@@ -63,10 +107,16 @@ mod test {
         init_test_setup! {
             runtime = runtime;
             sink = sink;
+            request_id = "info_request";
         };
         let code = r#"console.info("hello")"#;
         runtime.execute(code).unwrap();
-        assert_eq!(sink.to_string(), "[INFO] hello\n");
+
+        #[cfg(feature = "kernel")]
+        let expected = "[JSTZ:SMART_FUNCTION:LOG] {\"address\":\"KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton\",\"requestId\":\"info_request\",\"level\":\"INFO\",\"text\":\"hello\\n\"}\n";
+        #[cfg(not(feature = "kernel"))]
+        let expected = "[INFO] hello\n";
+        assert_eq!(sink.to_string(), expected);
     }
 
     #[test]
@@ -74,10 +124,16 @@ mod test {
         init_test_setup! {
             runtime = runtime;
             sink = sink;
+            request_id = "warn_request";
         };
         let code = r#"console.warn("hello")"#;
         runtime.execute(code).unwrap();
-        assert_eq!(sink.to_string(), "[WARN] hello\n");
+
+        #[cfg(feature = "kernel")]
+        let expected = "[JSTZ:SMART_FUNCTION:LOG] {\"address\":\"KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton\",\"requestId\":\"warn_request\",\"level\":\"WARN\",\"text\":\"hello\\n\"}\n";
+        #[cfg(not(feature = "kernel"))]
+        let expected = "[WARN] hello\n";
+        assert_eq!(sink.to_string(), expected);
     }
 
     #[test]
@@ -85,10 +141,16 @@ mod test {
         init_test_setup! {
             runtime = runtime;
             sink = sink;
+            request_id = "error_request";
         };
         let code = r#"console.error("hello")"#;
         runtime.execute(code).unwrap();
-        assert_eq!(sink.to_string(), "[ERROR] hello\n");
+
+        #[cfg(feature = "kernel")]
+        let expected = "[JSTZ:SMART_FUNCTION:LOG] {\"address\":\"KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton\",\"requestId\":\"error_request\",\"level\":\"ERROR\",\"text\":\"hello\\n\"}\n";
+        #[cfg(not(feature = "kernel"))]
+        let expected = "[ERROR] hello\n";
+        assert_eq!(sink.to_string(), expected);
     }
 
     #[test]
@@ -96,10 +158,16 @@ mod test {
         init_test_setup! {
             runtime = runtime;
             sink = sink;
+            request_id = "debug_request";
         };
         let code = r#"console.debug("hello")"#;
         runtime.execute(code).unwrap();
-        assert_eq!(sink.to_string(), "[DEBUG] hello\n");
+
+        #[cfg(feature = "kernel")]
+        let expected = "[JSTZ:SMART_FUNCTION:LOG] {\"address\":\"KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton\",\"requestId\":\"debug_request\",\"level\":\"DEBUG\",\"text\":\"hello\\n\"}\n";
+        #[cfg(not(feature = "kernel"))]
+        let expected = "[DEBUG] hello\n";
+        assert_eq!(sink.to_string(), expected);
     }
 
     #[test]
@@ -107,6 +175,7 @@ mod test {
         init_test_setup! {
             runtime = runtime;
             sink = sink;
+            request_id = "js_types";
         };
         let code = r#"
             console.info(123)
@@ -114,10 +183,15 @@ mod test {
             console.info({ message: "abc" })
         "#;
         runtime.execute(code).unwrap();
-        assert_eq!(
-            sink.to_string(),
-            "[INFO] 123\n[INFO] false\n[INFO] { message: \"abc\" }\n"
-        );
+
+        #[cfg(feature = "kernel")]
+        let expected = r#"[JSTZ:SMART_FUNCTION:LOG] {"address":"KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton","requestId":"js_types","level":"INFO","text":"123\n"}
+[JSTZ:SMART_FUNCTION:LOG] {"address":"KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton","requestId":"js_types","level":"INFO","text":"false\n"}
+[JSTZ:SMART_FUNCTION:LOG] {"address":"KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton","requestId":"js_types","level":"INFO","text":"{ message: \"abc\" }\n"}
+"#;
+        #[cfg(not(feature = "kernel"))]
+        let expected = "[INFO] 123\n[INFO] false\n[INFO] { message: \"abc\" }\n";
+        assert_eq!(sink.to_string(), expected);
     }
 
     #[test]

--- a/crates/jstz_runtime/src/lib.rs
+++ b/crates/jstz_runtime/src/lib.rs
@@ -81,6 +81,7 @@ mod test_utils {
             $(sink = $sink:ident;)?
             $(address = $addr:ident;)?
             $(fetch = $fetch_ext:expr;)?
+            $(request_id = $request_id:tt;)?
         ) => {
             #[allow(unused)]
             let mut init_host = tezos_smart_rollup_mock::MockHost::default();
@@ -96,7 +97,10 @@ mod test_utils {
                 let module_loader = deno_core::StaticModuleLoader::with($specifier.clone(), $code);
             )?
             #[allow(unused)]
-            let protocol  = Some($crate::ProtocolContext::new(&mut init_host, &mut init_tx, init_addr.clone()));
+            let request_id = String::new();
+            $(let request_id = $request_id.to_string();)?
+            #[allow(unused)]
+            let protocol  = Some($crate::ProtocolContext::new(&mut init_host, &mut init_tx, init_addr.clone(), request_id));
             #[allow(unused)]
             let mut $runtime = $crate::JstzRuntime::new($crate::JstzRuntimeOptions {
                 protocol,

--- a/crates/jstz_runtime/src/runtime.rs
+++ b/crates/jstz_runtime/src/runtime.rs
@@ -356,6 +356,7 @@ pub struct ProtocolContext {
     pub tx: Transaction,
     pub kv: Kv,
     pub address: SmartFunctionHash,
+    pub request_id: String,
 }
 
 impl ProtocolContext {
@@ -363,6 +364,7 @@ impl ProtocolContext {
         hrt: &mut impl HostRuntime,
         tx: &mut Transaction,
         address: SmartFunctionHash,
+        request_id: String,
     ) -> Self {
         let host = JsHostRuntime::new(hrt);
         ProtocolContext {
@@ -370,6 +372,7 @@ impl ProtocolContext {
             tx: tx.clone(),
             kv: Kv::new(address.to_base58()),
             address,
+            request_id,
         }
     }
 }
@@ -414,6 +417,10 @@ mod test {
     use jstz_utils::test_util::TOKIO;
 
     #[test]
+    #[cfg_attr(
+        feature = "kernel",
+        ignore = "logging format is different when kernel feature is enabled"
+    )]
     fn test_init_jstz_runtime() {
         init_test_setup! {
             runtime = runtime;

--- a/crates/jstz_runtime/tests/wpt.rs
+++ b/crates/jstz_runtime/tests/wpt.rs
@@ -253,7 +253,7 @@ fn init_runtime(host: &mut impl HostRuntime, tx: &mut Transaction) -> JstzRuntim
         .push(test_harness_api::init_ops_and_esm());
 
     let mut runtime = JstzRuntime::new(JstzRuntimeOptions {
-        protocol: Some(ProtocolContext::new(host, tx, address)),
+        protocol: Some(ProtocolContext::new(host, tx, address, String::new())),
         extensions: vec![test_harness_api::init_ops_and_esm()],
         ..Default::default()
     });


### PR DESCRIPTION
# Context

Part of JSTZ-647.
[JSTZ-647](https://linear.app/tezos/issue/JSTZ-647/log-operation-details-for-v2-runtime)

V2 runtime has no logging basically.

# Description

Updated the console extension for v2 runtime such that log lines are printed in a specific format recognised by the log collector in jstz node. A sample line looks as follows:
```
[JSTZ:SMART_FUNCTION:LOG] {"address":"KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton","requestId":"js_types","level":"INFO","text":"false\n"}
```

This is the same as what is implemented for v1 runtime.

Note that since this format is only required when the runtime is built into the kernel, a new feature flag `kernel` is added such that `console` still writes messages in the old format in normal cases, e.g. with repl. That is,
```
[INFO] something
```

# Manually testing the PR

* Unit testing: updated tests

I tried to create new tests for the changes and make the test runner ignore them when the feature flag is not set, but then codecov complains that those new tests "are not covered" because they are ignored. For now I'm "merging" these tests in an awkward way like this. Ideally we need to collect test coverage for different features, but for now I'll keep it like this.
