### PR TITLE
feat(kernel): support riscv pvm kernel event loop

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,9 +1,17 @@
 [target.riscv64gc-unknown-linux-musl]
-linker = "riscv64-unknown-linux-musl-g++"
+linker = "riscv64-unknown-linux-musl-gcc"
 rustflags = [
 	"-C",
 	"target-feature=+crt-static",
 	"-C",
-	"default-linker-libraries",
+	"link-arg=-latomic",
+	"-C",
+	"link-arg=-lstdc++",
+	"-C",
+	"link-arg=-lsupc++",
+	"-C",
+	"link-arg=-lgcc",
+	"-C",
+	"link-arg=-lc"
 ]
 

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.riscv64gc-unknown-linux-musl]
-linker = "riscv64-unknown-linux-musl-gcc"
+linker = "riscv64-unknown-linux-musl-g++"
 rustflags = [
 	"-C",
 	"target-feature=+crt-static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2982,7 +2982,6 @@ name = "jstz_kernel"
 version = "0.1.1-alpha.1"
 dependencies = [
  "bincode 2.0.0-rc.3",
- "futures",
  "hex",
  "jstz_core",
  "jstz_crypto",
@@ -2994,6 +2993,7 @@ dependencies = [
  "tezos-smart-rollup",
  "tezos_crypto_rs 0.6.0",
  "tezos_data_encoding 0.6.0",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,8 +2981,12 @@ dependencies = [
 name = "jstz_kernel"
 version = "0.1.1-alpha.1"
 dependencies = [
+ "anyhow",
  "bincode 2.0.0-rc.3",
+ "derive_more",
+ "futures",
  "hex",
+ "http 1.1.0",
  "jstz_core",
  "jstz_crypto",
  "jstz_mock",
@@ -2990,6 +2994,7 @@ dependencies = [
  "jstz_utils",
  "num-traits",
  "serde",
+ "serde_json",
  "tezos-smart-rollup",
  "tezos_crypto_rs 0.6.0",
  "tezos_data_encoding 0.6.0",
@@ -3006,6 +3011,7 @@ dependencies = [
  "tezos-smart-rollup",
  "tezos-smart-rollup-mock",
  "tezos_crypto_rs 0.6.0",
+ "tezos_data_encoding 0.6.0",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -67,15 +67,15 @@ build-sdk-wasm-pkg:
 build-native-kernel:
 	@cargo build -p jstz_engine --release --features "native-kernel"
 
-.PHONE: riscv-runtime
+.PHONY: riscv-runtime
 riscv-runtime:
 	@RUSTY_V8_ARCHIVE=$$RISCV_V8_ARCHIVE_DIR/librusty_v8.a RUSTY_V8_SRC_BINDING_PATH=$$RISCV_V8_ARCHIVE_DIR/src_binding.rs cargo build -p jstz_runtime --release --target riscv64gc-unknown-linux-musl
 
-.PHONE: riscv-runtime
+.PHONY: riscv-v2-one-shot-kernel
 riscv-v2-one-shot-kernel:
 	@RUSTY_V8_ARCHIVE=$$RISCV_V8_ARCHIVE_DIR/librusty_v8.a RUSTY_V8_SRC_BINDING_PATH=$$RISCV_V8_ARCHIVE_DIR/src_binding.rs cargo build -p jstz_kernel --no-default-features --features v2_runtime --release --target riscv64gc-unknown-linux-musl
 
-	.PHONE: riscv-runtime
+.PHONY: riscv-pvm-kernel
 riscv-pvm-kernel:
 	@RUSTY_V8_ARCHIVE=$$RISCV_V8_ARCHIVE_DIR/librusty_v8.a \
 		RUSTY_V8_SRC_BINDING_PATH=$$RISCV_V8_ARCHIVE_DIR/src_binding.rs \

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,10 @@ riscv-runtime:
 riscv-v2-one-shot-kernel:
 	@RUSTY_V8_ARCHIVE=$$RISCV_V8_ARCHIVE_DIR/librusty_v8.a RUSTY_V8_SRC_BINDING_PATH=$$RISCV_V8_ARCHIVE_DIR/src_binding.rs cargo build -p jstz_kernel --no-default-features --features v2_runtime --release --target riscv64gc-unknown-linux-musl
 
+	.PHONE: riscv-runtime
+riscv-pvm-kernel:
+	@RUSTY_V8_ARCHIVE=$$RISCV_V8_ARCHIVE_DIR/librusty_v8.a RUSTY_V8_SRC_BINDING_PATH=$$RISCV_V8_ARCHIVE_DIR/src_binding.rs cargo build -p jstz_kernel --no-default-features --features riscv_kernel --release --target riscv64gc-unknown-linux-musl
+
 .PHONY: test
 test: test-unit test-int
 

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,14 @@ riscv-v2-one-shot-kernel:
 
 	.PHONE: riscv-runtime
 riscv-pvm-kernel:
-	@RUSTY_V8_ARCHIVE=$$RISCV_V8_ARCHIVE_DIR/librusty_v8.a RUSTY_V8_SRC_BINDING_PATH=$$RISCV_V8_ARCHIVE_DIR/src_binding.rs cargo build -p jstz_kernel --no-default-features --features riscv_kernel --release --target riscv64gc-unknown-linux-musl
+	@RUSTY_V8_ARCHIVE=$$RISCV_V8_ARCHIVE_DIR/librusty_v8.a \
+		RUSTY_V8_SRC_BINDING_PATH=$$RISCV_V8_ARCHIVE_DIR/src_binding.rs \
+		cargo build \
+		-p jstz_kernel \
+		--no-default-features \
+		--features riscv_kernel \
+		--release \
+		--target riscv64gc-unknown-linux-musl \
 
 .PHONY: test
 test: test-unit test-int

--- a/crates/jstz_kernel/Cargo.toml
+++ b/crates/jstz_kernel/Cargo.toml
@@ -15,7 +15,9 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 bincode.workspace = true
+derive_more = { workspace = true, features = ["from"] }
 hex.workspace = true
+futures.workspace = true
 tokio.workspace = true
 jstz_core = { path = "../jstz_core" }
 jstz_crypto = { path = "../jstz_crypto" }
@@ -27,8 +29,12 @@ tezos_crypto_rs.workspace = true
 tezos_data_encoding.workspace = true
 
 [dev-dependencies]
+anyhow.workspace = true
 jstz_mock = { path = "../jstz_mock" }
 jstz_utils = { path = "../jstz_utils" }
+http.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
 
 [features]
 v2_runtime = ["jstz_proto/v2_runtime", "jstz_proto/kernel"]

--- a/crates/jstz_kernel/Cargo.toml
+++ b/crates/jstz_kernel/Cargo.toml
@@ -18,7 +18,7 @@ bincode.workspace = true
 derive_more = { workspace = true, features = ["from"] }
 hex.workspace = true
 futures.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, optional = true }
 jstz_core = { path = "../jstz_core" }
 jstz_crypto = { path = "../jstz_crypto" }
 jstz_proto = { path = "../jstz_proto" }
@@ -38,4 +38,4 @@ tokio.workspace = true
 
 [features]
 v2_runtime = ["jstz_proto/v2_runtime", "jstz_proto/kernel"]
-riscv_kernel = ["v2_runtime"]
+riscv_kernel = ["v2_runtime", "dep:tokio"]

--- a/crates/jstz_kernel/Cargo.toml
+++ b/crates/jstz_kernel/Cargo.toml
@@ -13,6 +13,11 @@ description.workspace = true
 [lib]
 crate-type = ["cdylib", "lib"]
 
+[[bin]]
+name = "kernel-executable"
+path = "src/executable.rs"
+required-features = ["riscv_kernel"]
+
 [dependencies]
 bincode.workspace = true
 derive_more = { workspace = true, features = ["from"] }

--- a/crates/jstz_kernel/Cargo.toml
+++ b/crates/jstz_kernel/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 bincode.workspace = true
 hex.workspace = true
-futures.workspace = true
+tokio.workspace = true
 jstz_core = { path = "../jstz_core" }
 jstz_crypto = { path = "../jstz_crypto" }
 jstz_proto = { path = "../jstz_proto" }
@@ -24,7 +24,7 @@ num-traits.workspace = true
 serde.workspace = true
 tezos-smart-rollup.workspace = true
 tezos_crypto_rs.workspace = true
-tezos_data_encoding = "0.6.0"
+tezos_data_encoding.workspace = true
 
 [dev-dependencies]
 jstz_mock = { path = "../jstz_mock" }
@@ -32,3 +32,4 @@ jstz_utils = { path = "../jstz_utils" }
 
 [features]
 v2_runtime = ["jstz_proto/v2_runtime", "jstz_proto/kernel"]
+riscv_kernel = ["v2_runtime"]

--- a/crates/jstz_kernel/src/executable.rs
+++ b/crates/jstz_kernel/src/executable.rs
@@ -1,0 +1,8 @@
+#![cfg(feature = "riscv_kernel")]
+use tezos_smart_rollup::{entrypoint, host::Runtime};
+
+// kernel entry
+#[entrypoint::main]
+pub fn entry(rt: &mut impl Runtime) {
+    jstz_kernel::riscv_kernel::run(rt);
+}

--- a/crates/jstz_kernel/src/inbox.rs
+++ b/crates/jstz_kernel/src/inbox.rs
@@ -3,6 +3,7 @@ use jstz_proto::context::account::Address;
 use jstz_proto::operation::{internal::Deposit, InternalOperation, SignedOperation};
 use num_traits::ToPrimitive;
 use tezos_crypto_rs::hash::{ContractKt1Hash, SmartRollupHash};
+use tezos_smart_rollup::inbox::InfoPerLevel;
 use tezos_smart_rollup::michelson::ticket::FA2_1Ticket;
 use tezos_smart_rollup::michelson::{
     MichelsonBytes, MichelsonContract, MichelsonNat, MichelsonOption, MichelsonOr,
@@ -43,7 +44,16 @@ pub fn read_message(
 ) -> Option<Message> {
     let input = rt.read_input().ok()??;
     let jstz_rollup_address = rt.reveal_metadata().address();
-    parse_inbox_message(rt, input.id, input.as_ref(), ticketer, &jstz_rollup_address)
+    match parse_inbox_message(
+        rt,
+        input.id,
+        input.as_ref(),
+        ticketer,
+        &jstz_rollup_address,
+    )? {
+        ParsedInboxMessage::JstzMessage(message) => Some(message),
+        _ => None,
+    }
 }
 
 /// Parse a hex-encoded L1 inbox input message into a jstz operation.
@@ -72,16 +82,21 @@ pub fn parse_inbox_message_hex(
     jstz_rollup_address: &SmartRollupHash,
 ) -> Option<Message> {
     let inbox_msg = hex::decode(inbox_msg).ok()?;
-    parse_inbox_message(logger, inbox_id, &inbox_msg, ticketer, jstz_rollup_address)
+    let msg =
+        parse_inbox_message(logger, inbox_id, &inbox_msg, ticketer, jstz_rollup_address)?;
+    match msg {
+        ParsedInboxMessage::JstzMessage(message) => Some(message),
+        _ => None,
+    }
 }
 
-fn parse_inbox_message(
+pub fn parse_inbox_message(
     logger: &impl WriteDebug,
     inbox_id: u32,
     inbox_msg: &[u8],
     ticketer: &ContractKt1Hash,
     jstz_rollup_address: &SmartRollupHash,
-) -> Option<Message> {
+) -> Option<ParsedInboxMessage> {
     let (_, message) = InboxMessage::<RollupType>::parse(inbox_msg).ok()?;
 
     match message {
@@ -89,7 +104,7 @@ fn parse_inbox_message(
             // Start of level message pushed by the Layer 1 at the
             // beginning of eavh level.
             logger.write_debug("Internal message: start of level\n");
-            None
+            Some(LevelInfo::Start.into())
         }
         InboxMessage::Internal(InternalInboxMessage::InfoPerLevel(info)) => {
             // The "Info per level" messages follows the "Start of level"
@@ -99,13 +114,13 @@ fn parse_inbox_message(
                         (block predecessor: {}, predecessor_timestamp: {}\n",
                 info.predecessor, info.predecessor_timestamp
             ));
-            None
+            Some(LevelInfo::Info(info).into())
         }
         InboxMessage::Internal(InternalInboxMessage::EndOfLevel) => {
             // The "End of level" message is pushed by the Layer 1
             // at the end of each level.
             logger.write_debug("Internal message: end of level\n");
-            None
+            Some(LevelInfo::End.into())
         }
         InboxMessage::Internal(InternalInboxMessage::Transfer(transfer)) => {
             if jstz_rollup_address != transfer.destination.hash() {
@@ -114,14 +129,16 @@ fn parse_inbox_message(
                 );
                 return None;
             };
-            read_transfer(logger, transfer, ticketer, inbox_id)
+            read_transfer(logger, transfer, ticketer, inbox_id).map(|m| m.into())
         }
         InboxMessage::External(bytes) => match ExternalMessageFrame::parse(bytes) {
             Ok(frame) => match frame {
                 ExternalMessageFrame::Targetted { address, contents } => {
-                    if jstz_rollup_address != address.hash() {
+                    let message = if jstz_rollup_address != address.hash() {
+                        println!("JSTZ_ADDRESS: {}", jstz_rollup_address);
+                        println!("ROLLUP ADDRESS: {}", address.hash());
                         logger.write_debug(
-                         "External message ignored because of different smart rollup address",
+                            "External message ignored because of different smart rollup address",
                         );
                         None
                     } else {
@@ -134,7 +151,8 @@ fn parse_inbox_message(
                                 None
                             }
                         }
-                    }
+                    };
+                    message.map(|m| m.into())
                 }
             },
             Err(_) => {
@@ -216,8 +234,21 @@ fn read_external_message(
     bytes: &[u8],
 ) -> Option<ExternalMessage> {
     let msg = ExternalMessage::decode(bytes).ok()?;
-    logger.write_debug("External message: {msg:?}\n");
+    logger.write_debug(format!("External message: {msg:?}\n").as_str());
     Some(msg)
+}
+
+#[derive(derive_more::From)]
+pub enum ParsedInboxMessage {
+    JstzMessage(Message),
+    LevelInfo(LevelInfo),
+}
+
+pub enum LevelInfo {
+    // Start of level
+    Start,
+    Info(InfoPerLevel),
+    End,
 }
 
 #[cfg(test)]

--- a/crates/jstz_kernel/src/inbox.rs
+++ b/crates/jstz_kernel/src/inbox.rs
@@ -42,7 +42,6 @@ pub fn read_message(
     ticketer: &ContractKt1Hash,
 ) -> Option<Message> {
     let input = rt.read_input().ok()??;
-    let _ = rt.mark_for_reboot();
     let jstz_rollup_address = rt.reveal_metadata().address();
     parse_inbox_message(rt, input.id, input.as_ref(), ticketer, &jstz_rollup_address)
 }

--- a/crates/jstz_kernel/src/inbox.rs
+++ b/crates/jstz_kernel/src/inbox.rs
@@ -135,8 +135,6 @@ pub fn parse_inbox_message(
             Ok(frame) => match frame {
                 ExternalMessageFrame::Targetted { address, contents } => {
                     let message = if jstz_rollup_address != address.hash() {
-                        println!("JSTZ_ADDRESS: {}", jstz_rollup_address);
-                        println!("ROLLUP ADDRESS: {}", address.hash());
                         logger.write_debug(
                             "External message ignored because of different smart rollup address",
                         );
@@ -234,7 +232,7 @@ fn read_external_message(
     bytes: &[u8],
 ) -> Option<ExternalMessage> {
     let msg = ExternalMessage::decode(bytes).ok()?;
-    logger.write_debug(format!("External message: {msg:?}\n").as_str());
+    logger.write_debug(&format!("External message: {msg:?}\n"));
     Some(msg)
 }
 

--- a/crates/jstz_kernel/src/lib.rs
+++ b/crates/jstz_kernel/src/lib.rs
@@ -1,6 +1,14 @@
-use jstz_core::kv::Storage;
+use inbox::Message;
+use jstz_core::kv::{Storage, Transaction};
 use jstz_crypto::{public_key::PublicKey, smart_function_hash::SmartFunctionHash};
-use tezos_smart_rollup::{entrypoint, prelude::Runtime, storage::path::RefPath};
+use jstz_proto::executor;
+use jstz_proto::Result;
+use tezos_crypto_rs::hash::ContractKt1Hash;
+use tezos_smart_rollup::{
+    entrypoint,
+    prelude::{debug_msg, Runtime},
+    storage::path::RefPath,
+};
 
 pub mod inbox;
 pub mod parsing;
@@ -14,12 +22,48 @@ mod wasm_kernel;
 pub const TICKETER: RefPath = RefPath::assert_from(b"/ticketer");
 pub const INJECTOR: RefPath = RefPath::assert_from(b"/injector");
 
-pub(crate) fn read_ticketer(rt: &impl Runtime) -> Option<SmartFunctionHash> {
-    Storage::get(rt, &TICKETER).ok()?
+pub(crate) fn read_ticketer(rt: &impl Runtime) -> SmartFunctionHash {
+    Storage::get(rt, &TICKETER)
+        .ok()
+        .flatten()
+        .expect("Ticketer not found")
 }
 
-pub(crate) fn read_injector(rt: &impl Runtime) -> Option<PublicKey> {
-    Storage::get(rt, &INJECTOR).ok()?
+pub(crate) fn read_injector(rt: &impl Runtime) -> PublicKey {
+    Storage::get(rt, &INJECTOR)
+        .ok()
+        .flatten()
+        .expect("Revealer not found")
+}
+
+pub async fn handle_message(
+    hrt: &mut impl Runtime,
+    message: Message,
+    ticketer: &ContractKt1Hash,
+    tx: &mut Transaction,
+    injector: &PublicKey,
+) -> Result<()> {
+    match message {
+        Message::Internal(internal_operation) => {
+            let receipt =
+                executor::execute_internal_operation(hrt, tx, internal_operation).await;
+            receipt.write(hrt, tx)?
+        }
+        Message::External(signed_operation) => {
+            debug_msg!(hrt, "External operation: {signed_operation:?}\n");
+            let receipt = executor::execute_operation(
+                hrt,
+                tx,
+                signed_operation,
+                ticketer,
+                injector,
+            )
+            .await;
+            debug_msg!(hrt, "Receipt: {receipt:?}\n");
+            receipt.write(hrt, tx)?
+        }
+    }
+    Ok(())
 }
 
 // kernel entry

--- a/crates/jstz_kernel/src/lib.rs
+++ b/crates/jstz_kernel/src/lib.rs
@@ -1,213 +1,33 @@
-use jstz_core::kv::{Storage, Transaction};
+use jstz_core::kv::Storage;
 use jstz_crypto::{public_key::PublicKey, smart_function_hash::SmartFunctionHash};
-use jstz_proto::{executor, Result};
-use tezos_crypto_rs::hash::ContractKt1Hash;
-use tezos_smart_rollup::{
-    entrypoint,
-    prelude::{debug_msg, Runtime},
-    storage::path::RefPath,
-};
+use tezos_smart_rollup::{entrypoint, prelude::Runtime, storage::path::RefPath};
 
-use crate::inbox::{read_message, Message};
 pub mod inbox;
 pub mod parsing;
+
+#[cfg(feature = "riscv_kernel")]
+mod riscv_kernel;
+
+#[cfg(not(feature = "riscv_kernel"))]
+mod wasm_kernel;
 
 pub const TICKETER: RefPath = RefPath::assert_from(b"/ticketer");
 pub const INJECTOR: RefPath = RefPath::assert_from(b"/injector");
 
-fn read_ticketer(rt: &impl Runtime) -> Option<SmartFunctionHash> {
+pub(crate) fn read_ticketer(rt: &impl Runtime) -> Option<SmartFunctionHash> {
     Storage::get(rt, &TICKETER).ok()?
 }
 
-fn read_injector(rt: &impl Runtime) -> Option<PublicKey> {
+pub(crate) fn read_injector(rt: &impl Runtime) -> Option<PublicKey> {
     Storage::get(rt, &INJECTOR).ok()?
-}
-
-async fn handle_message(
-    hrt: &mut impl Runtime,
-    message: Message,
-    ticketer: &ContractKt1Hash,
-    tx: &mut Transaction,
-    injector: &PublicKey,
-) -> Result<()> {
-    match message {
-        Message::Internal(internal_operation) => {
-            let receipt =
-                executor::execute_internal_operation(hrt, tx, internal_operation).await;
-            receipt.write(hrt, tx)?
-        }
-        Message::External(signed_operation) => {
-            debug_msg!(hrt, "External operation: {signed_operation:?}\n");
-            let receipt = executor::execute_operation(
-                hrt,
-                tx,
-                signed_operation,
-                ticketer,
-                injector,
-            )
-            .await;
-            debug_msg!(hrt, "Receipt: {receipt:?}\n");
-            receipt.write(hrt, tx)?
-        }
-    }
-    Ok(())
 }
 
 // kernel entry
 #[entrypoint::main]
 pub fn entry(rt: &mut impl Runtime) {
-    futures::executor::block_on(run(rt))
-}
+    #[cfg(not(feature = "riscv_kernel"))]
+    wasm_kernel::run(rt);
 
-pub async fn run(rt: &mut impl Runtime) {
-    // TODO: we should organize protocol consts into a struct
-    // https://linear.app/tezos/issue/JSTZ-459/organize-protocol-consts-into-a-struct
-    let ticketer = read_ticketer(rt).expect("Ticketer not found");
-    let injector = read_injector(rt).expect("Revealer not found");
-    let mut tx = Transaction::default();
-    tx.begin();
-    if let Some(message) = read_message(rt, &ticketer) {
-        handle_message(rt, message, &ticketer, &mut tx, &injector)
-            .await
-            .unwrap_or_else(|err| debug_msg!(rt, "[🔴] {err:?}\n"));
-    }
-    if let Err(commit_error) = tx.commit(rt) {
-        debug_msg!(rt, "Failed to commit transaction: {commit_error:?}\n");
-    }
-}
-
-#[cfg(test)]
-mod test {
-
-    use jstz_core::{host::HostRuntime, kv::Transaction};
-    use jstz_crypto::hash::Hash;
-    use jstz_mock::{
-        host::{JstzMockHost, MOCK_SOURCE},
-        message::{fa_deposit::MockFaDeposit, native_deposit::MockNativeDeposit},
-    };
-    use jstz_proto::{
-        context::{
-            account::{Account, Address},
-            ticket_table::TicketTable,
-        },
-        executor::smart_function,
-        runtime::ParsedCode,
-    };
-    use jstz_utils::test_util::TOKIO_MULTI_THREAD;
-    use tezos_smart_rollup::types::{Contract, PublicKeyHash};
-
-    use crate::{parsing::try_parse_contract, read_ticketer, run};
-
-    fn wrapped_run(rt: &mut impl HostRuntime) {
-        TOKIO_MULTI_THREAD.block_on(run(rt));
-    }
-
-    #[test]
-    fn read_ticketer_succeeds() {
-        let mut host = JstzMockHost::default();
-        let ticketer = read_ticketer(host.rt()).unwrap();
-        let expected_tickter = host.get_ticketer();
-        assert_eq!(ticketer, expected_tickter)
-    }
-
-    #[test]
-    fn entry_native_deposit_succeeds() {
-        let mut host = JstzMockHost::default();
-        let deposit = MockNativeDeposit::default();
-        host.add_internal_message(&deposit);
-        host.rt().run_level(wrapped_run);
-        let tx = &mut Transaction::default();
-        tx.begin();
-        match deposit.receiver {
-            Contract::Implicit(PublicKeyHash::Ed25519(tz1)) => {
-                let amount = Account::balance(
-                    host.rt(),
-                    tx,
-                    &Address::User(jstz_crypto::public_key_hash::PublicKeyHash::Tz1(
-                        tz1.into(),
-                    )),
-                )
-                .unwrap();
-                assert_eq!(amount, 100);
-            }
-            _ => panic!("Unexpected receiver"),
-        }
-    }
-
-    #[test]
-    fn entry_fa_deposit_succeeds_with_proxy() {
-        let mut host = JstzMockHost::default();
-
-        let tx = &mut Transaction::default();
-        tx.begin();
-        let parsed_code =
-            ParsedCode::try_from(jstz_mock::host::MOCK_PROXY_FUNCTION.to_string())
-                .unwrap();
-        let addr = Address::User(
-            jstz_crypto::public_key_hash::PublicKeyHash::from_base58(MOCK_SOURCE)
-                .unwrap(),
-        );
-        Account::set_balance(host.rt(), tx, &addr, 200).unwrap();
-        let proxy =
-            smart_function::deploy(host.rt(), tx, &addr, parsed_code, 100).unwrap();
-        tx.commit(host.rt()).unwrap();
-
-        let deposit = MockFaDeposit {
-            proxy_contract: Some(proxy),
-            ..MockFaDeposit::default()
-        };
-
-        host.add_internal_message(&deposit);
-        host.rt().run_level(wrapped_run);
-        let ticket_hash = deposit.ticket_hash();
-        match deposit.proxy_contract {
-            Some(proxy) => {
-                tx.begin();
-                let proxy_balance = TicketTable::get_balance(
-                    host.rt(),
-                    tx,
-                    &Address::SmartFunction(proxy),
-                    &ticket_hash,
-                )
-                .unwrap();
-                assert_eq!(300, proxy_balance);
-                let owner = try_parse_contract(&deposit.receiver).unwrap();
-                let receiver_balance =
-                    TicketTable::get_balance(host.rt(), tx, &owner, &ticket_hash)
-                        .unwrap();
-                assert_eq!(0, receiver_balance);
-            }
-            _ => panic!("Unexpected receiver"),
-        }
-    }
-
-    #[test]
-    fn entry_fa_deposit_succeeds_with_invalid_proxy() {
-        let mut host = JstzMockHost::default();
-        let deposit = MockFaDeposit::default();
-
-        host.add_internal_message(&deposit);
-        host.rt().run_level(wrapped_run);
-        let ticket_hash = deposit.ticket_hash();
-        match deposit.proxy_contract {
-            Some(proxy) => {
-                let mut tx = Transaction::default();
-                tx.begin();
-                let proxy_balance = TicketTable::get_balance(
-                    host.rt(),
-                    &mut tx,
-                    &Address::SmartFunction(proxy),
-                    &ticket_hash,
-                )
-                .unwrap();
-                assert_eq!(0, proxy_balance);
-                let owner = try_parse_contract(&deposit.receiver).unwrap();
-                let receiver_balance =
-                    TicketTable::get_balance(host.rt(), &mut tx, &owner, &ticket_hash)
-                        .unwrap();
-                assert_eq!(300, receiver_balance);
-            }
-            _ => panic!("Unexpected receiver"),
-        }
-    }
+    #[cfg(feature = "riscv_kernel")]
+    riscv_kernel::run(rt);
 }

--- a/crates/jstz_kernel/src/lib.rs
+++ b/crates/jstz_kernel/src/lib.rs
@@ -14,7 +14,7 @@ pub mod inbox;
 pub mod parsing;
 
 #[cfg(feature = "riscv_kernel")]
-mod riscv_kernel;
+pub mod riscv_kernel;
 
 #[cfg(not(feature = "riscv_kernel"))]
 mod wasm_kernel;

--- a/crates/jstz_kernel/src/riscv_kernel.rs
+++ b/crates/jstz_kernel/src/riscv_kernel.rs
@@ -18,9 +18,13 @@ use crate::{
 /// Addtionally, LocalSet supports support `!Send` futures which is currently required
 /// by [`JsHostRuntime`]
 pub fn run(rt: &mut impl Runtime) {
-    let tokio_runtime = tokio::runtime::Builder::new_current_thread()
-        .build()
-        .unwrap();
+    let tokio_runtime = match tokio::runtime::Builder::new_current_thread().build() {
+        Ok(runtime) => runtime,
+        Err(e) => {
+            debug_msg!(rt, "Failed to build Tokio runtime: {:?}", e);
+            return;
+        }
+    };
     let local_set = tokio::task::LocalSet::new();
     local_set.block_on(&tokio_runtime, run_event_loop(rt))
 }

--- a/crates/jstz_kernel/src/riscv_kernel.rs
+++ b/crates/jstz_kernel/src/riscv_kernel.rs
@@ -1,5 +1,276 @@
-use tezos_smart_rollup::prelude::Runtime;
+use std::sync::Arc;
 
-pub async fn run(rt: &mut impl Runtime) {
-    todo!()
+use jstz_core::{host::JsHostRuntime, kv::Transaction};
+use tezos_crypto_rs::hash::ContractKt1Hash;
+use tezos_smart_rollup::prelude::{debug_msg, Runtime};
+
+use crate::{
+    handle_message,
+    inbox::{self, ParsedInboxMessage},
+    read_injector, read_ticketer,
+};
+
+/// Runs the event loop within LocalSet which maintains a task FIFO queue. This is
+/// desirable because there is an expectation within blockchains to process operations
+/// in input order. Unfortunately, tokio doesn't give granular control to enforce priority
+/// queuing
+///
+/// Addtionally, LocalSet supports support `!Send` futures which is currently required
+/// by [`JsHostRuntime`]
+pub fn run(rt: &mut impl Runtime) {
+    let tokio_runtime = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+    let local_set = tokio::task::LocalSet::new();
+    local_set.block_on(&tokio_runtime, run_event_loop(rt))
+}
+
+/// Jstz kernel event Loop
+///
+/// On each iteration, read a message, spawn a local task for handling that message
+/// then yield to the scheduler. Yielding re-adds the current task to the back of
+/// the executor task queue
+async fn run_event_loop(rt: &mut impl Runtime) {
+    let ticketer = Arc::new(read_ticketer(rt));
+    let injector = Arc::new(read_injector(rt));
+
+    loop {
+        match read_message(rt, &ticketer) {
+            Some(ParsedInboxMessage::JstzMessage(message)) => {
+                let ticketer = ticketer.clone();
+                let injector = injector.clone();
+                let mut host = JsHostRuntime::new(rt);
+                // SpawnError only occurs in spawn_local when the executor has shutdown
+                tokio::task::spawn_local(async move {
+                    let mut tx = Transaction::default();
+                    tx.begin();
+                    handle_message(&mut host, message, &ticketer, &mut tx, &injector)
+                        .await
+                        .unwrap_or_else(|err| debug_msg!(&host, "[🔴] {err:?}\n"));
+                    if let Err(commit_error) = tx.commit(&mut host) {
+                        debug_msg!(
+                            &host,
+                            "Failed to commit transaction: {commit_error:?}\n"
+                        );
+                    }
+                });
+            }
+            Some(ParsedInboxMessage::LevelInfo(_)) => {}
+            None => {
+                // We reach here in 3 cases
+                // 1. No more inputs
+                // 2. Input targetting the wrong rollup
+                // 3. Parsing failures
+
+                // Break enabled in tests only
+                #[cfg(test)]
+                break;
+            }
+        }
+        // Yields twice; Once for processing the new task, the second for
+        // processing tasks that were awaken by the first.
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+    }
+}
+
+fn read_message(
+    rt: &mut impl Runtime,
+    ticketer: &ContractKt1Hash,
+) -> Option<ParsedInboxMessage> {
+    let input = rt.read_input().ok()??;
+    let jstz_rollup_address = rt.reveal_metadata().address();
+    inbox::parse_inbox_message(
+        rt,
+        input.id,
+        input.as_ref(),
+        ticketer,
+        &jstz_rollup_address,
+    )
+}
+
+#[cfg(test)]
+mod test {
+
+    use jstz_core::{
+        host::HostRuntime,
+        kv::{Storage, Transaction},
+    };
+    use jstz_crypto::{
+        hash::Hash, public_key::PublicKey, public_key_hash::PublicKeyHash,
+        secret_key::SecretKey,
+    };
+    use jstz_mock::{host::JstzMockHost, message::native_deposit::MockNativeDeposit};
+    use jstz_proto::{
+        context::account::Account,
+        operation::{
+            DeployFunction, Operation, OperationHash, RunFunction, SignedOperation,
+        },
+        receipt::Receipt,
+        runtime::ParsedCode,
+    };
+    use serde::de::DeserializeOwned;
+    use tezos_smart_rollup::{storage::path::OwnedPath, types::Contract as L1Address};
+
+    use super::run;
+
+    fn set_transfer_header(run_func: &mut RunFunction, amount: u64) {
+        run_func
+            .headers
+            .insert("X-JSTZ-TRANSFER", amount.try_into().unwrap());
+    }
+
+    /*
+       Scenario
+       - op1: 100 mutez deposited into bobs account
+       - op2: bob transfers 30 mutez to alice
+       - op3: alice deploys SF that forwards mutez to bob
+       - op4: alice runs the SF, send sending 10  mutez
+
+       Check
+       - bob has 80 mutez
+       - alice has 20 mutez
+    */
+    #[test]
+    fn scenario_1() -> Result<(), anyhow::Error> {
+        let mut host = JstzMockHost::new(false);
+        // host.set_debug_handler(std::io::stdout());
+        let bob_sk = SecretKey::from_base58(
+            "edsk3eA4FyZDnDSC2pzEh4kwnaLLknvdikvRuXZAV4T4pWMVd6GUyS",
+        )?;
+        let bob_pk = PublicKey::from_base58(
+            "edpkusQcxu7Zv33x1p54p62UgzcawjBRSdEFJbPKEtjQ1h1TaFV3U5",
+        )?;
+
+        let alice_sk = SecretKey::from_base58(
+            "edsk38mmuJeEfSYGiwLE1qHr16BPYKMT5Gg1mULT7dNUtg3ti4De3a",
+        )?;
+        let alice_pk = PublicKey::from_base58(
+            "edpkurYYUEb4yixA3oxKdvstG8H86SpKKUGmadHS6Ju2mM1Mz1w5or",
+        )?;
+
+        // 100 mutez deposited into bob's account
+        let op1 = MockNativeDeposit::new(
+            100,
+            None,
+            Some(L1Address::from_b58check(bob_pk.hash().as_str())?),
+        );
+
+        // bob transfers 30 mutez to alice
+        let op2 = {
+            let mut run_fn = RunFunction {
+                uri: format!("jstz://{}", alice_pk.hash()).parse()?,
+                method: http::Method::GET,
+                headers: http::HeaderMap::new(),
+                body: None,
+                gas_limit: 0,
+            };
+            set_transfer_header(&mut run_fn, 30);
+            let op = Operation {
+                public_key: bob_pk.clone(),
+                nonce: 0.into(),
+                content: run_fn.into(),
+            };
+            let sig = bob_sk.sign(op.hash())?;
+            SignedOperation::new(sig, op)
+        };
+
+        // alice deploys sf that forwards tez to bob
+        let op3 = {
+            let code = format!(
+                r#"
+            export default async (request) => {{
+                // forwards mutez to bob
+                let amount = request.headers.get("x-jstz-amount");
+                let resp = await fetch("jstz://{}", {{
+                    headers: {{ "x-jstz-transfer": amount }}
+                }});
+                return resp
+            }}
+            "#,
+                bob_pk.hash()
+            );
+            let deploy_fn = DeployFunction {
+                function_code: ParsedCode::try_from(code).unwrap(),
+                account_credit: 0,
+            };
+            let op = Operation {
+                public_key: alice_pk.clone(),
+                nonce: 0.into(),
+                content: deploy_fn.into(),
+            };
+            let sig = alice_sk.sign(op.hash())?;
+            SignedOperation::new(sig, op)
+        };
+
+        // alice runs previously deployed sf
+        let op4 = {
+            let mut run_fn = RunFunction {
+                uri: "jstz://KT1EPRuE9JnmkJFw58W39hBoiCmX14XtMgGd".parse()?,
+                method: http::Method::GET,
+                headers: http::HeaderMap::new(),
+                body: None,
+                gas_limit: 0,
+            };
+            set_transfer_header(&mut run_fn, 10);
+            let op = Operation {
+                public_key: alice_pk.clone(),
+                nonce: 1.into(),
+                content: run_fn.into(),
+            };
+            let sig = alice_sk.sign(op.hash())?;
+            SignedOperation::new(sig, op)
+        };
+
+        // Add operations to inbox and run
+        host.add_internal_message(&op1);
+        host.add_external_message(op2);
+        host.add_external_message(op3.clone());
+        host.add_external_message(op4.clone());
+
+        // Will exist when out of inbox message only in tests.
+        host.run_level(run);
+
+        // // Validated balances
+        let mut tx = Transaction::default();
+        tx.begin();
+        let bob_balance = Account::balance(
+            &mut *host,
+            &mut tx,
+            &PublicKeyHash::from_base58(bob_pk.hash().as_str())?,
+        )
+        .unwrap();
+        let alice_balance = Account::balance(
+            &mut *host,
+            &mut tx,
+            &PublicKeyHash::from_base58(alice_pk.hash().as_str())?,
+        )
+        .unwrap();
+
+        assert_eq!(80, bob_balance);
+        assert_eq!(20, alice_balance);
+
+        Ok(())
+    }
+
+    // Helper to inpect fields in a receipt by tarversing the json path. Useful for debugging.
+    // For example, to inpect the body of a successful RunFunctionReceipt, you can provide the path
+    // vec!["result", "inner", "body"]. If you don't really care what the return type is and just
+    // want to print field value, you can parameterize with `serde_json::Value`
+    #[allow(unused)]
+    fn inspect_receipt<'a, T: DeserializeOwned>(
+        host: &impl HostRuntime,
+        op_hash: OperationHash,
+        path_into_receipt: Vec<String>,
+    ) -> T {
+        let receipt_path =
+            OwnedPath::try_from(format!("/jstz_receipt/{}", op_hash)).unwrap();
+        let receipt: Receipt = Storage::get(&*host, &receipt_path).unwrap().unwrap();
+        let receipt = serde_json::to_value(&receipt).unwrap();
+        let mut cursor = receipt.clone();
+        for p in path_into_receipt {
+            cursor = cursor[p].clone();
+        }
+        serde_json::from_value(cursor).unwrap()
+    }
 }

--- a/crates/jstz_kernel/src/riscv_kernel.rs
+++ b/crates/jstz_kernel/src/riscv_kernel.rs
@@ -15,7 +15,7 @@ use crate::{
 /// in input order. Unfortunately, tokio doesn't give granular control to enforce priority
 /// queuing
 ///
-/// Addtionally, LocalSet supports support `!Send` futures which is currently required
+/// Additionally, LocalSet supports support `!Send` futures which is currently required
 /// by [`JsHostRuntime`]
 pub fn run(rt: &mut impl Runtime) {
     let tokio_runtime = match tokio::runtime::Builder::new_current_thread().build() {

--- a/crates/jstz_kernel/src/riscv_kernel.rs
+++ b/crates/jstz_kernel/src/riscv_kernel.rs
@@ -1,0 +1,5 @@
+use tezos_smart_rollup::prelude::Runtime;
+
+pub async fn run(rt: &mut impl Runtime) {
+    todo!()
+}

--- a/crates/jstz_kernel/src/wasm_kernel.rs
+++ b/crates/jstz_kernel/src/wasm_kernel.rs
@@ -1,0 +1,200 @@
+use jstz_core::kv::Transaction;
+use jstz_crypto::public_key::PublicKey;
+use jstz_proto::{executor, Result};
+use std::sync::LazyLock;
+use tezos_crypto_rs::hash::ContractKt1Hash;
+use tezos_smart_rollup::prelude::{debug_msg, Runtime};
+
+use crate::inbox::{read_message, Message};
+
+static SCHEDULER: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
+    tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap()
+});
+
+pub fn run(rt: &mut impl Runtime) {
+    SCHEDULER.block_on(async {
+        // TODO: we should organize protocol consts into a struct
+        // https://linear.app/tezos/issue/JSTZ-459/organize-protocol-consts-into-a-struct
+
+        let ticketer = crate::read_ticketer(rt).expect("Ticketer not found");
+        let injector = crate::read_injector(rt).expect("Revealer not found");
+        let mut tx = Transaction::default();
+        tx.begin();
+        let _ = rt.mark_for_reboot();
+        if let Some(message) = read_message(rt, &ticketer) {
+            handle_message(rt, message, &ticketer, &mut tx, &injector)
+                .await
+                .unwrap_or_else(|err| debug_msg!(rt, "[🔴] {err:?}\n"));
+        }
+        if let Err(commit_error) = tx.commit(rt) {
+            debug_msg!(rt, "Failed to commit transaction: {commit_error:?}\n");
+        }
+    })
+}
+
+async fn handle_message(
+    hrt: &mut impl Runtime,
+    message: Message,
+    ticketer: &ContractKt1Hash,
+    tx: &mut Transaction,
+    injector: &PublicKey,
+) -> Result<()> {
+    match message {
+        Message::Internal(internal_operation) => {
+            let receipt =
+                executor::execute_internal_operation(hrt, tx, internal_operation).await;
+            receipt.write(hrt, tx)?
+        }
+        Message::External(signed_operation) => {
+            debug_msg!(hrt, "External operation: {signed_operation:?}\n");
+            let receipt = executor::execute_operation(
+                hrt,
+                tx,
+                signed_operation,
+                ticketer,
+                injector,
+            )
+            .await;
+            debug_msg!(hrt, "Receipt: {receipt:?}\n");
+            receipt.write(hrt, tx)?
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+
+    use jstz_core::{host::HostRuntime, kv::Transaction};
+    use jstz_crypto::hash::Hash;
+    use jstz_mock::{
+        host::{JstzMockHost, MOCK_SOURCE},
+        message::{fa_deposit::MockFaDeposit, native_deposit::MockNativeDeposit},
+    };
+    use jstz_proto::{
+        context::{
+            account::{Account, Address},
+            ticket_table::TicketTable,
+        },
+        executor::smart_function,
+        runtime::ParsedCode,
+    };
+    use tezos_smart_rollup::types::{Contract, PublicKeyHash};
+
+    use crate::{parsing::try_parse_contract, read_ticketer};
+
+    fn wrapped_run(rt: &mut impl HostRuntime) {
+        super::run(rt);
+    }
+
+    #[test]
+    fn read_ticketer_succeeds() {
+        let mut host = JstzMockHost::default();
+        let ticketer = read_ticketer(host.rt()).unwrap();
+        let expected_tickter = host.get_ticketer();
+        assert_eq!(ticketer, expected_tickter)
+    }
+
+    #[test]
+    fn entry_native_deposit_succeeds() {
+        let mut host = JstzMockHost::default();
+        let deposit = MockNativeDeposit::default();
+        host.add_internal_message(&deposit);
+        host.rt().run_level(wrapped_run);
+        let tx = &mut Transaction::default();
+        tx.begin();
+        match deposit.receiver {
+            Contract::Implicit(PublicKeyHash::Ed25519(tz1)) => {
+                let amount = Account::balance(
+                    host.rt(),
+                    tx,
+                    &Address::User(jstz_crypto::public_key_hash::PublicKeyHash::Tz1(
+                        tz1.into(),
+                    )),
+                )
+                .unwrap();
+                assert_eq!(amount, 100);
+            }
+            _ => panic!("Unexpected receiver"),
+        }
+    }
+
+    #[test]
+    fn entry_fa_deposit_succeeds_with_proxy() {
+        let mut host = JstzMockHost::default();
+
+        let tx = &mut Transaction::default();
+        tx.begin();
+        let parsed_code =
+            ParsedCode::try_from(jstz_mock::host::MOCK_PROXY_FUNCTION.to_string())
+                .unwrap();
+        let addr = Address::User(
+            jstz_crypto::public_key_hash::PublicKeyHash::from_base58(MOCK_SOURCE)
+                .unwrap(),
+        );
+        Account::set_balance(host.rt(), tx, &addr, 200).unwrap();
+        let proxy =
+            smart_function::deploy(host.rt(), tx, &addr, parsed_code, 100).unwrap();
+        tx.commit(host.rt()).unwrap();
+
+        let deposit = MockFaDeposit {
+            proxy_contract: Some(proxy),
+            ..MockFaDeposit::default()
+        };
+
+        host.add_internal_message(&deposit);
+        host.rt().run_level(wrapped_run);
+        let ticket_hash = deposit.ticket_hash();
+        match deposit.proxy_contract {
+            Some(proxy) => {
+                tx.begin();
+                let proxy_balance = TicketTable::get_balance(
+                    host.rt(),
+                    tx,
+                    &Address::SmartFunction(proxy),
+                    &ticket_hash,
+                )
+                .unwrap();
+                assert_eq!(300, proxy_balance);
+                let owner = try_parse_contract(&deposit.receiver).unwrap();
+                let receiver_balance =
+                    TicketTable::get_balance(host.rt(), tx, &owner, &ticket_hash)
+                        .unwrap();
+                assert_eq!(0, receiver_balance);
+            }
+            _ => panic!("Unexpected receiver"),
+        }
+    }
+
+    #[test]
+    fn entry_fa_deposit_succeeds_with_invalid_proxy() {
+        let mut host = JstzMockHost::default();
+        let deposit = MockFaDeposit::default();
+
+        host.add_internal_message(&deposit);
+        host.rt().run_level(wrapped_run);
+        let ticket_hash = deposit.ticket_hash();
+        match deposit.proxy_contract {
+            Some(proxy) => {
+                let mut tx = Transaction::default();
+                tx.begin();
+                let proxy_balance = TicketTable::get_balance(
+                    host.rt(),
+                    &mut tx,
+                    &Address::SmartFunction(proxy),
+                    &ticket_hash,
+                )
+                .unwrap();
+                assert_eq!(0, proxy_balance);
+                let owner = try_parse_contract(&deposit.receiver).unwrap();
+                let receiver_balance =
+                    TicketTable::get_balance(host.rt(), &mut tx, &owner, &ticket_hash)
+                        .unwrap();
+                assert_eq!(300, receiver_balance);
+            }
+            _ => panic!("Unexpected receiver"),
+        }
+    }
+}

--- a/crates/jstz_kernel/src/wasm_kernel.rs
+++ b/crates/jstz_kernel/src/wasm_kernel.rs
@@ -4,7 +4,7 @@ use jstz_core::kv::Transaction;
 use tezos_smart_rollup::prelude::{debug_msg, Runtime};
 
 pub fn run(rt: &mut impl Runtime) {
-    futures::executor::block_on(async {
+    jstz_core::future::block_on(async {
         // TODO(https://linear.app/tezos/issue/JSTZ-459/organize-protocol-consts-into-a-struct)
         // we should organize protocol consts into a struct
         let ticketer = crate::read_ticketer(rt);

--- a/crates/jstz_mock/Cargo.toml
+++ b/crates/jstz_mock/Cargo.toml
@@ -12,3 +12,4 @@ jstz_crypto = { path = "../jstz_crypto" }
 tezos-smart-rollup-mock.workspace = true
 tezos-smart-rollup.workspace = true
 tezos_crypto_rs.workspace = true
+tezos_data_encoding.workspace = true

--- a/crates/jstz_mock/src/host.rs
+++ b/crates/jstz_mock/src/host.rs
@@ -110,7 +110,7 @@ impl Default for JstzMockHost {
             .expect("Could not insert ticketer");
         let injector: PublicKey = PublicKey::from_base58(INJECTOR).unwrap();
         Storage::insert(&mut mock_host, &INJECTOR_PATH, &injector)
-            .expect("Could not insert ticketer");
+            .expect("Could not insert injector");
         mock_host.set_debug_handler(empty());
         Self(mock_host)
     }

--- a/crates/jstz_mock/src/message/native_deposit.rs
+++ b/crates/jstz_mock/src/message/native_deposit.rs
@@ -21,6 +21,22 @@ pub struct MockNativeDeposit {
     pub smart_rollup: Option<SmartRollupAddress>,
 }
 
+impl MockNativeDeposit {
+    pub fn new(
+        amount: u32,
+        source: Option<PublicKeyHash>,
+        receiver: Option<Contract>,
+    ) -> Self {
+        let default = MockNativeDeposit::default();
+        Self {
+            receiver: receiver.unwrap_or(default.receiver),
+            source: source.unwrap_or(default.source),
+            ticket_amount: amount,
+            ..default
+        }
+    }
+}
+
 impl Default for MockNativeDeposit {
     fn default() -> Self {
         Self {

--- a/crates/jstz_proto/Cargo.toml
+++ b/crates/jstz_proto/Cargo.toml
@@ -39,7 +39,6 @@ deno_core = { workspace = true, optional = true }
 deno_error = { workspace = true, optional = true }
 deno_fetch_base = { workspace = true, optional = true }
 jstz_runtime = { path = "../jstz_runtime", optional = true }
-tokio = { workspace = true, optional = true }
 parking_lot.workspace = true
 thiserror.workspace = true
 url.workspace = true
@@ -53,6 +52,6 @@ tokio.workspace = true
 
 [features]
 default = ["dep:jstz_api"]
-v2_runtime = ["dep:jstz_runtime", "dep:deno_core", "dep:deno_fetch_base", "dep:deno_error", "dep:tokio"]
+v2_runtime = ["dep:jstz_runtime", "dep:deno_core", "dep:deno_fetch_base", "dep:deno_error"]
 kernel = ["jstz_runtime?/kernel"]
 

--- a/crates/jstz_proto/src/context/account.rs
+++ b/crates/jstz_proto/src/context/account.rs
@@ -235,6 +235,14 @@ impl Account {
         Ok(account_entry.or_insert_with(|| Self::default_account(addr)))
     }
 
+    pub fn exists(
+        hrt: &impl HostRuntime,
+        tx: &Transaction,
+        addr: &impl Addressable,
+    ) -> Result<bool> {
+        Ok(tx.contains_key(hrt, &Self::path(addr)?)?)
+    }
+
     fn try_insert(
         self,
         hrt: &impl HostRuntime,

--- a/crates/jstz_proto/src/context/receipt.rs
+++ b/crates/jstz_proto/src/context/receipt.rs
@@ -8,7 +8,6 @@ const RECEIPTS_PATH: RefPath = RefPath::assert_from(b"/jstz_receipt");
 impl Receipt {
     pub fn write(self, _hrt: &impl HostRuntime, tx: &mut Transaction) -> Result<()> {
         let receipt_path = OwnedPath::try_from(format!("/{}", self.hash()))?;
-
         Ok(tx.insert(path::concat(&RECEIPTS_PATH, &receipt_path)?, self)?)
     }
 }

--- a/crates/jstz_proto/src/lib.rs
+++ b/crates/jstz_proto/src/lib.rs
@@ -19,11 +19,17 @@ pub type Gas = u64;
 pub type HttpBody = Option<Vec<u8>>;
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use std::sync::{Arc, Mutex};
 
+    use jstz_core::{host::HostRuntime, kv::Storage};
+    use serde::de::DeserializeOwned;
+    use tezos_smart_rollup::storage::path::OwnedPath;
     use tezos_smart_rollup_mock::DebugSink;
 
+    use crate::{operation::OperationHash, receipt::Receipt};
+
+    #[derive(Default)]
     pub struct DebugLogSink {
         pub inner: Arc<Mutex<Vec<u8>>>,
     }
@@ -45,5 +51,26 @@ mod tests {
         pub fn content(&self) -> Arc<Mutex<Vec<u8>>> {
             self.inner.clone()
         }
+    }
+
+    // Helper to inpect fields in a receipt by tarversing the json path. Useful for debugging.
+    // For example, to inpect the body of a successful RunFunctionReceipt, you can provide the path
+    // vec!["result", "inner", "body"]. If you don't really care what the return type is and just
+    // want to print field value, you can parameterize with `serde_json::Value`
+    #[allow(unused)]
+    fn inspect_receipt<T: DeserializeOwned>(
+        host: &impl HostRuntime,
+        op_hash: OperationHash,
+        path_into_receipt: Vec<String>,
+    ) -> T {
+        let receipt_path =
+            OwnedPath::try_from(format!("/jstz_receipt/{}", op_hash)).unwrap();
+        let receipt: Receipt = Storage::get(host, &receipt_path).unwrap().unwrap();
+        let receipt = serde_json::to_value(&receipt).unwrap();
+        let mut cursor = receipt.clone();
+        for p in path_into_receipt {
+            cursor = cursor[p].clone();
+        }
+        serde_json::from_value(cursor).unwrap()
     }
 }

--- a/crates/jstz_proto/src/runtime/v2/fetch/error.rs
+++ b/crates/jstz_proto/src/runtime/v2/fetch/error.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 
 use deno_error::JsErrorClass as _;
+use jstz_crypto::smart_function_hash::SmartFunctionHash;
 use jstz_runtime::error::RuntimeError;
 use serde::Serialize;
 
@@ -33,6 +34,9 @@ pub enum FetchError {
     #[class("RuntimeError")]
     #[error("{0}")]
     JstzError(String),
+    #[class(syntax)]
+    #[error("Smart function '{address}' has no code")]
+    EmptyCode { address: SmartFunctionHash },
 }
 
 #[derive(Serialize)]

--- a/crates/jstz_proto/src/runtime/v2/fetch/fetch_handler.rs
+++ b/crates/jstz_proto/src/runtime/v2/fetch/fetch_handler.rs
@@ -256,7 +256,7 @@ async fn handle_address(
             {
                 return Ok(Response {
                     status: 404,
-                    status_text: "Not found".to_string(),
+                    status_text: "Not Found".to_string(),
                     headers,
                     body: "Account does not exist".into(),
                 });

--- a/crates/jstz_proto/src/runtime/v2/fetch/fetch_handler.rs
+++ b/crates/jstz_proto/src/runtime/v2/fetch/fetch_handler.rs
@@ -251,6 +251,16 @@ async fn handle_address(
             body: Body::Vector(Vec::with_capacity(0)),
         }),
         AddressKind::SmartFunction => {
+            if !Account::exists(host, tx, &to)
+                .map_err(|e| FetchError::JstzError(e.to_string()))?
+            {
+                return Ok(Response {
+                    status: 404,
+                    status_text: "Not found".to_string(),
+                    headers,
+                    body: "Account does not exist".into(),
+                });
+            }
             let address = to.as_smart_function().unwrap();
             let run_result = load_and_run(
                 host,
@@ -317,10 +327,8 @@ async fn load_and_run(
         address.clone(),
         operation_hash.map(|v| v.to_string()).unwrap_or_default(),
     );
-
     // 1. Load script
     let script = { load_script(tx, &mut proto.host, &proto.address)? };
-
     // 2. Prepare runtime
     let path = format!("jstz://{}", address);
     // `resolve_import` will panic without pinning
@@ -369,9 +377,15 @@ fn load_script(
     host: &impl HostRuntime,
     address: &SmartFunctionHash,
 ) -> Result<String> {
-    Account::function_code(host, tx, address)
+    let code = Account::function_code(host, tx, address)
         .map(|s| s.to_string())
-        .map_err(|err| FetchError::JstzError(err.to_string()))
+        .map_err(|err| FetchError::JstzError(err.to_string()))?;
+    if code.is_empty() {
+        return Err(FetchError::EmptyCode {
+            address: address.clone(),
+        });
+    }
+    Ok(code)
 }
 
 async fn convert_js_to_response(

--- a/crates/jstz_runtime/Cargo.toml
+++ b/crates/jstz_runtime/Cargo.toml
@@ -21,9 +21,9 @@ serde.workspace = true
 serde_json.workspace = true
 tezos-smart-rollup.workspace = true
 tezos-smart-rollup-host.workspace = true
+tokio.workspace = true
 utoipa.workspace = true
 thiserror.workspace = true
-tokio.workspace = true
 deno_webidl.workspace = true
 deno_web.workspace = true
 deno_url.workspace = true
@@ -31,6 +31,7 @@ deno_error.workspace = true
 deno_fetch_base.workspace = true
 parking_lot.workspace = true
 pin-project.workspace = true
+
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/crates/jstz_runtime/Cargo.toml
+++ b/crates/jstz_runtime/Cargo.toml
@@ -21,7 +21,7 @@ serde.workspace = true
 serde_json.workspace = true
 tezos-smart-rollup.workspace = true
 tezos-smart-rollup-host.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["sync", "rt"] }
 utoipa.workspace = true
 thiserror.workspace = true
 deno_webidl.workspace = true

--- a/crates/jstz_runtime/src/runtime.rs
+++ b/crates/jstz_runtime/src/runtime.rs
@@ -21,7 +21,6 @@ use std::{
 };
 
 use serde::Deserialize;
-use tokio;
 
 use crate::ext::{jstz_console, jstz_kv, jstz_kv::kv::Kv, jstz_main};
 use deno_console;
@@ -136,7 +135,6 @@ impl JstzRuntime {
         extensions.extend(options.extensions);
 
         let v8_platform = Some(new_single_threaded_default_platform(false).make_shared());
-
         // Construct Runtime options
         let js_runtime_options = RuntimeOptions {
             extensions,
@@ -148,7 +146,6 @@ impl JstzRuntime {
         // SAFETY: See `impl Drop for JstzRuntime`
         let mut runtime = ManuallyDrop::new(JsRuntime::new(js_runtime_options));
         unsafe { runtime.v8_isolate().exit() };
-
         // Give protocol access to the running script
         let op_state = runtime.op_state();
         if let Some(protocol) = options.protocol {
@@ -199,7 +196,6 @@ impl JstzRuntime {
           result = &mut receiver => {
             result
           }
-
           run_event_loop_result = self.run_event_loop(Default::default()) => {
             run_event_loop_result?;
             receiver.await

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 channel = "1.82.0"
 profile = "minimal"
 components = ["rustfmt", "clippy", "llvm-tools-preview"]
-targets = ["wasm32-unknown-unknown"]
+targets = ["wasm32-unknown-unknown", "riscv64gc-unknown-linux-musl"]


### PR DESCRIPTION
# Context
Closes https://linear.app/tezos/issue/JSTZ-599/integrate-v2-fetch 

Introduces the Jstz kernel event loop for use within RISCV PVM.

RISCV PVM is fundamentally different from WASM in that kernel's no longer need to return to the PVM for tick counting. Tick counting and proof generation occur within the RISCV VM itself, enabling kernel's to manage their own event loops, and keep memory around for the lifetime of the program, essentially as long as the blockchain lives. 

This let's jstz keep around suspended futures in memory and across read_input events
# Description

<!-- Describe your changes in detail. -->
* Split wasm and riscv kernel entrypoint, guarded by feature flag
* Use tokio single threaded and local set to drive event loop to enforce FIFO task queing and support !Send futures required by JsHostRuntime
* Refactor parse message to expose the different types of messages it parses in a meaningful way instead of filtering them to (1) distinct between ignoring a message and running out of input messages. We use this distinction to break the loop during tests (2) setup for time keeping support
* Fix fetch to prevent execution of smart functions that do not exist or that have empty code (The latter is a result of defaulting smart functions to empty even on read, which needs to be fixed generally). This fix also prevents smart functions creation on receiving xtz
* Adds `riscv-pvm-kernel` make target that does what it says
<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
`cargo nextest run -p jstz_kernel scenario_1 --features riscv_kernel --nocapture`
<!-- Describe how reviewers and approvers can test this PR. -->
