### PR TITLE
fix(v2): misspell referer key according to http spec

### DIFF
--- a/crates/jstz_proto/src/runtime/v2/fetch/tests/resources/fetch_cleans_headers/remote.js
+++ b/crates/jstz_proto/src/runtime/v2/fetch/tests/resources/fetch_cleans_headers/remote.js
@@ -1,7 +1,7 @@
 /** @param {Request} req */
 export default async (req) => {
-  if (req.headers.get("referrer") !== "KT1LC1JVTpMZZRXoaHBZNHvvAaFYiwCZi9Fu") {
-    throw new Error("Unexpected referrer " + req.headers.get("referrer"));
+  if (req.headers.get("referer") !== "KT1MB74JfevE3nvkGWz4vXH34xsrXyvTAMtg") {
+    throw new Error("Unexpected referer " + req.headers.get("referer"));
   }
   if (req.headers.get("x-jstz-amount") !== "1000000") {
     throw new Error("Unexpected amount " + req.headers.get("x-jstz-amount"));
@@ -10,7 +10,7 @@ export default async (req) => {
   if (headerKeys.length != 4) {
     throw new Error("too few keys");
   }
-  let keys = ["accept", "accept-language", "referrer", "x-jstz-amount"];
+  let keys = ["accept", "accept-language", "referer", "x-jstz-amount"];
   for (let i in keys) {
     if (req.headers.get(keys[i]) === null) {
       throw new Error("missingkey! " + keys[i]);
@@ -20,7 +20,7 @@ export default async (req) => {
     headers: {
       "X-JSTZ-AMOUNT": 5000000,
       "X-JSTZ-NON-EXISTENT": "test",
-      REFERRER: "tz1eLbDXYceRsPZoPmaJXZgQ6pzgnTQvZtpo",
+      REFERER: "tz1eLbDXYceRsPZoPmaJXZgQ6pzgnTQvZtpo",
     },
   });
 };

--- a/crates/jstz_proto/src/runtime/v2/fetch/tests/resources/fetch_cleans_headers/run.js
+++ b/crates/jstz_proto/src/runtime/v2/fetch/tests/resources/fetch_cleans_headers/run.js
@@ -4,7 +4,7 @@ export default async (req) => {
   let newRequest = new Request(`jstz://${address}`, {
     headers: {
       "X-JSTZ-AMOUNT": 3000000, // 3 XTZ
-      REFERRER: "tz1eLbDXYceRsPZoPmaJXZgQ6pzgnTQvZtpo",
+      REFERER: "tz1eLbDXYceRsPZoPmaJXZgQ6pzgnTQvZtpo",
       "X-JSTZ-TRANSFER": 1000000,
       "X-JSTZ-NON-EXISTENT": "test",
     },


### PR DESCRIPTION
# Context
Referrer is misspelt in the http spec. Align to "Referer" instead.
<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
* Replace referrer with "referer"
* Update smart function address hash where it changed

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
`make build-v2 && make test-v2`
<!-- Describe how reviewers and approvers can test this PR. -->
