### PR TITLE
feat(kernel): add v2_runtime feature to kernel and make target for bu…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2967,12 +2967,8 @@ name = "jstz_kernel"
 version = "0.1.1-alpha.1"
 dependencies = [
  "bincode 2.0.0-rc.3",
- "boa_engine",
  "futures",
  "hex",
- "http 1.1.0",
- "http-serde",
- "jstz_api",
  "jstz_core",
  "jstz_crypto",
  "jstz_mock",

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,10 @@ build-native-kernel:
 riscv-runtime:
 	@RUSTY_V8_ARCHIVE=$$RISCV_V8_ARCHIVE_DIR/librusty_v8.a RUSTY_V8_SRC_BINDING_PATH=$$RISCV_V8_ARCHIVE_DIR/src_binding.rs cargo build -p jstz_runtime --release --target riscv64gc-unknown-linux-musl
 
+.PHONE: riscv-runtime
+riscv-v2-one-shot-kernel:
+	@RUSTY_V8_ARCHIVE=$$RISCV_V8_ARCHIVE_DIR/librusty_v8.a RUSTY_V8_SRC_BINDING_PATH=$$RISCV_V8_ARCHIVE_DIR/src_binding.rs cargo build -p jstz_kernel --no-default-features --features v2_runtime --release --target riscv64gc-unknown-linux-musl
+
 .PHONY: test
 test: test-unit test-int
 

--- a/crates/jstz_kernel/Cargo.toml
+++ b/crates/jstz_kernel/Cargo.toml
@@ -15,12 +15,8 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 bincode.workspace = true
-boa_engine.workspace = true
 hex.workspace = true
 futures.workspace = true
-http-serde.workspace = true
-http.workspace = true
-jstz_api = { path = "../jstz_api" }
 jstz_core = { path = "../jstz_core" }
 jstz_crypto = { path = "../jstz_crypto" }
 jstz_proto = { path = "../jstz_proto" }
@@ -33,3 +29,6 @@ tezos_data_encoding = "0.6.0"
 [dev-dependencies]
 jstz_mock = { path = "../jstz_mock" }
 jstz_utils = { path = "../jstz_utils" }
+
+[features]
+v2_runtime = ["jstz_proto/v2_runtime", "jstz_proto/kernel"]

--- a/crates/jstz_proto/Cargo.toml
+++ b/crates/jstz_proto/Cargo.toml
@@ -22,7 +22,7 @@ erased-serde.workspace = true
 http-serde.workspace = true
 http.workspace = true
 nom.workspace = true
-jstz_api = { path = "../jstz_api" }
+jstz_api = { path = "../jstz_api", optional = true }
 jstz_core = { path = "../jstz_core" }
 jstz_crypto = { path = "../jstz_crypto" }
 serde.workspace = true
@@ -39,7 +39,6 @@ deno_core = { workspace = true, optional = true }
 deno_error = { workspace = true, optional = true }
 deno_fetch_base = { workspace = true, optional = true }
 jstz_runtime = { path = "../jstz_runtime", optional = true }
-jstz_utils = { path = "../jstz_utils", optional = true }
 tokio = { workspace = true, optional = true }
 parking_lot.workspace = true
 thiserror.workspace = true
@@ -53,6 +52,7 @@ tezos-smart-rollup-mock.workspace = true
 tokio.workspace = true
 
 [features]
-v2_runtime = ["dep:jstz_runtime", "dep:deno_core", "dep:deno_fetch_base", "dep:deno_error", "dep:tokio", "dep:jstz_utils"]
+default = ["dep:jstz_api"]
+v2_runtime = ["dep:jstz_runtime", "dep:deno_core", "dep:deno_fetch_base", "dep:deno_error", "dep:tokio"]
 kernel = ["jstz_runtime?/kernel"]
 

--- a/crates/jstz_proto/src/executor/fa_deposit.rs
+++ b/crates/jstz_proto/src/executor/fa_deposit.rs
@@ -1,7 +1,6 @@
 use bincode::{Decode, Encode};
 use derive_more::{Display, Error, From};
 use http::{header::CONTENT_TYPE, HeaderMap, Method, Uri};
-use jstz_api::http::body::HttpBody;
 use jstz_core::{host::HostRuntime, kv::Transaction};
 use jstz_crypto::{hash::Hash, public_key_hash::PublicKeyHash};
 use serde::{Deserialize, Serialize};
@@ -13,7 +12,7 @@ use crate::{
     executor::smart_function,
     operation::{internal::FaDeposit, RunFunction},
     receipt::Receipt,
-    Result,
+    HttpBody, Result,
 };
 
 const FA_DEPOSIT_GAS_LIMIT: usize = usize::MAX;

--- a/crates/jstz_proto/src/executor/fa_withdraw.rs
+++ b/crates/jstz_proto/src/executor/fa_withdraw.rs
@@ -1,6 +1,5 @@
 use bincode::{Decode, Encode};
 use derive_more::{Display, Error, From};
-use jstz_api::http::body::HttpBody;
 use jstz_core::{
     host::HostRuntime,
     kv::{outbox::OutboxMessage, Transaction},
@@ -22,7 +21,7 @@ use crate::{
         account::{Address, Addressable, Amount},
         ticket_table::TicketTable,
     },
-    Error, Result,
+    Error, HttpBody, Result,
 };
 
 const WITHDRAW_ENTRYPOINT: &str = "withdraw";

--- a/crates/jstz_proto/src/lib.rs
+++ b/crates/jstz_proto/src/lib.rs
@@ -15,6 +15,7 @@ pub mod runtime;
 /// https://linear.app/tezos/issue/JSTZ-617/
 pub type BlockLevel = u64;
 pub type Gas = u64;
+pub type HttpBody = Option<Vec<u8>>;
 
 #[cfg(test)]
 mod tests {

--- a/crates/jstz_proto/src/operation.rs
+++ b/crates/jstz_proto/src/operation.rs
@@ -1,12 +1,12 @@
 use crate::runtime::ParsedCode;
 use crate::{
     context::account::{Account, Address, Amount, Nonce},
-    Error, Result,
+    Error, HttpBody, Result,
 };
 use bincode::{Decode, Encode};
 use derive_more::{Deref, Display, From};
 use http::{HeaderMap, Method, Uri};
-use jstz_api::http::body::HttpBody;
+
 use jstz_core::{host::HostRuntime, kv::Transaction, reveal_data::PreimageHash};
 use jstz_crypto::{
     hash::Blake2b, public_key::PublicKey, public_key_hash::PublicKeyHash,

--- a/crates/jstz_proto/src/receipt.rs
+++ b/crates/jstz_proto/src/receipt.rs
@@ -2,11 +2,10 @@ use crate::{
     context::account::Address,
     executor::{fa_deposit::FaDepositReceipt, fa_withdraw::FaWithdrawReceipt},
     operation::OperationHash,
-    Result,
+    HttpBody, Result,
 };
 use bincode::{Decode, Encode};
 use http::{HeaderMap, StatusCode};
-use jstz_api::http::body::HttpBody;
 use jstz_crypto::smart_function_hash::SmartFunctionHash;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;


### PR DESCRIPTION
# Context
Build current kernel (one shot) kernel using `v2_runtime` for drop in replacement to RISCV team's benchmark script.

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
* Support `v2_runtime` feature in `jstz_kernel`
* Remove `jstz_util` from main dependency of proto. It was bringing in openssl which causes problems in riscv
* Cleaned up kernel's `Cargo.toml`
* Make `jstz_api` in proto to slowly get rid of boa when v2 is activated.  We can't fully get rid of jstz_api from the depenency tree because it is depended on heavily by core.
<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
`make`
`make riscv-v2-one-shot-kernel`
<!-- Describe how reviewers and approvers can test this PR. -->
