### PR TITLE
feat(fetch): dispatch handling http request to the oracle

### DIFF
--- a/crates/jstz_proto/src/context/account.rs
+++ b/crates/jstz_proto/src/context/account.rs
@@ -167,6 +167,13 @@ impl Address {
         }
     }
 
+    pub fn as_user(&self) -> Option<&PublicKeyHash> {
+        match self {
+            Address::User(public_key_hash) => Some(public_key_hash),
+            Address::SmartFunction(_) => None,
+        }
+    }
+
     pub fn from_base58(data: &str) -> Result<Self> {
         if data.len() < 3 {
             return Err(Error::InvalidAddress);

--- a/crates/jstz_proto/src/lib.rs
+++ b/crates/jstz_proto/src/lib.rs
@@ -8,6 +8,7 @@ pub mod logger;
 pub mod operation;
 pub mod receipt;
 pub mod storage;
+
 pub use error::{Error, Result};
 
 pub mod runtime;

--- a/crates/jstz_proto/src/runtime/v2/fetch/error.rs
+++ b/crates/jstz_proto/src/runtime/v2/fetch/error.rs
@@ -5,6 +5,8 @@ use jstz_crypto::smart_function_hash::SmartFunctionHash;
 use jstz_runtime::error::RuntimeError;
 use serde::Serialize;
 
+use crate::runtime::v2::oracle::OracleError;
+
 use super::http::*;
 
 pub type Result<T> = std::result::Result<T, FetchError>;
@@ -29,6 +31,15 @@ pub enum FetchError {
     #[class(not_supported)]
     #[error("{0}")]
     NotSupported(&'static str),
+    #[class(generic)]
+    #[error("Oracle calls are not allowed to be called from RunFunction")]
+    TopLevelOracleCallNotSupported,
+    #[class("ProtocolError")]
+    #[error("Source address must be user address")]
+    InvalidSourceAddress,
+    #[class(inherit)]
+    #[error(transparent)]
+    OracleError(#[from] OracleError),
     // TODO: Boa's JsClass errors are not Send safe. Once we remove boa, we
     // should be able to use crate::Error type directly
     #[class("RuntimeError")]

--- a/crates/jstz_proto/src/runtime/v2/fetch/fetch_handler.rs
+++ b/crates/jstz_proto/src/runtime/v2/fetch/fetch_handler.rs
@@ -3,12 +3,18 @@ use crate::logger::{
 };
 use crate::operation::OperationHash;
 use crate::runtime::v2::fetch::error::{FetchError, Result};
+use crate::runtime::v2::fetch::http::Request;
 use crate::runtime::v2::ledger;
+use crate::runtime::v2::protocol_context::PROTOCOL_CONTEXT;
 
 use deno_core::{
     resolve_import, v8, ByteString, JsBuffer, OpState, ResourceId, StaticModuleLoader,
 };
 use deno_fetch_base::{FetchHandler, FetchResponse, FetchReturn};
+use futures::FutureExt;
+use jstz_crypto::public_key_hash::PublicKeyHash;
+use std::future::Future;
+use std::pin::Pin;
 use std::{cell::RefCell, rc::Rc};
 
 use jstz_core::host::JsHostRuntime;
@@ -116,13 +122,22 @@ fn fetch(
     body: Option<Body>,
 ) -> Result<FetchReturn> {
     let url = Url::try_from(url.as_str())?;
-    let protocol = state.borrow_mut::<RuntimeContext>();
-    let host = JsHostRuntime::new(&mut protocol.host);
+    let (tx, from, host) = {
+        let rt_context = state.borrow_mut::<RuntimeContext>();
+        (
+            rt_context.tx.clone(),
+            rt_context.address.clone(),
+            JsHostRuntime::new(&mut rt_context.host),
+        )
+    };
+    let SourceAddress(source) = state.borrow::<SourceAddress>();
     let fut = process_and_dispatch_request(
         host,
-        protocol.tx.clone(),
+        tx,
+        false,
         None,
-        protocol.address.clone().into(),
+        source.clone(),
+        from.clone().into(),
         method,
         url.clone(),
         headers,
@@ -131,7 +146,7 @@ fn fetch(
     let fetch_request_resource = FetchRequestResource {
         future: Box::pin(fut),
         url,
-        from: protocol.address.clone(),
+        from: from.clone(),
     };
     let request_rid = state.resource_table.add(fetch_request_resource);
     Ok(FetchReturn {
@@ -153,7 +168,13 @@ fn fetch(
 pub async fn process_and_dispatch_request(
     mut host: JsHostRuntime<'static>,
     mut tx: Transaction,
+    is_run_function: bool,
+    // Top level operation hash
     operation_hash: Option<OperationHash>,
+    // Source address that initiated the RunFunction operation. Must be a user address
+    source: Address,
+    // Address that initiated the call. This will be a user address equal to source
+    // if called from RunFunction or a smart function address if called from fetch
     from: Address,
     method: ByteString,
     url: Url,
@@ -161,6 +182,10 @@ pub async fn process_and_dispatch_request(
     data: Option<Body>,
 ) -> Response {
     let scheme = SupportedScheme::try_from(&url);
+    let source = match SourceAddress::try_from(source) {
+        Ok(ok) => ok,
+        Err(e) => return e.into(),
+    };
     let response = match scheme {
         Ok(SupportedScheme::Jstz) => {
             let mut is_successful = true;
@@ -168,7 +193,9 @@ pub async fn process_and_dispatch_request(
             let result = dispatch_run(
                 &mut host,
                 &mut tx,
+                is_run_function,
                 operation_hash.as_ref(),
+                source,
                 from,
                 method,
                 &url,
@@ -182,7 +209,19 @@ pub async fn process_and_dispatch_request(
             result.into()
         }
         Ok(SupportedScheme::Http) => {
-            todo!()
+            match dispatch_oracle(
+                &mut host,
+                &mut tx,
+                is_run_function,
+                source,
+                method,
+                &url,
+                headers,
+                data,
+            ) {
+                Ok(resp) => resp.await,
+                Err(e) => Err(e).into(),
+            }
         }
         Err(err) => err.into(),
     };
@@ -194,12 +233,67 @@ pub async fn process_and_dispatch_request(
     response
 }
 
+fn dispatch_oracle(
+    host: &mut JsHostRuntime<'static>,
+    tx: &mut Transaction,
+    is_run_function: bool,
+    source: SourceAddress,
+    method: ByteString,
+    url: &Url,
+    headers: Vec<(ByteString, ByteString)>,
+    data: Option<Body>,
+) -> Result<Pin<Box<dyn Future<Output = Response>>>> {
+    if is_run_function {
+        return Ok(async {
+            Response {
+                status: 400,
+                status_text: "Bad Request".into(),
+                headers: Vec::with_capacity(0),
+                body: "HTTP requests are not callable from RunFunction".into(),
+            }
+        }
+        .boxed_local());
+    }
+    let response_rx = {
+        let ctx = PROTOCOL_CONTEXT
+            .get()
+            .expect("Protocol context should be initialized");
+        let mut ctx_lock = ctx.lock();
+        let oracle = ctx_lock.oracle();
+        oracle.send_request(
+            host,
+            tx,
+            &source.as_user(),
+            Request {
+                method,
+                url: url.clone(),
+                headers,
+                body: data,
+            },
+        )
+    }?;
+    Ok(async {
+        match response_rx.await {
+            Ok(resp) => resp,
+            Err(_cancelled) => Response {
+                status: 408,
+                status_text: "Request Timeout".to_string(),
+                headers: Vec::with_capacity(0),
+                body: Body::zero_capacity(),
+            },
+        }
+    }
+    .boxed_local())
+}
+
 /// # Safety
 /// Transaction snapshot creation and commitment should happen outside this function
 async fn dispatch_run(
     host: &mut JsHostRuntime<'static>,
     tx: &mut Transaction,
+    is_run_function: bool,
     operation_hash: Option<&OperationHash>,
+    source: SourceAddress,
     from: Address,
     method: ByteString,
     url: &Url,
@@ -215,6 +309,7 @@ async fn dispatch_run(
                 host,
                 tx,
                 operation_hash,
+                source,
                 to.clone(),
                 method,
                 url,
@@ -227,6 +322,12 @@ async fn dispatch_run(
             log_event(host, operation_hash, LogEvent::RequestEnd(&to));
             response
         }
+        Ok(HostName::JstzHost) if is_run_function => Ok(Response {
+            status: 400,
+            status_text: "Bad Request".into(),
+            headers: Vec::with_capacity(0),
+            body: "HostScript is not callable from RunFunction".into(),
+        }),
         Ok(HostName::JstzHost) => HostScript::route(host, tx, from, method, url).await,
         Err(e) => Err(e),
     }
@@ -236,6 +337,7 @@ async fn handle_address(
     host: &mut JsHostRuntime<'static>,
     tx: &mut Transaction,
     operation_hash: Option<&OperationHash>,
+    source: SourceAddress,
     to: Address,
     method: ByteString,
     url: &Url,
@@ -269,6 +371,7 @@ async fn handle_address(
                 host,
                 tx,
                 operation_hash,
+                source,
                 address.clone(),
                 method,
                 url,
@@ -315,6 +418,7 @@ async fn load_and_run(
     host: &mut impl HostRuntime,
     tx: &mut Transaction,
     operation_hash: Option<&OperationHash>,
+    source: SourceAddress,
     address: SmartFunctionHash,
     method: ByteString,
     url: &Url,
@@ -347,6 +451,7 @@ async fn load_and_run(
         extensions: vec![ledger::jstz_ledger::init_ops_and_esm()],
         ..Default::default()
     });
+    runtime.set_state(source);
 
     // 3. Prepare request
     let request = {
@@ -577,6 +682,27 @@ fn log_event(
     }
 }
 
+// Newtype used to store source in op state. Always a user address
+struct SourceAddress(Address);
+
+impl SourceAddress {
+    pub fn as_user(&self) -> &PublicKeyHash {
+        self.0.as_user().unwrap()
+    }
+}
+
+impl TryFrom<Address> for SourceAddress {
+    type Error = FetchError;
+
+    fn try_from(source: Address) -> std::result::Result<Self, Self::Error> {
+        if matches!(source, Address::User(_)) {
+            Ok(SourceAddress(source))
+        } else {
+            Err(FetchError::InvalidSourceAddress)
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::{collections::HashMap, str::FromStr};
@@ -585,9 +711,13 @@ mod test {
 
     use jstz_runtime::{JstzRuntime, JstzRuntimeOptions, RuntimeContext};
 
-    use jstz_core::{host::JsHostRuntime, kv::Transaction};
+    use jstz_core::{
+        host::JsHostRuntime,
+        kv::{Storage, Transaction},
+    };
     use jstz_crypto::{
         hash::{Blake2b, Hash},
+        public_key::PublicKey,
         smart_function_hash::SmartFunctionHash,
     };
     use jstz_utils::test_util::TOKIO;
@@ -596,12 +726,25 @@ mod test {
     use url::Url;
 
     use super::ProtoFetchHandler;
-    use crate::runtime::v2::fetch::fetch_handler::process_and_dispatch_request;
-    use crate::runtime::v2::test_utils::*;
     use crate::runtime::ParsedCode;
     use crate::{
         context::account::{Account, Address},
         tests::DebugLogSink,
+    };
+    use crate::{
+        event,
+        runtime::v2::{
+            fetch::fetch_handler::process_and_dispatch_request, oracle::OracleRequest,
+            protocol_context::ProtocolContext,
+        },
+    };
+    use crate::{
+        runtime::v2::{
+            fetch::{fetch_handler::SourceAddress, http::Response},
+            protocol_context::PROTOCOL_CONTEXT,
+            test_utils::*,
+        },
+        storage::ORACLE_PUBLIC_KEY_PATH,
     };
 
     use std::rc::Rc;
@@ -630,7 +773,9 @@ mod test {
             let response = process_and_dispatch_request(
                 host,
                 tx,
+                false,
                 None,
+                source_address.clone().into(),
                 source_address.into(),
                 "GET".into(),
                 Url::parse(format!("jstz://{}/{}", run_address, remote_address).as_str())
@@ -665,7 +810,9 @@ mod test {
         let response = process_and_dispatch_request(
             host,
             tx,
+            false,
             None,
+            source_address.clone().into(),
             source_address.into(),
             "GET".into(),
             Url::parse(format!("jstz://{}/{}", run_address, run_address).as_str())
@@ -702,7 +849,9 @@ mod test {
             let response = process_and_dispatch_request(
                 host,
                 tx,
+                false,
                 None,
+                source_address.clone().into(),
                 source_address.into(),
                 "GET".into(),
                 Url::parse(format!("jstz://{}", run_address).as_str()).unwrap(),
@@ -740,7 +889,9 @@ mod test {
             let response = process_and_dispatch_request(
                 host,
                 tx,
+                false,
                 None,
+                source_address.clone().into(),
                 source_address.into(),
                 "GET".into(),
                 Url::parse(format!("jstz://{}/{}", run_address, remote_address).as_str())
@@ -776,7 +927,9 @@ mod test {
             let response = process_and_dispatch_request(
                 host,
                 tx,
+                false,
                 None,
+                source_address.clone().into(),
                 source_address.into(),
                 "GET".into(),
                 Url::parse(format!("jstz://{}/{}", run_address, remote_address).as_str())
@@ -816,7 +969,9 @@ mod test {
             let response = process_and_dispatch_request(
                 host,
                 tx,
+                false,
                 None,
+                source_address.clone().into(),
                 source_address.into(),
                 "GET".into(),
                 Url::parse(format!("jstz://{}/{}", run_address, remote_address).as_str())
@@ -850,7 +1005,9 @@ mod test {
             let response = process_and_dispatch_request(
                 JsHostRuntime::new(&mut host),
                 tx,
+                false,
                 None,
+                jstz_mock::account1().into(),
                 jstz_mock::account1().into(),
                 "GET".into(),
                 Url::parse(format!("jstz://{}", run_address).as_str()).unwrap(),
@@ -889,7 +1046,9 @@ mod test {
             let response = process_and_dispatch_request(
                 JsHostRuntime::new(&mut host),
                 tx,
+                false,
                 None,
+                jstz_mock::account1().into(),
                 jstz_mock::account1().into(),
                 "GET".into(),
                 Url::parse(format!("jstz://{}/{}", run_address, remote_address).as_str())
@@ -942,7 +1101,9 @@ mod test {
             let _ = process_and_dispatch_request(
                 JsHostRuntime::new(&mut host),
                 tx.clone(),
+                false,
                 None,
+                jstz_mock::account1().into(),
                 jstz_mock::account1().into(),
                 "GET".into(),
                 Url::parse(format!("jstz://{}/{}", run_address, remote_address).as_str())
@@ -987,7 +1148,9 @@ mod test {
             let response = process_and_dispatch_request(
                 JsHostRuntime::new(&mut host),
                 tx.clone(),
+                false,
                 None,
+                jstz_mock::account1().into(),
                 jstz_mock::account1().into(),
                 "GET".into(),
                 Url::parse(format!("jstz://{}/{}", run_address, remote_address).as_str())
@@ -1048,7 +1211,9 @@ mod test {
             let response = process_and_dispatch_request(
                 JsHostRuntime::new(&mut host),
                 tx.clone(),
+                false,
                 None,
+                jstz_mock::account1().into(),
                 jstz_mock::account1().into(),
                 "GET".into(),
                 Url::parse(format!("jstz://{}/{}", run_address, remote_address).as_str())
@@ -1092,7 +1257,9 @@ mod test {
         let response = process_and_dispatch_request(
             JsHostRuntime::new(&mut host),
             tx.clone(),
+            false,
             None,
+            jstz_mock::account1().into(),
             jstz_mock::account1().into(),
             "GET".into(),
             Url::parse(format!("jstz://{}/{}", run_address, remote_address).as_str())
@@ -1129,7 +1296,9 @@ mod test {
             let response = process_and_dispatch_request(
                 JsHostRuntime::new(&mut host),
                 tx.clone(),
+                false,
                 None,
+                jstz_mock::account1().into(),
                 jstz_mock::account1().into(),
                 "GET".into(),
                 Url::parse(format!("jstz://{}/{}", run_address, remote_address).as_str())
@@ -1173,7 +1342,9 @@ mod test {
             let _ = process_and_dispatch_request(
                 JsHostRuntime::new(&mut host),
                 tx.clone(),
+                false,
                 None,
+                jstz_mock::account1().into(),
                 jstz_mock::account1().into(),
                 "GET".into(),
                 Url::parse(format!("jstz://{}/{}", run_address, remote_address).as_str())
@@ -1213,7 +1384,9 @@ mod test {
             let response = process_and_dispatch_request(
                 JsHostRuntime::new(&mut host),
                 tx.clone(),
+                false,
                 None,
+                jstz_mock::account1().into(),
                 jstz_mock::account1().into(),
                 "GET".into(),
                 Url::parse(format!("jstz://{}/{}", run_address, remote_address).as_str())
@@ -1258,7 +1431,9 @@ mod test {
             let response = process_and_dispatch_request(
                 JsHostRuntime::new(&mut host),
                 tx.clone(),
+                false,
                 None,
+                jstz_mock::account1().into(),
                 jstz_mock::account1().into(),
                 "GET".into(),
                 Url::parse(format!("jstz://{}/{}", run_address, remote_address).as_str())
@@ -1305,7 +1480,9 @@ mod test {
             let response = process_and_dispatch_request(
                 JsHostRuntime::new(&mut host),
                 tx.clone(),
+                false,
                 None,
+                jstz_mock::account1().into(),
                 jstz_mock::account1().into(),
                 "GET".into(),
                 Url::parse(format!("jstz://{}/{}", run_address, remote_address).as_str())
@@ -1349,7 +1526,9 @@ mod test {
             let _ = process_and_dispatch_request(
                 JsHostRuntime::new(&mut host),
                 tx.clone(),
+                false,
                 None,
+                jstz_mock::account1().into(),
                 jstz_mock::account1().into(),
                 "GET".into(),
                 Url::parse(format!("jstz://{}/{}", run_address, remote_address).as_str())
@@ -1387,7 +1566,9 @@ mod test {
             let _ = process_and_dispatch_request(
                 JsHostRuntime::new(&mut host),
                 tx.clone(),
+                false,
                 None,
+                jstz_mock::account1().into(),
                 jstz_mock::account1().into(),
                 "GET".into(),
                 Url::parse(format!("jstz://{}/{}", run_address, remote_address).as_str())
@@ -1429,7 +1610,9 @@ mod test {
         let response = process_and_dispatch_request(
             JsHostRuntime::new(&mut host),
             tx.clone(),
+            false,
             None,
+            jstz_mock::account1().into(),
             jstz_mock::account1().into(),
             "GET".into(),
             Url::parse(format!("jstz://{}/{}", run_address, remote_address).as_str())
@@ -1551,6 +1734,7 @@ mod test {
             module_loader: Rc::new(module_loader),
             ..Default::default()
         });
+        runtime.set_state(SourceAddress::try_from(source).unwrap());
         let id = runtime.execute_main_module(&specifier).await.unwrap();
         let _ = runtime.call_default_handler(id, &[]).await.unwrap();
     }
@@ -1664,7 +1848,9 @@ mod test {
         let response = super::process_and_dispatch_request(
             JsHostRuntime::new(&mut host),
             tx,
+            false,
             Some(Blake2b::from(b"op_hash".as_ref())),
+            from.clone(),
             from,
             "GET".into(),
             Url::parse(&format!("jstz://{}/", func_addr.to_base58_check())).unwrap(),
@@ -1713,7 +1899,9 @@ mod test {
             let response = process_and_dispatch_request(
                 JsHostRuntime::new(&mut host),
                 tx.clone(),
+                false,
                 None,
+                jstz_mock::account1().into(),
                 jstz_mock::account1().into(),
                 "GET".into(),
                 Url::parse(format!("jstz://{}/{}", run_address, remote_address).as_str())
@@ -1753,7 +1941,9 @@ mod test {
             let response = process_and_dispatch_request(
                 JsHostRuntime::new(&mut host),
                 tx.clone(),
+                false,
                 None,
+                jstz_mock::account1().into(),
                 jstz_mock::account1().into(),
                 "GET".into(),
                 Url::parse(format!("jstz://{}/{}", run_address, remote_address).as_str())
@@ -1789,7 +1979,9 @@ mod test {
             let response = process_and_dispatch_request(
                 JsHostRuntime::new(&mut host),
                 tx.clone(),
+                false,
                 None,
+                jstz_mock::account1().into(),
                 jstz_mock::account1().into(),
                 "GET".into(),
                 Url::parse(format!("jstz://{}/{}", run_address, remote_address).as_str())
@@ -1827,7 +2019,9 @@ mod test {
             let response = process_and_dispatch_request(
                 JsHostRuntime::new(&mut host),
                 tx.clone(),
+                false,
                 None,
+                jstz_mock::account1().into(),
                 jstz_mock::account1().into(),
                 "GET".into(),
                 Url::parse(format!("jstz://{}/{}", run_address, remote_address).as_str())
@@ -1866,7 +2060,9 @@ mod test {
             let response = process_and_dispatch_request(
                 JsHostRuntime::new(&mut host),
                 tx.clone(),
+                false,
                 None,
+                jstz_mock::account1().into(),
                 jstz_mock::account1().into(),
                 "GET".into(),
                 Url::parse(format!("jstz://{}/{}", run_address, remote_address).as_str())
@@ -1883,5 +2079,85 @@ mod test {
                 String::from_utf8(response.body.into()).unwrap()
             );
         });
+    }
+
+    // Oracle behaviour
+
+    #[test]
+    fn fetch_http_returns_response() {
+        TOKIO.block_on(async {
+            let code = r#"
+        export default async () => {
+            let result = await fetch("http://example.com")
+            return result
+        }
+        "#;
+            let debug_sink = DebugLogSink::new();
+            let mut host = tezos_smart_rollup_mock::MockHost::default();
+            host.set_debug_handler(debug_sink.clone());
+            let pk = PublicKey::from_base58(
+                "edpkukK9ecWxib28zi52nvbXTdsYt8rYcvmt5bdH8KjipWXm8sH3Qi",
+            )
+            .unwrap();
+            Storage::insert(&mut host, &ORACLE_PUBLIC_KEY_PATH, &pk).unwrap();
+            let (mut host, mut tx, source_address, hashes) = setup(&mut host, [code]);
+            Account::add_balance(&mut host,&mut tx, &source_address, 0).unwrap();
+            tx.commit(&mut host).unwrap();
+
+            let run_address = hashes[0].clone();
+            ProtocolContext::init_global(&mut host).unwrap();
+            tokio::pin! {
+                let response_fut = process_and_dispatch_request(
+                    JsHostRuntime::new(&mut host),
+                    tx.clone(),
+                    false,
+                    None,
+                    jstz_mock::account1().into(),
+                    jstz_mock::account1().into(),
+                    "GET".into(),
+                    Url::parse(format!("jstz://{}", run_address).as_str()).unwrap(),
+                    vec![],
+                    None,
+                );
+            };
+            let response = Response {
+                status: 200,
+                status_text: "OK".into(),
+                headers: Vec::with_capacity(0),
+                body: serde_json::to_vec(&json!({ "message": "this is a test message" }))
+                    .unwrap()
+                    .into(),
+            };
+
+
+            let fetch_response = tokio::select! {
+                response = &mut response_fut => {
+                    response
+                }
+                _ = async {
+                    while debug_sink.str_content().is_empty() {
+                        tokio::task::yield_now().await
+                    }
+                    let oracle_request =
+                        event::decode_line::<OracleRequest>(debug_sink.lines().first().unwrap())
+                            .unwrap();
+                    assert_eq!(oracle_request.request.method, "GET".into());
+                    assert_eq!(
+                        oracle_request.request.url,
+                        Url::parse("http://example.com").unwrap()
+                    );
+                    assert_eq!(oracle_request.caller, source_address);
+                    let mut locked = PROTOCOL_CONTEXT.get().unwrap().lock();
+                    let oracle = locked.oracle();
+
+                    oracle
+                        .respond(&mut host, oracle_request.id, response.clone())
+                        .unwrap();
+                } => {
+                    response_fut.await
+                }
+            };
+            assert_eq!(response, fetch_response);
+        })
     }
 }

--- a/crates/jstz_proto/src/runtime/v2/fetch/http.rs
+++ b/crates/jstz_proto/src/runtime/v2/fetch/http.rs
@@ -175,6 +175,7 @@ impl<'s> ToV8<'s> for Body {
 
 pub enum SupportedScheme {
     Jstz,
+    Http,
 }
 
 impl TryFrom<&Url> for SupportedScheme {
@@ -183,6 +184,7 @@ impl TryFrom<&Url> for SupportedScheme {
     fn try_from(value: &Url) -> Result<Self> {
         match value.scheme() {
             "jstz" => Ok(Self::Jstz),
+            "http" => Ok(Self::Http),
             scheme => Err(FetchError::UnsupportedScheme(scheme.to_string())),
         }
     }

--- a/crates/jstz_proto/src/runtime/v2/fetch/http.rs
+++ b/crates/jstz_proto/src/runtime/v2/fetch/http.rs
@@ -19,12 +19,21 @@ use deno_core::{serde_v8, v8, ToJsBuffer};
 use crate::executor::smart_function::JSTZ_HOST;
 
 /// Response returned from fetch or [`crate::operation::RunFunction`]
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Eq, Clone, Serialize, Deserialize)]
 pub struct Response {
     pub status: u16,
     pub status_text: String,
     pub headers: Vec<(ByteString, ByteString)>,
     pub body: Body,
+}
+
+impl PartialEq for Response {
+    fn eq(&self, other: &Self) -> bool {
+        self.status == other.status
+            && self.status_text == other.status_text
+            && self.headers == other.headers
+            && self.body.as_slice() == other.body.as_slice()
+    }
 }
 
 impl Into<http::Response<Option<Vec<u8>>>> for Response {
@@ -110,6 +119,13 @@ impl Body {
             Self::Buffer(b) => b.len(),
         }
     }
+
+    pub fn as_slice(&self) -> &[u8] {
+        match self {
+            Body::Vector(vec) => vec.as_slice(),
+            Body::Buffer(buffer) => buffer.as_ref(),
+        }
+    }
 }
 
 impl From<Body> for BytesStream {
@@ -136,6 +152,12 @@ impl From<&str> for Body {
 impl From<&[u8]> for Body {
     fn from(bytes: &[u8]) -> Self {
         Body::Vector(bytes.to_vec())
+    }
+}
+
+impl From<Vec<u8>> for Body {
+    fn from(value: Vec<u8>) -> Self {
+        Body::Vector(value)
     }
 }
 

--- a/crates/jstz_proto/src/runtime/v2/ledger/mod.rs
+++ b/crates/jstz_proto/src/runtime/v2/ledger/mod.rs
@@ -88,7 +88,9 @@ mod test {
             let response = process_and_dispatch_request(
                 host,
                 tx,
+                false,
                 None,
+                source_address.clone().into(),
                 source_address.into(),
                 "GET".into(),
                 Url::parse(format!("jstz://{}", run_address).as_str()).unwrap(),
@@ -125,7 +127,9 @@ mod test {
             let response = process_and_dispatch_request(
                 host,
                 tx,
+                false,
                 None,
+                source_address.clone().into(),
                 source_address.into(),
                 "GET".into(),
                 Url::parse(format!("jstz://{}", run_address).as_str()).unwrap(),
@@ -164,7 +168,9 @@ mod test {
             let _ = process_and_dispatch_request(
                 JsHostRuntime::new(&mut host),
                 tx.clone(),
+                false,
                 None,
+                source_address.clone().into(),
                 source_address.clone().into(),
                 "GET".into(),
                 Url::parse(format!("jstz://{}", run_address).as_str()).unwrap(),

--- a/crates/jstz_proto/src/runtime/v2/ledger/mod.rs
+++ b/crates/jstz_proto/src/runtime/v2/ledger/mod.rs
@@ -1,21 +1,21 @@
 use deno_core::{extension, op2, OpState};
 
 use jstz_crypto::hash::Hash;
-use jstz_runtime::ProtocolContext;
+use jstz_runtime::RuntimeContext;
 
 use crate::context::account::{Account, Address};
 
 #[op2]
 #[string]
 fn op_self_address(state: &mut OpState) -> String {
-    let proto = state.borrow_mut::<ProtocolContext>();
+    let proto = state.borrow_mut::<RuntimeContext>();
     proto.address.to_base58()
 }
 
 #[op2(fast)]
 #[number]
 fn op_balance(state: &mut OpState, #[string] address: String) -> Result<u64> {
-    let ProtocolContext { host, tx, .. } = state.borrow_mut::<ProtocolContext>();
+    let RuntimeContext { host, tx, .. } = state.borrow_mut::<RuntimeContext>();
     let address = Address::from_base58(&address)?;
     Ok(Account::balance(host, tx, &address)?)
 }
@@ -26,9 +26,9 @@ fn op_transfer(
     #[string] dest_address: String,
     #[number] amount: u64,
 ) -> Result<()> {
-    let ProtocolContext {
+    let RuntimeContext {
         host, tx, address, ..
-    } = state.borrow_mut::<ProtocolContext>();
+    } = state.borrow_mut::<RuntimeContext>();
     let dest = Address::from_base58(&dest_address)?;
     Ok(Account::transfer(host, tx, address, &dest, amount)?)
 }

--- a/crates/jstz_proto/src/runtime/v2/mod.rs
+++ b/crates/jstz_proto/src/runtime/v2/mod.rs
@@ -20,6 +20,7 @@ mod parsed_code;
 pub use parsed_code::ParsedCode;
 mod ledger;
 pub mod oracle;
+pub mod protocol_context;
 
 pub async fn run_toplevel_fetch(
     hrt: &mut impl HostRuntime,
@@ -44,7 +45,9 @@ async fn run(
     let response: http::Response<Option<Vec<u8>>> = process_and_dispatch_request(
         JsHostRuntime::new(hrt),
         tx.clone(),
+        true,
         Some(operation_hash),
+        source_address.clone().into(),
         source_address.clone().into(),
         run_operation.method.to_string().into(),
         url,

--- a/crates/jstz_proto/src/runtime/v2/oracle/oracle.rs
+++ b/crates/jstz_proto/src/runtime/v2/oracle/oracle.rs
@@ -191,7 +191,8 @@ impl OracleRequestStorage {
 }
 
 type Result<T> = std::result::Result<T, OracleError>;
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, deno_error::JsError)]
+#[class("OracleError")]
 pub enum OracleError {
     #[error("Oracle signer public key not found at '{ORACLE_PUBLIC_KEY_PATH}'")]
     PublicKeyNotFound,

--- a/crates/jstz_proto/src/runtime/v2/protocol_context.rs
+++ b/crates/jstz_proto/src/runtime/v2/protocol_context.rs
@@ -1,0 +1,32 @@
+use std::sync::{Arc, OnceLock};
+
+use jstz_core::host::HostRuntime;
+use parking_lot::Mutex;
+
+use super::oracle::{Oracle, OracleError};
+
+/// Holds stateful globals required by the protocol
+pub static PROTOCOL_CONTEXT: OnceLock<Arc<Mutex<ProtocolContext>>> = OnceLock::new();
+
+pub struct ProtocolContext {
+    oracle: Oracle,
+}
+
+impl ProtocolContext {
+    pub fn oracle(&mut self) -> &mut Oracle {
+        &mut self.oracle
+    }
+
+    /// Initialize the global protocol context
+    pub fn init_global(rt: &mut impl HostRuntime) -> Result<(), ProtocolContextError> {
+        let oracle = Oracle::new(rt, None)?;
+        PROTOCOL_CONTEXT.get_or_init(|| Arc::new(Mutex::new(ProtocolContext { oracle })));
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ProtocolContextError {
+    #[error(transparent)]
+    OracleFailedToInitialize(#[from] OracleError),
+}

--- a/crates/jstz_runtime/src/ext/jstz_console/mod.rs
+++ b/crates/jstz_runtime/src/ext/jstz_console/mod.rs
@@ -1,4 +1,4 @@
-use crate::{ext::NotSupported, runtime::ProtocolContext};
+use crate::{ext::NotSupported, runtime::RuntimeContext};
 use deno_core::*;
 use jstz_core::log_record::LogLevel;
 use tezos_smart_rollup::prelude::debug_msg;
@@ -25,7 +25,7 @@ pub fn op_debug_msg(
     #[string] msg: &str,
     level: u32,
 ) -> Result<(), NotSupported> {
-    let proto = op_state.try_borrow_mut::<ProtocolContext>();
+    let proto = op_state.try_borrow_mut::<RuntimeContext>();
     match proto {
         Some(proto) => {
             #[cfg(not(feature = "kernel"))]

--- a/crates/jstz_runtime/src/ext/jstz_kv/mod.rs
+++ b/crates/jstz_runtime/src/ext/jstz_kv/mod.rs
@@ -1,7 +1,7 @@
 pub mod kv;
 pub(crate) mod extension {
     use super::kv::KvValue;
-    use crate::{ext::NotSupported, runtime::ProtocolContext};
+    use crate::{ext::NotSupported, runtime::RuntimeContext};
     use deno_core::{extension, op2, OpState};
     use thiserror;
     struct Kv;
@@ -15,9 +15,9 @@ pub(crate) mod extension {
             op_state: &mut OpState,
             #[string] key: &str,
         ) -> Result<Option<serde_json::Value>> {
-            let maybe_proto = op_state.try_borrow_mut::<ProtocolContext>();
+            let maybe_proto = op_state.try_borrow_mut::<RuntimeContext>();
             match maybe_proto {
-                Some(ProtocolContext { host, tx, kv, .. }) => {
+                Some(RuntimeContext { host, tx, kv, .. }) => {
                     let maybe_value = kv
                         .get(host, tx, key)
                         .map_err(|e| KvError::JstzCoreError(e.to_string()))?;
@@ -33,9 +33,9 @@ pub(crate) mod extension {
             #[string] key: &str,
             #[serde] value: serde_json::Value,
         ) -> Result<()> {
-            let maybe_proto = op_state.try_borrow_mut::<ProtocolContext>();
+            let maybe_proto = op_state.try_borrow_mut::<RuntimeContext>();
             match maybe_proto {
-                Some(ProtocolContext { tx, kv, .. }) => kv
+                Some(RuntimeContext { tx, kv, .. }) => kv
                     .set(tx, key, KvValue(value))
                     .map_err(|e| KvError::JstzCoreError(e.to_string())),
                 None => Err(NOT_SUPPORTED_ERROR)?,
@@ -45,9 +45,9 @@ pub(crate) mod extension {
         #[fast]
         #[static_method]
         fn delete(op_state: &mut OpState, #[string] key: &str) -> Result<()> {
-            let maybe_proto = op_state.try_borrow_mut::<ProtocolContext>();
+            let maybe_proto = op_state.try_borrow_mut::<RuntimeContext>();
             match maybe_proto {
-                Some(ProtocolContext { tx, kv, .. }) => kv
+                Some(RuntimeContext { tx, kv, .. }) => kv
                     .delete(tx, key)
                     .map_err(|e| KvError::JstzCoreError(e.to_string())),
                 None => Err(NOT_SUPPORTED_ERROR)?,
@@ -57,9 +57,9 @@ pub(crate) mod extension {
         #[fast]
         #[static_method]
         fn contains(op_state: &mut OpState, #[string] key: &str) -> Result<bool> {
-            let maybe_proto = op_state.try_borrow_mut::<ProtocolContext>();
+            let maybe_proto = op_state.try_borrow_mut::<RuntimeContext>();
             match maybe_proto {
-                Some(ProtocolContext { tx, kv, host, .. }) => kv
+                Some(RuntimeContext { tx, kv, host, .. }) => kv
                     .has(host, tx, key)
                     .map_err(|e| KvError::JstzCoreError(e.to_string())),
                 None => Err(NOT_SUPPORTED_ERROR)?,

--- a/crates/jstz_runtime/src/lib.rs
+++ b/crates/jstz_runtime/src/lib.rs
@@ -5,7 +5,7 @@ pub use ext::jstz_kv::kv::*;
 pub mod runtime;
 pub mod sys;
 
-pub use runtime::{JstzRuntime, JstzRuntimeOptions, ProtocolContext};
+pub use runtime::{JstzRuntime, JstzRuntimeOptions, RuntimeContext};
 
 #[cfg(test)]
 mod test_utils {
@@ -100,7 +100,7 @@ mod test_utils {
             let request_id = String::new();
             $(let request_id = $request_id.to_string();)?
             #[allow(unused)]
-            let protocol  = Some($crate::ProtocolContext::new(&mut init_host, &mut init_tx, init_addr.clone(), request_id));
+            let protocol  = Some($crate::RuntimeContext::new(&mut init_host, &mut init_tx, init_addr.clone(), request_id));
             #[allow(unused)]
             let mut $runtime = $crate::JstzRuntime::new($crate::JstzRuntimeOptions {
                 protocol,

--- a/crates/jstz_runtime/src/runtime.rs
+++ b/crates/jstz_runtime/src/runtime.rs
@@ -156,6 +156,11 @@ impl JstzRuntime {
         Self { runtime }
     }
 
+    pub fn set_state<S: 'static>(&mut self, state: S) {
+        let op_state = self.op_state();
+        op_state.borrow_mut().put(state);
+    }
+
     /// Executes traditional, non-ECMAScript-module JavaScript code, ignoring
     /// its result
     pub fn execute(&mut self, code: &str) -> Result<()> {

--- a/crates/jstz_runtime/src/runtime.rs
+++ b/crates/jstz_runtime/src/runtime.rs
@@ -78,7 +78,7 @@ impl Drop for JstzRuntime {
 }
 pub struct JstzRuntimeOptions {
     /// Protocol context accessible by protocol defined APIs
-    pub protocol: Option<ProtocolContext>,
+    pub protocol: Option<RuntimeContext>,
     /// Additional extensions to be registered on initialization.
     pub extensions: Vec<Extension>,
     /// Implementation of the `ModuleLoader` which will be
@@ -347,7 +347,7 @@ impl DerefMut for JstzRuntime {
     }
 }
 
-pub struct ProtocolContext {
+pub struct RuntimeContext {
     pub host: JsHostRuntime<'static>,
     pub tx: Transaction,
     pub kv: Kv,
@@ -355,7 +355,7 @@ pub struct ProtocolContext {
     pub request_id: String,
 }
 
-impl ProtocolContext {
+impl RuntimeContext {
     pub fn new(
         hrt: &mut impl HostRuntime,
         tx: &mut Transaction,
@@ -363,7 +363,7 @@ impl ProtocolContext {
         request_id: String,
     ) -> Self {
         let host = JsHostRuntime::new(hrt);
-        ProtocolContext {
+        RuntimeContext {
             host,
             tx: tx.clone(),
             kv: Kv::new(address.to_base58()),

--- a/crates/jstz_runtime/tests/wpt.rs
+++ b/crates/jstz_runtime/tests/wpt.rs
@@ -9,7 +9,7 @@ use deno_error::JsErrorBox;
 use derive_more::{From, Into};
 use jstz_core::{host::HostRuntime, kv::Transaction};
 use jstz_crypto::{hash::Hash, smart_function_hash::SmartFunctionHash};
-use jstz_runtime::{JstzRuntime, JstzRuntimeOptions, ProtocolContext};
+use jstz_runtime::{JstzRuntime, JstzRuntimeOptions, RuntimeContext};
 use jstz_wpt::{
     Bundle, BundleItem, TestFilter, TestToRun, Wpt, WptMetrics, WptReportTest, WptServe,
     WptSubtest, WptSubtestStatus, WptTestStatus,
@@ -253,7 +253,7 @@ fn init_runtime(host: &mut impl HostRuntime, tx: &mut Transaction) -> JstzRuntim
         .push(test_harness_api::init_ops_and_esm());
 
     let mut runtime = JstzRuntime::new(JstzRuntimeOptions {
-        protocol: Some(ProtocolContext::new(host, tx, address, String::new())),
+        protocol: Some(RuntimeContext::new(host, tx, address, String::new())),
         extensions: vec![test_harness_api::init_ops_and_esm()],
         ..Default::default()
     });


### PR DESCRIPTION
# Context
Closes https://linear.app/tezos/issue/JSTZ-697/dispatch-to-oracle-on-http-request 

We need to support oracle calls in fetch
<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
* Extends SupportedScheme to http (no https support yet)
* Dispatch http calls to `dispatch_oracle`
* `ProtocolContext` in `Runtime` was renamed to `RuntimeContext`
* `ProtocolContext` introduced in proto to hold stateful globals. This is implemented as a global `pub static Arc<Mutex<>>`. ProtocolContext can only be initialized globally.
* Checks for pre-conditions before making an oracle call which are
(1) Source address must be user address. Source is the address that initiated the run operation. Its important to note that all gas deductions occur against the source address only, although gas is set to 0 for now
(2)  RunFunctions cannot call the oracle directly. The same pre condition is true for host scripts. A flag has been added to detect this. 

 

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
`cargo nextest run -p jstz_proto fetch_http_returns_response  --features v2_runtime`
<!-- Describe how reviewers and approvers can test this PR. -->
