### PR TITLE
fix(sequencer,jstzd): wait for rollup

### DIFF
--- a/crates/jstz_node/src/sequencer/inbox/mod.rs
+++ b/crates/jstz_node/src/sequencer/inbox/mod.rs
@@ -53,6 +53,7 @@ impl WriteDebug for Logger {
 }
 
 /// Spawn a future that monitors the L1 blocks, parses inbox messages and pushes them into the queue.
+/// precondition: the rollup node is healthy.
 pub async fn spawn_monitor<
     #[cfg(test)] Fut: Future<Output = ()> + 'static + Send,
     #[cfg(test)] F: Fn(u32) -> Fut + Send + 'static,
@@ -61,10 +62,6 @@ pub async fn spawn_monitor<
     queue: Arc<RwLock<OperationQueue>>,
     #[cfg(test)] on_new_block: F,
 ) -> Result<Monitor> {
-    // temp fix for jstzd to run locally.
-    // TODO: add logic to wait until rollup node is `healthy` in jstzd
-    #[cfg(not(test))]
-    tokio::time::sleep(Duration::from_secs(3)).await;
     let kill_sig = CancellationToken::new();
     let kill_sig_clone = kill_sig.clone();
     let mut block_stream = api::monitor_blocks(&rollup_endpoint).await?;


### PR DESCRIPTION
# Context

Sequencer assumes that the rollup node is healthy by the time it starts. However jstzd starts the sequencer before the rollup is healthy. This PR fixes that.

# Description

* make jstzd::spawn wait for the rollup to spin up before spinning up the jstz node
* removed the sleep used for temp fix inside inbox::monitor 


# Manually testing the PR

* manually tested by running jstzd 
* existing test works
