### PR TITLE
fix(sequencer): change runtime db journal config

### DIFF
--- a/crates/jstz_node/src/sequencer/db.rs
+++ b/crates/jstz_node/src/sequencer/db.rs
@@ -1,5 +1,6 @@
 use std::{fs, path::PathBuf};
 
+use anyhow::Context;
 use anyhow::Result;
 use r2d2::{Pool, PooledConnection};
 use r2d2_sqlite::SqliteConnectionManager;
@@ -34,21 +35,36 @@ impl Db {
                 SqliteConnectionManager::file(db_path)
             }
             None => SqliteConnectionManager::memory(),
-        };
+        }
+        // Documentation says that a default busy timeout of 5 seconds is set for each connection
+        // so this shouldn't matter. Setting it explicitly here just to be safe.
+        .with_init(|c| c.busy_timeout(std::time::Duration::from_secs(5)));
 
         let pool = SqliteConnectionPool::new(manager)?;
-        Self::create_table(pool.clone())?;
+        Self::setup(pool.clone())?;
 
         Ok(Db { pool })
     }
 
     pub fn connection(&self) -> Result<PooledConnection<SqliteConnectionManager>> {
-        Ok(self.pool.get()?)
+        let conn = self
+            .pool
+            .get()
+            .context("failed to get connection from pool")?;
+        Ok(conn)
     }
 
-    fn create_table(pool: Pool<SqliteConnectionManager>) -> Result<()> {
-        let conn = pool.get()?;
-        conn.execute("CREATE TABLE IF NOT EXISTS jstz_kv (jstz_key TEXT NOT NULL PRIMARY KEY, jstz_value, UNIQUE(jstz_key))", [])?;
+    fn setup(pool: Pool<SqliteConnectionManager>) -> Result<()> {
+        let conn = pool.get().context("failed to get connection from pool")?;
+        conn.execute("CREATE TABLE IF NOT EXISTS jstz_kv (jstz_key TEXT NOT NULL PRIMARY KEY, jstz_value, UNIQUE(jstz_key))", []).context("failed to create table")?;
+        // Allows reads while writes are taking place. This works when there is only one writer
+        // and is fine in our use case.
+        conn.pragma_update(None, "journal_mode", "WAL")
+            .context("failed to set pragma journal mode")?;
+        // Reduces the frequency that sqlite synchronises with the journal. NORMAL is fine with WAL.
+        conn.pragma_update(None, "synchronous", "NORMAL")
+            .context("failed to set pragma synchronous")?;
+
         Ok(())
     }
 

--- a/crates/jstz_node/tests/sequencer.rs
+++ b/crates/jstz_node/tests/sequencer.rs
@@ -263,16 +263,10 @@ fn make_mock_rollup_rpc_server(url: String) -> JoinHandle<()> {
 pub(crate) fn make_mock_monitor_blocks_filter(
 ) -> impl warp::Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("global" / "monitor_blocks").map(|| {
-        let delay_stream = stream::once(async {
-            // TODO: remove this once db issue is fixed
-            // https://github.com/jstz-dev/jstz/actions/runs/15685845390/job/44188722352
-            tokio::time::sleep(Duration::from_secs(2)).await;
-            Ok::<Bytes, Infallible>(Bytes::new())
-        });
         let data_stream = stream::iter(vec![Ok::<Bytes, Infallible>(Bytes::from(
             "{\"level\": 123}\n",
         ))]);
-        warp::reply::Response::new(Body::wrap_stream(delay_stream.chain(data_stream)))
+        warp::reply::Response::new(Body::wrap_stream(data_stream))
     })
 }
 


### PR DESCRIPTION
# Context

Completes JSTZ-671. (Maybe)
[JSTZ-671](https://linear.app/tezos/issue/JSTZ-671/fix-runtime-db-connections)

There were some random errors related to the runtime database in #1095.

# Description

Updated the runtime database's config, hoping to make accesses less problematic. WAL journal mode should permit reads during writes instead of terminating all ongoing reads when a write takes place.

# Manually testing the PR

Ran tests with the CI runner multiple times and it seemed fine. Not completely sure how robust this is, but since it cannot be reproduced easily, we see how it goes. At least now the integration test does not fail with the delay in response stream is removed.
