### PR TITLE
feat(sequencer): expose worker heartbeat

### DIFF
--- a/crates/jstz_node/src/lib.rs
+++ b/crates/jstz_node/src/lib.rs
@@ -16,7 +16,8 @@ use services::{
 };
 use std::{
     path::PathBuf,
-    sync::{Arc, RwLock},
+    sync::{atomic::AtomicU64, Arc, RwLock},
+    time::SystemTime,
 };
 use tempfile::NamedTempFile;
 use tokio::net::TcpListener;
@@ -42,6 +43,22 @@ pub struct AppState {
     pub mode: RunMode,
     pub queue: Arc<RwLock<OperationQueue>>,
     pub runtime_db: sequencer::db::Db,
+    worker_heartbeat: Arc<AtomicU64>,
+}
+
+impl AppState {
+    pub fn is_worker_healthy(&self) -> bool {
+        let current_sec = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        // safety: there is only one writer -- the worker itself.
+        let diff = current_sec
+            - self
+                .worker_heartbeat
+                .load(std::sync::atomic::Ordering::Relaxed);
+        diff <= 30
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, clap::ValueEnum)]
@@ -108,7 +125,7 @@ pub async fn run(
         "failed to convert temp db file path to str"
     ))?;
     let runtime_db = sequencer::db::Db::init(Some(db_path))?;
