### PR TITLE
fix(runtime): propagate errors from sys lib

### DIFF
--- a/crates/jstz_runtime/src/error.rs
+++ b/crates/jstz_runtime/src/error.rs
@@ -45,7 +45,11 @@ impl From<v8::DataError> for RuntimeError {
 
 impl From<JsError> for RuntimeError {
     fn from(js_error: JsError) -> Self {
-        Self::DenoCore(js_error.into())
+        let js_error_box = JsErrorBox::new(
+            js_error.name.unwrap_or("Error".to_string()),
+            js_error.exception_message,
+        );
+        Self::DenoCore(js_error_box.into())
     }
 }
 


### PR DESCRIPTION
# Context
Catch and propagate JS errors occuring in sys lib instead of ignoring them. Part of the effort to improve transparency of errors occurring in the runtime environment
<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
- Propagates errors from js class, static method calls and set method calls
- Also converts JsErrors to JsErrorBox in RuntimeError convertor to capture only the exception message while hiding the deno line that the error comes from. 


<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
`cargo nextest run -p jstz_runtime uncaught_constructor_errors_should_propagate`
<!-- Describe how reviewers and approvers can test this PR. -->
