### PR TITLE
fix: stub random and timers

### DIFF
--- a/crates/jstz_node/src/lib.rs
+++ b/crates/jstz_node/src/lib.rs
@@ -283,7 +283,7 @@ mod test {
             sleep(Duration::from_secs(1)).await;
             h.abort();
             // wait for the worker in run to be dropped
-            sleep(Duration::from_secs(1)).await;
+            sleep(Duration::from_secs(2)).await;
         }
         let preimages_dir = TempDir::new().unwrap().into_path();
 

--- a/crates/jstz_runtime/src/ext/jstz_main/01_errors.js
+++ b/crates/jstz_runtime/src/ext/jstz_main/01_errors.js
@@ -1,0 +1,6 @@
+export class NotSupported extends Error {
+  constructor(msg) {
+    super(msg);
+    this.name = "NotSupported";
+  }
+}

--- a/crates/jstz_runtime/src/ext/jstz_main/98_global_scope.js
+++ b/crates/jstz_runtime/src/ext/jstz_main/98_global_scope.js
@@ -1,4 +1,4 @@
-import { core } from "ext:core/mod.js";
+import { core, primordials } from "ext:core/mod.js";
 
 import * as webidl from "ext:deno_webidl/00_webidl.js";
 import jstzConsole from "ext:jstz_console/console.js";
@@ -28,6 +28,11 @@ import * as request from "ext:deno_fetch/23_request.js";
 import * as response from "ext:deno_fetch/23_response.js";
 import * as fetch from "ext:deno_fetch/26_fetch.js";
 
