### PR TITLE
feat(docs): add biel chatbot and search

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -3,6 +3,14 @@
 
 import { themes } from "prism-react-renderer";
 
+const BIEL_PROJECT = "w30c27l8fg";
+const BIEL_WARNING =
+  'AI-generated answers may contain errors. Verify the information before use. For more information, see <a href="https://docs.tezos.com/overview/chatbot">Using the chatbot</a>.';
+const BIEL_SEARCH_HEADER_TITLE =
+  "Search or use AI to learn about Jstz and Tezos";
+const BIEL_SEARCH_BOX_TEXT = "Search all docs/Ask AI";
+const ALGOLIA_SEARCH_BOX_TEXT = "Search Jstz docs";
+
 // script-src causes development builds to fail
 // But unsafe-eval should NOT be in production builds
 // Also, put GTM first because sometimes the ';' in the escaped single quotes causes the browser to think it's the end
@@ -21,7 +29,7 @@ font-src https://cdn.jsdelivr.net https://fonts.gstatic.com 'self';
 img-src 'self' https://*.googletagmanager.com https://*.google-analytics.com data: 'unsafe-eval';
 media-src 'self';
 form-action 'self';
-connect-src 'self' https://*.algolia.net https://*.algolianet.com https://*.googletagmanager.com https://*.google-analytics.com https://*.analytics.google.com;`;
+connect-src 'self' https://*.algolia.net https://*.algolianet.com https://*.googletagmanager.com https://*.google-analytics.com https://*.analytics.google.com wss://app.biel.ai https://app.biel.ai;`;
 
 /** @type {import('@docusaurus/types').Config} */
 module.exports = async function createConfigAsync() {
@@ -39,6 +47,13 @@ module.exports = async function createConfigAsync() {
     i18n: {
       defaultLocale: "en",
       locales: ["en"],
+    },
+    customFields: {
+      BIEL_PROJECT,
+      BIEL_WARNING,
+      BIEL_SEARCH_HEADER_TITLE,
+      BIEL_SEARCH_BOX_TEXT,
+      ALGOLIA_SEARCH_BOX_TEXT,
     },
 
     headTags: [
@@ -94,6 +109,22 @@ module.exports = async function createConfigAsync() {
           min: 640, // min resized image's size. if original is lower, use that size.
           steps: 2, // the max number of images generated between min and max (inclusive)
           disableInDev: false,
+        },
+      ],
+      [
+        "docusaurus-biel",
+        {
+          project: BIEL_PROJECT,
+          headerTitle: "Jstz/Tezos documentation chatbot (beta)",
+          buttonPosition: "center-right",
+          version: "latest",
+          suggestedQuestions: [
+            "Write a simple smart function for me.",
+            "How do I deploy a smart function?",
+            "What can I do and not do with smart functions?",
+          ],
+          welcomeMessage: "Hi! How can I help you learn about Jstz and Tezos?",
+          footerText: BIEL_WARNING,
         },
       ],
     ],

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,6 +18,7 @@
     "@docusaurus/plugin-ideal-image": "3.7.0",
     "@docusaurus/preset-classic": "3.7.0",
     "@mdx-js/react": "3.1.0",
+    "docusaurus-biel": "1.0.6",
     "plugin-image-zoom": "github:flexanalytics/plugin-image-zoom",
     "prism-react-renderer": "2.4.1",
     "react": "18.2",

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -62,6 +62,12 @@
   --ifm-color-primary-lightest: #3cad6e;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+
+  --biel-bot-footer-link: #0d61ff;
+  --biel-search-button-bg-color: transparent;
+  --biel-search-button-border-color: #fff;
+  --biel-search-button-text-color: #fff;
+  --biel-search-button-text-font-size: 14px;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */

--- a/docs/src/theme/SearchBar/index.js
+++ b/docs/src/theme/SearchBar/index.js
@@ -1,0 +1,216 @@
+import React, { useCallback, useMemo, useRef, useState } from "react";
+import { DocSearchButton, useDocSearchKeyboardEvents } from "@docsearch/react";
+import Head from "@docusaurus/Head";
+import Link from "@docusaurus/Link";
+import { useHistory } from "@docusaurus/router";
+import {
+  isRegexpStringMatch,
+  useSearchLinkCreator,
+} from "@docusaurus/theme-common";
+import {
+  useAlgoliaContextualFacetFilters,
+  useSearchResultUrlProcessor,
+} from "@docusaurus/theme-search-algolia/client";
+import Translate from "@docusaurus/Translate";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import { createPortal } from "react-dom";
+import translations from "@theme/SearchTranslations";
+import clsx from "clsx";
+import styles from "./styles.module.css";
+
+let DocSearchModal = null;
+function Hit({ hit, children }) {
+  return <Link to={hit.url}>{children}</Link>;
+}
+function ResultsFooter({ state, onClose }) {
+  const createSearchLink = useSearchLinkCreator();
+  return (
+    <Link to={createSearchLink(state.query)} onClick={onClose}>
+      <Translate
+        id="theme.SearchBar.seeAll"
+        values={{ count: state.context.nbHits }}
+      >
+        {"See all {count} results"}
+      </Translate>
+    </Link>
+  );
+}
+function mergeFacetFilters(f1, f2) {
+  const normalize = (f) => (typeof f === "string" ? [f] : f);
+  return [...normalize(f1), ...normalize(f2)];
+}
+function DocSearch({ contextualSearch, externalUrlRegex, ...props }) {
+  const { siteMetadata } = useDocusaurusContext();
+  const processSearchResultUrl = useSearchResultUrlProcessor();
+  const contextualSearchFacetFilters = useAlgoliaContextualFacetFilters();
+  const configFacetFilters = props.searchParameters?.facetFilters ?? [];
+  const facetFilters = contextualSearch
+    ? // Merge contextual search filters with config filters
+      mergeFacetFilters(contextualSearchFacetFilters, configFacetFilters)
+    : // ... or use config facetFilters
+      configFacetFilters;
+  // We let user override default searchParameters if she wants to
+  const searchParameters = {
+    ...props.searchParameters,
+    facetFilters,
+  };
+  const history = useHistory();
+  const searchContainer = useRef(null);
+  const searchButtonRef = useRef(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [initialQuery, setInitialQuery] = useState(undefined);
+  const importDocSearchModalIfNeeded = useCallback(() => {
+    if (DocSearchModal) {
+      return Promise.resolve();
+    }
+    return Promise.all([
+      import("@docsearch/react/modal"),
+      import("@docsearch/react/style"),
+      import("./styles.css"),
+    ]).then(([{ DocSearchModal: Modal }]) => {
+      DocSearchModal = Modal;
+    });
+  }, []);
+  const onOpen = useCallback(() => {
+    importDocSearchModalIfNeeded().then(() => {
+      searchContainer.current = document.createElement("div");
+      document.body.insertBefore(
+        searchContainer.current,
+        document.body.firstChild,
+      );
+      setIsOpen(true);
+    });
+  }, [importDocSearchModalIfNeeded, setIsOpen]);
+  const onClose = useCallback(() => {
+    setIsOpen(false);
+    searchContainer.current?.remove();
+  }, [setIsOpen]);
+  const onInput = useCallback(
+    (event) => {
+      importDocSearchModalIfNeeded().then(() => {
+        setIsOpen(true);
+        setInitialQuery(event.key);
+      });
+    },
+    [importDocSearchModalIfNeeded, setIsOpen, setInitialQuery],
+  );
+  const navigator = useRef({
+    navigate({ itemUrl }) {
+      // Algolia results could contain URL's from other domains which cannot
+      // be served through history and should navigate with window.location
+      if (isRegexpStringMatch(externalUrlRegex, itemUrl)) {
+        window.location.href = itemUrl;
+      } else {
+        history.push(itemUrl);
+      }
+    },
+  }).current;
+  const transformItems = useRef((items) =>
+    props.transformItems
+      ? // Custom transformItems
+        props.transformItems(items)
+      : // Default transformItems
+        items.map((item) => ({
+          ...item,
+          url: processSearchResultUrl(item.url),
+        })),
+  ).current;
+  const resultsFooterComponent = useMemo(
+    () =>
+      // eslint-disable-next-line react/no-unstable-nested-components
+      (footerProps) => <ResultsFooter {...footerProps} onClose={onClose} />,
+    [onClose],
+  );
+  const transformSearchClient = useCallback(
+    (searchClient) => {
+      searchClient.addAlgoliaAgent(
+        "docusaurus",
+        siteMetadata.docusaurusVersion,
+      );
+      return searchClient;
+    },
+    [siteMetadata.docusaurusVersion],
+  );
+  useDocSearchKeyboardEvents({
+    isOpen,
+    onOpen,
+    onClose,
+    onInput,
+    searchButtonRef,
+  });
+
+  const { siteConfig } = useDocusaurusContext();
+
+  const customTranslations = {
+    button: {
+      buttonText: siteConfig.customFields.ALGOLIA_SEARCH_BOX_TEXT,
+      buttonAriaLabel: siteConfig.customFields.ALGOLIA_SEARCH_BOX_TEXT,
+    },
+    placeholder: siteConfig.customFields.ALGOLIA_SEARCH_BOX_TEXT,
+  };
+
+  return (
+    <>
+      <Head>
+        {/* This hints the browser that the website will load data from Algolia,
+        and allows it to preconnect to the DocSearch cluster. It makes the first
+        query faster, especially on mobile. */}
+        <link
+          rel="preconnect"
+          href={`https://${props.appId}-dsn.algolia.net`}
+          crossOrigin="anonymous"
+        />
+      </Head>
+
+      <DocSearchButton
+        onTouchStart={importDocSearchModalIfNeeded}
+        onFocus={importDocSearchModalIfNeeded}
+        onMouseOver={importDocSearchModalIfNeeded}
+        onClick={onOpen}
+        ref={searchButtonRef}
+        translations={customTranslations.button}
+      />
+
+      {isOpen &&
+        DocSearchModal &&
+        searchContainer.current &&
+        createPortal(
+          <DocSearchModal
+            onClose={onClose}
+            initialScrollY={window.scrollY}
+            initialQuery={initialQuery}
+            navigator={navigator}
+            transformItems={transformItems}
+            hitComponent={Hit}
+            transformSearchClient={transformSearchClient}
+            {...(props.searchPagePath && {
+              resultsFooterComponent,
+            })}
+            {...props}
+            searchParameters={searchParameters}
+            placeholder={customTranslations.placeholder}
+            translations={translations.modal}
+          />,
+          searchContainer.current,
+        )}
+    </>
+  );
+}
+export default function SearchBar() {
+  const { siteConfig } = useDocusaurusContext();
+  return (
+    <div className={clsx(styles.container)}>
+      <biel-search-button
+        project={siteConfig.customFields.BIEL_PROJECT}
+        hide-ctrl-k="true"
+        button-style="rounded"
+        header-title={siteConfig.customFields.BIEL_SEARCH_HEADER_TITLE}
+        search-placeholder={siteConfig.customFields.BIEL_SEARCH_BOX_TEXT}
+        footer-text={siteConfig.customFields.BIEL_WARNING}
+      >
+        {siteConfig.customFields.BIEL_SEARCH_BOX_TEXT}
+      </biel-search-button>
+      <DocSearch {...siteConfig.themeConfig.algolia} />
+    </div>
+  );
+}

--- a/docs/src/theme/SearchBar/styles.css
+++ b/docs/src/theme/SearchBar/styles.css
@@ -1,0 +1,40 @@
+:root {
+  --docsearch-primary-color: none !important;
+  --docsearch-text-color: var(--ifm-font-color-base);
+  --docsearch-hit-active-color: inherit;
+}
+
+.DocSearch-Button {
+  margin: 0;
+  background-color: #030405;
+  border: 1px white solid !important;
+  transition: all var(--ifm-transition-fast)
+    var(--ifm-transition-timing-default);
+}
+
+.DocSearch-Button:hover,
+.DocSearch-Button:focus,
+.DocSearch-Button:active {
+  background: #030405;
+  background-color: #030405;
+  border-color: gray !important;
+  box-shadow: var(--docsearch-searchbox-shadow);
+}
+
+.DocSearch-Container {
+  z-index: calc(var(--ifm-z-index-fixed) + 1);
+}
+
+.DocSearch-Button-Keys {
+  display: none;
+}
+
+.DocSearch-Button-Placeholder {
+  font-family: "Inter", "Tahoma", "sans-serif";
+  font-size: 14px;
+  color: #ffffff;
+}
+
+.DocSearch-Search-Icon path {
+  color: #ffffff;
+}

--- a/docs/src/theme/SearchBar/styles.module.css
+++ b/docs/src/theme/SearchBar/styles.module.css
@@ -1,0 +1,9 @@
+.container {
+  display: inline-flex;
+  line-height: normal;
+  gap: 10px;
+}
+
+.container:first-child {
+  height: 36px;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@docusaurus/plugin-ideal-image": "3.7.0",
         "@docusaurus/preset-classic": "3.7.0",
         "@mdx-js/react": "3.1.0",
+        "docusaurus-biel": "^1.0.6",
         "plugin-image-zoom": "github:flexanalytics/plugin-image-zoom",
         "prism-react-renderer": "2.4.1",
         "react": "18.2",
@@ -9315,6 +9316,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/docusaurus-biel": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/docusaurus-biel/-/docusaurus-biel-1.0.6.tgz",
+      "integrity": "sha512-XdCvq7JE2oyT1nGi3z0QJpkkHJnH2V5BUPBhSVu6k8+ldtNHtTBNPV9y2OZujrsAnEFcRgIYj+9V5KK/0lwZGA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@docusaurus/core": "3.x"
       }
     },
     "node_modules/dom-converter": {
@@ -27539,6 +27549,12 @@
         "esutils": "^2.0.2"
       }
     },
