### PR TITLE
feat(runtime): terminate slow executions in native environment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1062,6 +1062,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3145,6 +3164,7 @@ dependencies = [
  "jstz_wpt",
  "parking_lot",
  "pin-project",
+ "rayon",
  "regex",
  "serde",
  "serde_json",
@@ -3153,6 +3173,7 @@ dependencies = [
  "tezos-smart-rollup-mock",
  "thiserror 1.0.67",
  "tokio",
+ "tokio-util",
  "url",
  "utoipa",
 ]
@@ -4434,6 +4455,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6928fa44c097620b706542d428957635951bade7143269085389d42c8a4927e"
 dependencies = [
  "bitflags 2.6.0",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ prettytable = "0.10.0"
 pretty_assertions = "1.4.1"
 proptest = "1.1"
 rand = "0.8"
+rayon = "1.10.0"
 regex = "1"
 reqwest = { version = "0.11.24", features = ["json", "blocking","stream"] }
 reqwest-eventsource = "0.5.0"

--- a/crates/jstz_node/Cargo.toml
+++ b/crates/jstz_node/Cargo.toml
@@ -71,4 +71,4 @@ path = "src/main.rs"
 
 [features]
 persistent-logging = []
-v2_runtime = ["jstz_proto/v2_runtime"]
+v2_runtime = ["jstz_proto/v2_runtime", "jstz_proto/native"]

--- a/crates/jstz_proto/Cargo.toml
+++ b/crates/jstz_proto/Cargo.toml
@@ -55,4 +55,4 @@ tokio.workspace = true
 default = ["dep:jstz_api"]
 v2_runtime = ["dep:jstz_runtime", "dep:deno_core", "dep:deno_fetch_base", "dep:deno_error", "dep:tokio"]
 kernel = ["jstz_runtime?/kernel"]
-
+native = ["jstz_runtime?/native"]

--- a/crates/jstz_proto/src/error.rs
+++ b/crates/jstz_proto/src/error.rs
@@ -49,6 +49,7 @@ pub enum Error {
     InvalidInjector,
     #[cfg(feature = "v2_runtime")]
     V2Error(crate::runtime::v2::Error),
+    TimeoutSetupFailed,
 }
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -139,6 +140,9 @@ impl From<Error> for JsError {
             Error::V2Error(_) => {
                 unimplemented!("V2 runtime errors are not supported in boa")
             }
+            Error::TimeoutSetupFailed => JsNativeError::eval()
+                .with_message("TimeoutSetupFailed")
+                .into(),
         }
     }
 }

--- a/crates/jstz_proto/src/runtime/v2/fetch/error.rs
+++ b/crates/jstz_proto/src/runtime/v2/fetch/error.rs
@@ -33,6 +33,9 @@ pub enum FetchError {
     #[class("RuntimeError")]
     #[error("{0}")]
     JstzError(String),
+    #[class("RuntimeError")]
+    #[error("Execution deadline exceeded")]
+    DeadlineExceeded,
 }
 
 #[derive(Serialize)]

--- a/crates/jstz_proto/src/runtime/v2/mod.rs
+++ b/crates/jstz_proto/src/runtime/v2/mod.rs
@@ -6,6 +6,7 @@ use jstz_core::{
     host::{HostRuntime, JsHostRuntime},
     kv::Transaction,
 };