+let GlobalMath = Math;
+GlobalMath.random = () => {
+  return 0.42;
+};
+
 // https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope
 const workerGlobalScope = {
   AbortController: core.propNonEnumerable(abortSignal.AbortController),
@@ -52,6 +57,7 @@ const workerGlobalScope = {
   FormData: core.propNonEnumerable(formData.FormData),
   Headers: core.propNonEnumerable(headers.Headers),
   ImageData: core.propNonEnumerable(imageData.ImageData),
+  Math: GlobalMath,
   MessageChannel: core.propNonEnumerable(messagePort.MessageChannel),
   MessageEvent: core.propNonEnumerable(event.MessageEvent),
   MessagePort: core.propNonEnumerable(messagePort.MessagePort),

--- a/crates/jstz_runtime/src/ext/jstz_main/98_global_scope.js
+++ b/crates/jstz_runtime/src/ext/jstz_main/98_global_scope.js
@@ -8,8 +8,9 @@ import * as jstzKv from "ext:jstz_kv/kv.js";
 
 // https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope
 import { DOMException } from "ext:deno_web/01_dom_exception.js";
+import { NotSupported } from "ext:jstz_main/01_errors.js";
 import * as event from "ext:deno_web/02_event.js";
-import * as timers from "ext:deno_web/02_timers.js";
+// import * as timers from "ext:deno_web/02_timers.js";
 import * as abortSignal from "ext:deno_web/03_abort_signal.js";
 import * as globalInterfaces from "ext:deno_web/04_global_interfaces.js";
 import * as base64 from "ext:deno_web/05_base64.js";
@@ -33,6 +34,73 @@ GlobalMath.random = () => {
   return 0.42;
 };
 
+let NativeDate = Date;
+
+// Always show time in UTC instead of host time.
+// `toString` can't be configured so we manually implement UTC encoded time
+NativeDate.prototype.toString = function () {
+  // Month and weekday names from ECMA-262 spec
+  const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  const MONTHS = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+  ];
+
+  // Use UTC getters to lock to UTC
+  const wd = WEEKDAYS[this.getUTCDay()];
+  const mo = MONTHS[this.getUTCMonth()];
+  const d = String(this.getUTCDate()).padStart(2, "0");
+  const y = this.getUTCFullYear();
+  const hh = String(this.getUTCHours()).padStart(2, "0");
+  const mm = String(this.getUTCMinutes()).padStart(2, "0");
+  const ss = String(this.getUTCSeconds()).padStart(2, "0");
+  // Always "GMT+0000 (UTC)"
+  return `${wd} ${mo} ${d} ${y} ${hh}:${mm}:${ss} GMT+0000 (Coordinated Universal Time)`;
+};
+
+// Override string coercion
+NativeDate[Symbol.toPrimitive] = function (hint) {
+  if (hint === "string") return this.toString();
+  // for number or default, keep original behavior
+  return this.valueOf();
+};
+
+const NOW = 1530380397121;
+
+function JstzDate(...args) {
+  if (this instanceof JstzDate) {
+    if (args.length === 0) {
+      // Constructor with no args ie. new Date()
+      return new NativeDate(NOW);
+    } else {
+      return new NativeDate(...args);
+    }
+  } else {
+    // Static constructor call ie. Date()
+    return new NativeDate(NOW).toString();
+  }
+}
+
+// Manually set static methods to reduce leaking inherited class. This ensures
+// that `now()` and `constructor()` of NativeDate are not exposed
+JstzDate.now = () => NOW;
+JstzDate.parse = (...args) => NativeDate.parse(...args);
+JstzDate.UTC = (...args) => NativeDate.UTC(...args);
+
+// Forwards instance methods
+JstzDate.prototype = NativeDate.prototype;
+JstzDate.prototype.contructor = JstzDate;
+
 // https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope
 const workerGlobalScope = {
   AbortController: core.propNonEnumerable(abortSignal.AbortController),
@@ -45,6 +113,7 @@ const workerGlobalScope = {
   CompressionStream: core.propNonEnumerable(compression.CompressionStream),
   CountQueuingStrategy: core.propNonEnumerable(streams.CountQueuingStrategy),
   CustomEvent: core.propNonEnumerable(event.CustomEvent),
+  Date: core.propNonEnumerable(JstzDate),
   DecompressionStream: core.propNonEnumerable(compression.DecompressionStream),
   DedicatedWorkerGlobalScope:
     globalInterfaces.dedicatedWorkerGlobalScopeConstructorDescriptor,
@@ -57,7 +126,8 @@ const workerGlobalScope = {
   FormData: core.propNonEnumerable(formData.FormData),
   Headers: core.propNonEnumerable(headers.Headers),
   ImageData: core.propNonEnumerable(imageData.ImageData),
-  Math: GlobalMath,
+  Math: core.propNonEnumerable(GlobalMath),
+  NotSupported: core.propNonEnumerable(NotSupported),
   MessageChannel: core.propNonEnumerable(messagePort.MessageChannel),
   MessageEvent: core.propNonEnumerable(event.MessageEvent),
   MessagePort: core.propNonEnumerable(messagePort.MessagePort),
@@ -106,15 +176,27 @@ const workerGlobalScope = {
   WorkerLocation: location.workerLocationConstructorDescriptor,
   atob: core.propWritable(base64.atob),
   btoa: core.propWritable(base64.btoa),
-  clearInterval: core.propWritable(timers.clearInterval),
-  clearTimeout: core.propWritable(timers.clearTimeout),
+  // clearInterval: core.propWritable(timers.clearInterval),
+  clearInterval: core.propWritable((..._args) => {
+    throw new NotSupported("'clearInterval()' is not supported");
+  }),
+  // clearTimeout: core.propWritable(timers.clearTimeout),
+  clearTimeout: core.propWritable((..._args) => {
+    throw new NotSupported("'clearTimeout()' is not supported");
+  }),
   console: core.propNonEnumerable(jstzConsole),
   fetch: core.propWritable(fetch.fetch),
   location: location.workerLocationDescriptor,
   performance: core.propWritable(performance.performance),
   reportError: core.propWritable(event.reportError),
-  setInterval: core.propWritable(timers.setInterval),
-  setTimeout: core.propWritable(timers.setTimeout),
+  // setInterval: core.propWritable(timers.setInterval),
+  setInterval: core.propWritable((..._args) => {
+    throw new NotSupported("'setInterval()' is not supported");
+  }),
+  // setTimeout: core.propWritable(timers.setTimeout)
+  setTimeout: core.propWritable((..._args) => {
+    throw new NotSupported("'setTimeout()' is not supported");
+  }),
   structuredClone: core.propWritable(messagePort.structuredClone),
   [webidl.brand]: core.propNonEnumerable(webidl.brand),
   Kv: {

--- a/crates/jstz_runtime/src/ext/jstz_main/mod.rs
+++ b/crates/jstz_runtime/src/ext/jstz_main/mod.rs
@@ -6,3 +6,35 @@ extension!(
   esm_entry_point = "ext:jstz_main/99_main.js",
   esm = [dir "src/ext/jstz_main", "98_global_scope.js", "99_main.js"],
 );
+
+#[cfg(test)]
+mod test {
+    use crate::init_test_setup;
+
+    #[test]
+    pub fn random_returns_constant() {
+        init_test_setup! {
+            runtime = runtime;
+        };
+        let code = r#"
+          let collected = []
+          function assert(expected, value) {
+              if (value !== expected) throw new Error(`${value}  !== ${expected}`)
+              collected.push(value)
+          }
+          for (let i = 0; i <10; i++) {
+              assert(0.42, Math.random())
+          }
+          assert(2304, Math.max(0.123, 2304))
+          assert(0.123, Math.min(0.123, 2304))
+          assert(-1, Math.sign(-3));
+          collected
+        "#;
+        let result: Vec<f64> = runtime.execute_with_result(code).unwrap();
+        let expected = [vec![0.42; 10], vec![2304.0, 0.123, -1.0]].concat();
+        assert_eq!(expected, result);
+    }
+
+    #[test]
+    pub fn time_is_unsupported() {}
+}

--- a/crates/jstz_runtime/src/ext/jstz_main/mod.rs
+++ b/crates/jstz_runtime/src/ext/jstz_main/mod.rs
@@ -4,19 +4,21 @@ extension!(
   jstz_main,
   deps = [deno_webidl, deno_console, jstz_console, deno_url, deno_web],
   esm_entry_point = "ext:jstz_main/99_main.js",
-  esm = [dir "src/ext/jstz_main", "98_global_scope.js", "99_main.js"],
+  esm = [dir "src/ext/jstz_main", "01_errors.js", "98_global_scope.js", "99_main.js"],
 );
 
 #[cfg(test)]
 mod test {
+    use deno_core::{serde_v8, v8};
+    use jstz_utils::test_util::TOKIO_MULTI_THREAD;
+
     use crate::init_test_setup;
 
     #[test]
     pub fn random_returns_constant() {
-        init_test_setup! {
-            runtime = runtime;
-        };
-        let code = r#"
+        TOKIO_MULTI_THREAD.block_on(async {
+            let code = r#"
+        const handler = () => {
           let collected = []
           function assert(expected, value) {
               if (value !== expected) throw new Error(`${value}  !== ${expected}`)
@@ -28,13 +30,116 @@ mod test {
           assert(2304, Math.max(0.123, 2304))
           assert(0.123, Math.min(0.123, 2304))
           assert(-1, Math.sign(-3));
-          collected
+          return collected
+        };
+
+        export default handler;
         "#;
-        let result: Vec<f64> = runtime.execute_with_result(code).unwrap();
-        let expected = [vec![0.42; 10], vec![2304.0, 0.123, -1.0]].concat();
-        assert_eq!(expected, result);
+            init_test_setup! {
+                runtime = runtime;
+                specifier = (s, code);
+            };
+            let id = runtime.execute_main_module(&s).await.unwrap();
+            let result = runtime.call_default_handler(id, &[]).await.unwrap();
+            let result = {
+                let scope = &mut runtime.handle_scope();
+                let local = v8::Local::new(scope, result);
+                serde_v8::from_v8::<Vec<f64>>(scope, local).unwrap()
+            };
+            let expected = [vec![0.42; 10], vec![2304.0, 0.123, -1.0]].concat();
+            assert_eq!(expected, result);
+        })
     }
 
     #[test]
-    pub fn time_is_unsupported() {}
+    pub fn date_returns_constant() {
+        TOKIO_MULTI_THREAD.block_on(async {
+            let code = r#"
+          export default () => {
+            function assert(expected, value) {
+                if (value !== expected) throw new Error(`${value}  !== ${expected}`)
+            }
+            assert(1530380397121, Date.now())
+            assert(1530380397121, new Date().getTime())
+            assert("Sat Jun 30 2018 17:39:57 GMT+0000 (Coordinated Universal Time)", Date())
+            assert(1530380397121, new Date(1530380397121).getTime())
+            assert("Thu Nov 12 2020 00:00:00 GMT+0000 (Coordinated Universal Time)", new Date(2020, 10, 12).toString())
+          }
+        "#;
+
+            init_test_setup! {
+                runtime = runtime;
+                specifier = (s, code);
+            };
+
+            let id = runtime.execute_main_module(&s).await.unwrap();
+            runtime.call_default_handler(id, &[]).await.expect("Unexpected error!");
+        });
+    }
+
+    #[test]
+    #[allow(non_snake_case)]
+    pub fn setTimeout_not_supported() {
+        TOKIO_MULTI_THREAD.block_on(async {
+            let code = r#"let handler = () => setTimeout(() => console.log('hello'), 100);
+                export default handler"#;
+            init_test_setup! {
+                  runtime = runtime;
+                  specifier = (s, code);
+            }
+            let id = runtime.execute_main_module(&s).await.unwrap();
+            let error = runtime.call_default_handler(id, &[]).await.unwrap_err();
+            assert_eq!(error.to_string(), "NotSupported: 'setTimeout()' is not supported\n    at ext:jstz_main/98_global_scope.js:198:11\n    at handler (file://jstz/accounts/root:1:21)");
+        });
+    }
+
+    #[test]
+    #[allow(non_snake_case)]
+    pub fn setInterval_not_supported() {
+        TOKIO_MULTI_THREAD.block_on(async {
+        let code = r#"let handler = () => setInterval(() => console.log('hello'), 100);
+                      export default handler"#;
+        init_test_setup! {
+              runtime = runtime;
+              specifier = (s, code);
+        }
+        let id = runtime.execute_main_module(&s).await.unwrap();
+        let error = runtime.call_default_handler(id, &[]).await.unwrap_err();
+        // FIXME: Do not show line number stacktrace to users
+        // https://linear.app/tezos/issue/JSTZ-665
+        assert_eq!(error.to_string(), "NotSupported: 'setInterval()' is not supported\n    at ext:jstz_main/98_global_scope.js:194:11\n    at handler (file://jstz/accounts/root:1:21)");
+      });
+    }
+
+    #[test]
+    #[allow(non_snake_case)]
+    pub fn clearTimeout_not_supported() {
+        TOKIO_MULTI_THREAD.block_on(async {
+            let code = r#"let handler = () => clearTimeout(null);
+                      export default handler"#;
+            init_test_setup! {
+              runtime = runtime;
+              specifier = (s, code);
+            }
+            let id = runtime.execute_main_module(&s).await.unwrap();
+            let error = runtime.call_default_handler(id, &[]).await.unwrap_err();
+            assert_eq!(error.to_string(), "NotSupported: 'clearTimeout()' is not supported\n    at ext:jstz_main/98_global_scope.js:185:11\n    at handler (file://jstz/accounts/root:1:21)");
+        });
+    }
+
+    #[test]
+    #[allow(non_snake_case)]
+    pub fn clearInterval_not_supported() {
+        TOKIO_MULTI_THREAD.block_on(async {
+            let code = r#"let handler = () => clearInterval(null);
+                    export default handler;"#;
+            init_test_setup! {
+                  runtime = runtime;
+                  specifier = (s, code);
+            }
+            let id = runtime.execute_main_module(&s).await.unwrap();
+            let error = runtime.call_default_handler(id, &[]).await.unwrap_err();
+            assert_eq!(error.to_string(), "NotSupported: 'clearInterval()' is not supported\n    at ext:jstz_main/98_global_scope.js:181:11\n    at handler (file://jstz/accounts/root:1:21)");
+        });
+    }
 }


### PR DESCRIPTION
# Context
Random and timers will subbed in RISCV but we'd like them stub in native execution too.
<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
Stub `Date.now` and  `Math.random` with constant values and make set/clear timeout/interval throw `NotSupported` error

Date is particularly difficult to stub because it has 5 constructors and since it is a built in types, its internals are completely opaque. My implementation tries to hide as much of the prototype chain as possible without re-writing the entire class but a motivated attacker would still be able to quite easily access it and call its functions. 

This solution temporary and exists while we are in native execution mode. RISCV solves this in kernel space, so I think its ok. 

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
`cargo nextest  run -p jstz_runtime jstz_main`
<!-- Describe how reviewers and approvers can test this PR. -->