+    "docusaurus-biel": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/docusaurus-biel/-/docusaurus-biel-1.0.6.tgz",
+      "integrity": "sha512-XdCvq7JE2oyT1nGi3z0QJpkkHJnH2V5BUPBhSVu6k8+ldtNHtTBNPV9y2OZujrsAnEFcRgIYj+9V5KK/0lwZGA==",
+      "requires": {}
+    },
     "dom-converter": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
@@ -29765,6 +29781,7 @@
         "@docusaurus/preset-classic": "3.7.0",
         "@mdx-js/react": "3.1.0",
         "@types/node": "^22.13.0",
+        "docusaurus-biel": "^1.0.6",
         "plugin-image-zoom": "github:flexanalytics/plugin-image-zoom",
         "prism-react-renderer": "2.4.1",
         "react": "18.2",


### PR DESCRIPTION
We have a chatbot that's been trained on Tezos docs. I added Jstz to its sources and it can now answer questions about Jstz.

Preview: https://timothymcmackin.github.io/previews/jstz/biel-chatbot

As described in [this page](https://docs.tezos.com/overview/chatbot), the chatbot has a button at the right side of the page and also its own search box at the top. Now one search is AI-powered for all TEzos info and the other is ordinary keyword search of only Jstz docs. 

<img width="539" alt="Screenshot 2025-06-16 at 4 29 51 PM" src="https://github.com/user-attachments/assets/620bb30f-9d07-4d08-b4be-064ba50e6744" />