-    let _worker = match mode {
+    let worker = match mode {
         #[cfg(not(test))]
         RunMode::Sequencer => Some(
             worker::spawn(
@@ -157,6 +174,7 @@ pub async fn run(
         mode,
         queue,
         runtime_db,
+        worker_heartbeat: worker.as_ref().map(|w| w.heartbeat()).unwrap_or_default(),
     };
 
     let cors = CorsLayer::new()
@@ -183,6 +201,7 @@ fn router() -> OpenApiRouter<AppState> {
         .merge(LogsService::router_with_openapi())
         .route("/mode", get(utils::get_mode))
         .route("/health", get(http::StatusCode::OK))
+        .route("/worker/health", get(utils::worker_health))
         .layer(DefaultBodyLimit::max(MAX_REVEAL_SIZE))
 }
 
@@ -194,14 +213,20 @@ pub fn openapi_json_raw() -> anyhow::Result<String> {
 
 #[cfg(test)]
 mod test {
-    use std::path::PathBuf;
+    use std::{
+        path::PathBuf,
+        sync::{atomic::AtomicU64, Arc},
+        time::SystemTime,
+    };
 
     use octez::unused_port;
     use pretty_assertions::assert_eq;
     use tempfile::{NamedTempFile, TempDir};
     use tokio::time::{sleep, Duration};
 
-    use crate::{run, KeyPair, RunMode, RunOptions};
+    use crate::{
+        run, services::utils::tests::mock_app_state, KeyPair, RunMode, RunOptions,
+    };
 
     #[test]
     fn api_doc_regression() {
@@ -304,5 +329,25 @@ mod test {
         )
         .await;
         assert!(!preimages_dir.join("default-test-file.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn worker_heartbeat() {
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        let mut state =
+            mock_app_state("", PathBuf::default(), "", RunMode::Default).await;
+        state.worker_heartbeat = Arc::new(AtomicU64::new(now - 60));
+        // heartbeat is too old
+        assert!(!state.is_worker_healthy());
+
+        let mut state =
+            mock_app_state("", PathBuf::default(), "", RunMode::Default).await;
+        state.worker_heartbeat = Arc::new(AtomicU64::new(now - 5));
+        // heartbeat is recent enough
+        assert!(state.is_worker_healthy());
     }
 }

--- a/crates/jstz_node/src/services/utils.rs
+++ b/crates/jstz_node/src/services/utils.rs
@@ -1,6 +1,6 @@
 use crate::{sequencer::db::Db, services::AppState, RunMode};
 use anyhow::Context;
-use axum::{extract::State, response::IntoResponse};
+use axum::{extract::State, http::StatusCode, response::IntoResponse};
 use octez::OctezRollupClient;
 use tezos_crypto_rs::base58::FromBase58Check;
 
@@ -8,6 +8,13 @@ pub async fn get_mode(
     State(AppState { mode, .. }): State<AppState>,
 ) -> impl IntoResponse {
     serde_json::to_string(&mode).unwrap().into_response()
+}
+
+pub async fn worker_health(State(state): State<AppState>) -> impl IntoResponse {
+    match state.is_worker_healthy() {
+        true => StatusCode::OK,
+        false => StatusCode::SERVICE_UNAVAILABLE,
+    }
 }
 
 pub enum StoreWrapper {
@@ -46,9 +53,11 @@ impl StoreWrapper {
 pub(crate) mod tests {
     use std::{
         path::PathBuf,
-        sync::{Arc, RwLock},
+        sync::{atomic::AtomicU64, Arc, RwLock},
+        time::SystemTime,
     };
 
+    use axum::{body::Body, http::Request};
     use jstz_core::BinEncodable;
     use jstz_crypto::{
         hash::Blake2b,
@@ -61,6 +70,7 @@ pub(crate) mod tests {
     use octez::OctezRollupClient;
     use tempfile::NamedTempFile;
     use tezos_crypto_rs::{base58::ToBase58Check, hash::ContractKt1Hash};
+    use tower::util::ServiceExt;
 
     use crate::{
         config::KeyPair,
@@ -95,6 +105,7 @@ pub(crate) mod tests {
             mode,
             queue: Arc::new(RwLock::new(OperationQueue::new(1))),
             runtime_db: crate::sequencer::db::Db::init(Some(db_path)).unwrap(),
+            worker_heartbeat: Arc::default(),
         }
     }
 
@@ -215,5 +226,41 @@ pub(crate) mod tests {
             .await
             .expect("should get result from store")
             .is_none());
+    }
+
+    #[tokio::test]
+    async fn worker_health() {
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        let mut state =
+            mock_app_state("", PathBuf::default(), "", RunMode::Default).await;
+        state.worker_heartbeat = Arc::new(AtomicU64::new(now - 60));
+        let router = axum::Router::new()
+            .route("/worker/health", axum::routing::get(super::worker_health))
+            .with_state(state);
+
+        let res = router
+            .oneshot(Request::get("/worker/health").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        // heartbeat is too old
+        assert_eq!(res.status(), 503);
+
+        let mut state =
+            mock_app_state("", PathBuf::default(), "", RunMode::Default).await;
+        state.worker_heartbeat = Arc::new(AtomicU64::new(now - 5));
+        let router = axum::Router::new()
+            .route("/worker/health", axum::routing::get(super::worker_health))
+            .with_state(state);
+
+        let res = router
+            .oneshot(Request::get("/worker/health").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        // heartbeat is recent enough
+        assert_eq!(res.status(), 200);
     }
 }

--- a/crates/jstz_node/tests/sequencer.rs
+++ b/crates/jstz_node/tests/sequencer.rs
@@ -69,9 +69,11 @@ async fn run_sequencer() {
     let client = Client::new();
 
     check_mode(&client, &base_uri).await;
+    check_worker_health(&client, &base_uri).await;
     deploy_function(&client, &base_uri).await;
     call_function(&client, &base_uri).await;
     check_inbox_op(&client, &base_uri).await;
+    check_worker_health(&client, &base_uri).await;
 }
 
 async fn check_mode(client: &Client, base_uri: &str) {
@@ -299,4 +301,13 @@ fn mock_deposit_fa_op() -> (&'static str, &'static str) {
     let op = "0000050807070a000000160000e7670f32038107a59a2b9cfefae36ea21f5aa63c070705090a0000001601238f371da359b757db57238e9f27f3c48234defa0007070a0000001601207905b1a5abdace0a6b5bff0d71a467d5b85cf500070707070001030600a80f9424c685d3f69801ff6e3f2cfb74b250f00988e100e7670f32038107a59a2b9cfefae36ea21f5aa63cc3ea4c18195bcfac262dcb29e3d803ae74681739";
     let op_hash = "34461635d31fd734cee1f20839218ffef78785d536b348b04204510012a8cbd2";
     (op_hash, op)
+}
+
+async fn check_worker_health(client: &Client, base_uri: &str) {
+    let res = client
+        .get(format!("{base_uri}/worker/health"))
+        .send()
+        .await
+        .unwrap();
+    assert!(res.status().is_success());
 }


### PR DESCRIPTION
# Context

Completes JSTZ-663.
[JSTZ-663](https://linear.app/tezos/issue/JSTZ-663/expose-worker-heartbeat)

Since the worker runs in a separate thread, it is possible that the worker somehow panics and fails silently while the entire jstz node keeps running. We therefore need a way to know if the worker is still okay.

# Description

Added one endpoint `/worker/health` that reads the heartbeat value set by the worker and returns OK if the value was set in the last 30 seconds.

# Manually testing the PR

* Unit testing: added tests.
* Integration testing: updated the existing test.
