### PR TITLE
feat(sequencer): stream logs from runtime

### DIFF
--- a/crates/jstz_node/Cargo.toml
+++ b/crates/jstz_node/Cargo.toml
@@ -31,7 +31,7 @@ hex.workspace = true
 jstz_api = { path = "../jstz_api" }
 jstz_core = { path = "../jstz_core" }
 jstz_crypto = { path = "../jstz_crypto" }
-jstz_proto = { path = "../jstz_proto" }
+jstz_proto = { path = "../jstz_proto", features = ["kernel"] }
 jstz_utils = { path = "../jstz_utils" }
 log.workspace = true
 mockito.workspace = true

--- a/crates/jstz_node/src/sequencer/worker.rs
+++ b/crates/jstz_node/src/sequencer/worker.rs
@@ -1,6 +1,6 @@
 use crate::sequencer::runtime::{init_host, process_message};
 use std::{
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{
         atomic::AtomicU64,
         mpsc::{channel, Sender, TryRecvError},
@@ -40,14 +40,14 @@ pub fn spawn(
     queue: Arc<RwLock<OperationQueue>>,
     db: Db,
     preimage_dir: PathBuf,
-    debug_log_path: Option<PathBuf>,
+    debug_log_path: Option<&Path>,
     #[cfg(test)] on_exit: impl FnOnce() + Send + 'static,
 ) -> anyhow::Result<Worker> {
     let (thread_kill_sig, rx) = channel();
     let mut host_rt = init_host(db, preimage_dir).context("failed to init host")?;
     if let Some(p) = debug_log_path {
         host_rt = host_rt
-            .with_debug_log_file(&p)
+            .with_debug_log_file(p)
             .context("failed to set host debug log file")?;
     }
     let tokio_rt = tokio::runtime::Builder::new_current_thread()
@@ -170,7 +170,7 @@ mod tests {
             wrapper.clone(),
             cp,
             PathBuf::new(),
-            Some(log_file.path().to_path_buf()),
+            Some(log_file.path()),
             move || {},
         );
 

--- a/crates/jstz_proto/src/runtime/v1/mod.rs
+++ b/crates/jstz_proto/src/runtime/v1/mod.rs
@@ -6,7 +6,7 @@ mod script;
 
 pub use api::{Kv, KvValue, ProtocolApi, ProtocolData, WebApi};
 use fetch_handler::{fetch, runtime_and_request_from_run_operation};
-pub use js_logger::{LogRecord, LOG_PREFIX};
+pub use js_logger::{LogLevel, LogRecord, LOG_PREFIX};
 pub use script::ParsedCode;
 
 use jstz_api::http::response::Response;

--- a/crates/jstz_proto/src/runtime/v2/mod.rs
+++ b/crates/jstz_proto/src/runtime/v2/mod.rs
@@ -13,7 +13,6 @@ use crate::{
     operation::{OperationHash, RunFunction},
     receipt::RunFunctionReceipt,
 };
-
 pub mod fetch;
 pub use jstz_core::log_record::{LogRecord, LOG_PREFIX};
 pub use jstz_runtime::{Kv, KvValue};


### PR DESCRIPTION
# Context

Completes JSTZ-645.
[JSTZ-645](https://linear.app/tezos/issue/JSTZ-645/stream-logs-from-runtime-debug-log-file)

The logging API in jstz node should be able to stream logs from the sequencer runtime.

# Description

Updated jstz node such that it streams from the local debug file when it runs in sequencer mode. Dependency `jstz_proto` needs to have feature `kernel` enabled in order to get logs written in the same format as what v1 runtime has right now.

# Manually testing the PR

* Integration test: updated the test.