+use jstz_runtime::runtime::ExecutionTimeout;
 use url::Url;
 
 use crate::{
@@ -28,12 +29,44 @@ pub async fn run_toplevel_fetch(
     run_operation: RunFunction,
     operation_hash: OperationHash,
 ) -> Result<RunFunctionReceipt, crate::Error> {
-    Ok(run(hrt, tx, source_address, run_operation, operation_hash).await?)
+    #[allow(unused)]
+    let (timeout, clock) = ExecutionTimeout::new(500, 8);
+    #[cfg(not(feature = "native"))]
+    return Ok(run(
+        hrt,
+        tx,
+        timeout,
+        source_address,
+        run_operation,
+        operation_hash,
+    )
+    .await?);
+
+    #[cfg(feature = "native")]
+    return {
+        let (setup_ok, cancellation_token) = clock.start();
+        if let Ok(true) = setup_ok.await {
+            let r = run(
+                hrt,
+                tx,
+                timeout,
+                source_address,
+                run_operation,
+                operation_hash,
+            )
+            .await?;
+            cancellation_token.cancel();
+            Ok(r)
+        } else {
+            Err(crate::Error::TimeoutSetupFailed)
+        }
+    };
 }
 
 async fn run(
     hrt: &mut impl HostRuntime,
     tx: &mut Transaction,
+    timeout: ExecutionTimeout,
     source_address: &(impl Addressable + 'static),
     run_operation: RunFunction,
     operation_hash: OperationHash,
@@ -44,6 +77,7 @@ async fn run(
     let response: http::Response<Option<Vec<u8>>> = process_and_dispatch_request(
         JsHostRuntime::new(hrt),
         tx.clone(),
+        timeout,
         Some(operation_hash),
         source_address.clone().into(),
         run_operation.method.to_string().into(),
@@ -124,5 +158,65 @@ pub mod test_utils {
         let hashes =
             deploy_smart_functions(scripts, &mut host, &mut tx, &source_address, 0);
         (host, tx, source_address, hashes)
+    }
+
+    #[cfg(feature = "native")]
+    #[tokio::test]
+    async fn timeout() {
+        use http::{HeaderMap, Method, StatusCode, Uri};
+        use jstz_core::kv::Transaction;
+        use jstz_crypto::hash::Blake2b;
+
+        use crate::{
+            context::account::{Account, Address},
+            operation::RunFunction,
+            runtime::ParsedCode,
+        };
+
+        let from = Address::User(jstz_mock::account1());
+        let mut host = tezos_smart_rollup_mock::MockHost::default();
+        let mut tx = Transaction::default();
+
+        let parsed_code = ParsedCode("export default () => { for (;;) {} };".to_string());
+        tx.begin();
+        let f0_addr =
+            Account::create_smart_function(&mut host, &mut tx, &from, 0, parsed_code)
+                .unwrap();
+        let parsed_code = ParsedCode(format!(
+            "export default async () => await fetch(\"jstz://{f0_addr}/\");"
+        ));
+        let f1_addr =
+            Account::create_smart_function(&mut host, &mut tx, &from, 0, parsed_code)
+                .unwrap();
+        let parsed_code = ParsedCode(format!(
+            "export default async () => await fetch(\"jstz://{f1_addr}/\");"
+        ));
+        let func_addr =
+            Account::create_smart_function(&mut host, &mut tx, &from, 0, parsed_code)
+                .unwrap();
+        tx.commit(&mut host).unwrap();
+
+        tx.begin();
+        let receipt = super::run_toplevel_fetch(
+            &mut host,
+            &mut tx,
+            &from,
+            RunFunction {
+                uri: Uri::try_from(&format!("jstz://{}/", func_addr.to_base58_check()))
+                    .unwrap(),
+                method: Method::GET,
+                headers: HeaderMap::new(),
+                body: None,
+                gas_limit: 10000,
+            },
+            Blake2b::from(b"op_hash".as_ref()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(receipt.status_code, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(
+            String::from_utf8(receipt.body.unwrap()).unwrap(),
+            r#"{"class":"RuntimeError","message":"Uncaught Error: execution terminated"}"#
+        );
     }
 }

--- a/crates/jstz_proto/src/runtime/v2/parsed_code.rs
+++ b/crates/jstz_proto/src/runtime/v2/parsed_code.rs
@@ -77,7 +77,8 @@ impl ParsedCode {
             // Explicitly switch off protocol
             protocol: None,
             ..Default::default()
-        });
+        })
+        .map_err(|e| ParseError::Other(e))?;
         let scope = &mut runtime.handle_scope();
 
         let script_origin = script_origin(scope, "code".to_string()).unwrap();

--- a/crates/jstz_runtime/Cargo.toml
+++ b/crates/jstz_runtime/Cargo.toml
@@ -17,6 +17,7 @@ deno_console.workspace = true
 derive_more = { workspace = true, features = ["deref", "deref_mut", "from"] }
 jstz_core = { path = "../jstz_core" }
 jstz_crypto = { path = "../jstz_crypto" }
+rayon = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 tezos-smart-rollup.workspace = true
@@ -24,6 +25,7 @@ tezos-smart-rollup-host.workspace = true
 utoipa.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 deno_webidl.workspace = true
 deno_web.workspace = true
 deno_url.workspace = true
@@ -46,3 +48,4 @@ tezos-smart-rollup-mock.workspace = true
 [features]
 skip-wpt = []
 kernel = []
+native = ["dep:rayon"]

--- a/crates/jstz_runtime/src/error.rs
+++ b/crates/jstz_runtime/src/error.rs
@@ -15,6 +15,9 @@ pub enum RuntimeError {
     SerdeV8(#[from] serde_v8::Error),
     #[class(inherit)]
     WebSysError(#[from] WebSysError),
+    #[class(generic)]
+    #[error("Execution deadline exceeded")]
+    DeadlineExceeded,
 }
 
 #[derive(Debug, thiserror::Error, deno_error::JsError)]

--- a/crates/jstz_runtime/src/ext/jstz_console/mod.rs
+++ b/crates/jstz_runtime/src/ext/jstz_console/mod.rs
@@ -199,7 +199,7 @@ mod tests {
 
     #[test]
     fn console_not_supported() {
-        let mut runtime = JstzRuntime::new(JstzRuntimeOptions::default());
+        let mut runtime = JstzRuntime::new(JstzRuntimeOptions::default()).unwrap();
         let code = r#"console.info("hello")"#;
         let err = runtime.execute(code).unwrap_err();
         assert_eq!(

--- a/crates/jstz_runtime/src/ext/jstz_fetch/mod.rs
+++ b/crates/jstz_runtime/src/ext/jstz_fetch/mod.rs
@@ -68,7 +68,7 @@ mod test {
             let mut runtime = JstzRuntime::new(JstzRuntimeOptions {
                 module_loader: Rc::new(loader),
                 ..Default::default()
-            });
+            }).unwrap();
             let id = runtime.execute_main_module(&specifier).await.unwrap();
             let err = runtime.call_default_handler(id, &[]).await.unwrap_err();
             assert_eq!(

--- a/crates/jstz_runtime/src/ext/jstz_kv/mod.rs
+++ b/crates/jstz_runtime/src/ext/jstz_kv/mod.rs
@@ -118,7 +118,7 @@ pub(crate) mod extension {
 
         #[test]
         fn kv_not_supported() {
-            let mut runtime = JstzRuntime::new(JstzRuntimeOptions::default());
+            let mut runtime = JstzRuntime::new(JstzRuntimeOptions::default()).unwrap();
             let code = r#"Kv.set("hello", "world")"#;
             let err = runtime.execute(code).unwrap_err();
             assert_eq!(

--- a/crates/jstz_runtime/src/lib.rs
+++ b/crates/jstz_runtime/src/lib.rs
@@ -110,7 +110,7 @@ mod test_utils {
                 )?
                 ..Default::default()
 
-            });
+            }).unwrap();
 
             $(let mut $host = init_host;)?
             $(let mut $tx = init_tx;)?

--- a/crates/jstz_runtime/tests/wpt.rs
+++ b/crates/jstz_runtime/tests/wpt.rs
@@ -256,7 +256,8 @@ fn init_runtime(host: &mut impl HostRuntime, tx: &mut Transaction) -> JstzRuntim
         protocol: Some(ProtocolContext::new(host, tx, address, String::new())),
         extensions: vec![test_harness_api::init_ops_and_esm()],
         ..Default::default()
-    });
+    })
+    .unwrap();
 
     let op_state = runtime.op_state();
     // Insert a blank report to be filled in by test cases


### PR DESCRIPTION
# Context

Completes JSTZ-664.
[JSTZ-664](https://linear.app/tezos/issue/JSTZ-664/implement-execution-timeout)

The V2 runtime needs to terminate function calls involving infinite loops.

# Description

Updated the v2 runtime such that executions that take more than 500ms are terminated. This solution involves spinning up a timer in a separate thread, which is not going to work in the rollup, so a feature `native` is introduced to hide the relevant code. This is also why the timeout is set to 500ms -- keeping this too long means that the thread pool needs to be larger as the timer thread does not get cancelled when the corresponding execution finishes early. 500ms should be reasonable, given that there is only one processing unit and that we don't want any execution to block the runtime for too long. Terminating executions in this way is possibly the simplest since there is no need to handle transactions or craft receipt with custom errors outside the runtime. One downside is that the error code is 500 and the error message isn't very clear, but I think this is acceptable for now as long as the main issue is addressed.

# Manually testing the PR

* Unit testing: updated the relevant test in jstz_runtime and added one test in jstz_node to demonstrate that it works.
