### PR TITLE
chore(cli): set sandbox jstz node config

### DIFF
--- a/crates/jstz_cli/src/sandbox/container.rs
+++ b/crates/jstz_cli/src/sandbox/container.rs
@@ -183,6 +183,10 @@ async fn create_config_file_and_client_dir() -> Result<(PathBuf, PathBuf)> {
         "octez_rollup": {
             "rpc_endpoint": format!("http://0.0.0.0:{SANDBOX_OCTEZ_ROLLUP_RPC_PORT}")
         },
+        "jstz_node": {
+            "mode": "sequencer",
+            "capacity": 64,
+        }
     })).context("Failed to serialise sandbox config")?;
     let config_file_path = NamedTempFile::new()
         .context("Failed to create a file as the config file")?
@@ -489,6 +493,10 @@ mod tests {
                 "octez_rollup": {
                     "rpc_endpoint": format!("http://0.0.0.0:{SANDBOX_OCTEZ_ROLLUP_RPC_PORT}")
                 },
+                "jstz_node": {
+                    "mode": "sequencer",
+                    "capacity": 64
+                }
             })
         );
     }


### PR DESCRIPTION
# Context

Completes JSTZ-689.
[JSTZ-689](https://linear.app/tezos/issue/JSTZ-689/expose-jstz-node-config-in-jstzd)

Following #1122. Since now jstz node is configurable and there are default values for the config, we need to set the desired values when launching a sandbox from CLI.

# Description

Updated CLI such that `jstz_node` config is added to the sandbox config. Since the mode in default jstz node config is "default", we need to explicitly set it to "sequencer" to run the sequencer in the sandbox.

# Manually testing the PR

* Unit testing: updated tests
* Manual testing: build CLI and launched the sandbox. Confirmed that jstz node ran in sequencer mode by checking the endpoint `http://localhost:8933/mode`.
