### PR TITLE
chore(jstzd): load built-in bootstrap accounts from file

### DIFF
--- a/crates/jstz_cli/tests/fa_deploy_test.rs
+++ b/crates/jstz_cli/tests/fa_deploy_test.rs
@@ -12,7 +12,6 @@ use jstz_crypto::{
 use jstzd::{
     self,
     task::jstzd::{JstzdConfig, JstzdServer},
-    BOOTSTRAP_ACCOUNTS,
 };
 use octez::r#async::client::OctezClient;
 use std::{fs, path::Path, process::Command, str::FromStr};
@@ -36,7 +35,11 @@ async fn fa_deploy_test() {
     // 1. Deploy FA2.1 contract
     // The `TEST` (0x54455354) token has a total supply of `1000` tokens and is minted to `bootstrap2`.
     // https://github.com/oxheadalpha/smart-contracts/blob/master/multi_asset/ligo/src/fa2_multi_asset.mligo
-    let bootstrap2 = BOOTSTRAP_ACCOUNTS[2];
+    let bootstrap2 = (
+        "bootstrap2",
+        "edpktzNbDAUjUk697W7gYg2CRuBQjyPxbEg8dLccYYwKSKvkPvjtV9",
+        "unencrypted:edsk39qAm1fiMjgmPkw1EgQYkMzkJezLNewd7PLNHTkr6w9XA2zdfo",
+    );
     let bootstrap2_alias = bootstrap2.0;
     let bootstrap2 = PublicKey::from_base58(bootstrap2.1).unwrap().hash();
 

--- a/crates/jstzd/Cargo.toml
+++ b/crates/jstzd/Cargo.toml
@@ -36,6 +36,7 @@ tokio.workspace = true
 anyhow.workspace = true
 bincode.workspace = true
 hex.workspace = true
+serde_json.workspace = true
 tempfile.workspace = true
 tezos_crypto_rs.workspace = true
 tezos-smart-rollup.workspace = true

--- a/crates/jstzd/resources/bootstrap_account/accounts.json
+++ b/crates/jstzd/resources/bootstrap_account/accounts.json
@@ -1,0 +1,32 @@
+[
+  [
+    "bootstrap0",
+    "edpkuSLWfVU1Vq7Jg9FucPyKmma6otcMHac9zG4oU1KMHSTBpJuGQ2",
+    "unencrypted:edsk31vznjHSSpGExDMHYASz45VZqXN4DPxvsa4hAyY8dHM28cZzp6"
+  ],
+  [
+    "bootstrap1",
+    "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav",
+    "unencrypted:edsk3gUfUPyBSfrS9CCgmCiQsTCHGkviBDusMxDJstFtojtc1zcpsh"
+  ],
+  [
+    "bootstrap2",
+    "edpktzNbDAUjUk697W7gYg2CRuBQjyPxbEg8dLccYYwKSKvkPvjtV9",
+    "unencrypted:edsk39qAm1fiMjgmPkw1EgQYkMzkJezLNewd7PLNHTkr6w9XA2zdfo"
+  ],
+  [
+    "bootstrap3",
+    "edpkuTXkJDGcFd5nh6VvMz8phXxU3Bi7h6hqgywNFi1vZTfQNnS1RV",
+    "unencrypted:edsk4ArLQgBTLWG5FJmnGnT689VKoqhXwmDPBuGx3z4cvwU9MmrPZZ"
+  ],
+  [
+    "bootstrap4",
+    "edpkuFrRoDSEbJYgxRtLx2ps82UdaYc1WwfS9sE11yhauZt5DgCHbU",
+    "unencrypted:edsk2uqQB9AY4FvioK2YMdfmyMrer5R8mGFyuaLLFfSRo8EoyNdht3"
+  ],
+  [
+    "bootstrap5",
+    "edpkv8EUUH68jmo3f7Um5PezmfGrRF24gnfLpH3sVNwJnV5bVCxL2n",
+    "unencrypted:edsk4QLrcijEffxV31gGdN2HU7UpyJjA8drFoNcmnB28n89YjPNRFm"
+  ]
+]


### PR DESCRIPTION
# Context

Completes JSTZ-694.
[JSTZ-694](https://linear.app/tezos/issue/JSTZ-694/make-bootstrap-accounts-configurable-at-build-time)

Need a mechanism to replace the built-in bootstrap accounts when necessary.

# Description

Moved built-in bootstrap account details to a resource file and made jstzd config reader load the accounts from the resource file. The file will be embedded into release builds, which means we can have replace the built-in bootstrap accounts if we replace the resource file at compile time.

Also added a check to the build script that validates bootstrap accounts in the resource file. This ensures that these accounts packed into release builds are always valid.

# Manually testing the PR

* Unit testing: all relevant tests that depend on old still work.
* Integration testing: though `jstzd_test` actually needs to be polished, the test works after the necessary patches are applied.
* Manual testing: tampered the resource file and observed that the build failed.
