### PR TITLE
fix(nix): add v2_runtime feature to nix check

### DIFF
--- a/crates/jstz_proto/src/runtime/v2/ledger/mod.rs
+++ b/crates/jstz_proto/src/runtime/v2/ledger/mod.rs
@@ -149,8 +149,8 @@ mod test {
         TOKIO_MULTI_THREAD.block_on(async {
             // Code
             let run = r#"export default async (request) => {
-                let referrer = request.headers.get("referrer");
-                Ledger.transfer(referrer, 500 * 1000000);
+                let referer = request.headers.get("referer");
+                Ledger.transfer(referer, 500 * 1000000);
                 return new Response()
             }"#;
 

--- a/nix/crates.nix
+++ b/nix/crates.nix
@@ -180,7 +180,7 @@ in let
         buildInputs = commonWorkspace.buildInputs ++ [pkgs.iana-etc octez pkgs.cacert];
         doCheck = true;
         # Run the unit tests
-        cargoNextestExtraArgs = "--bins --lib --features \"skip-wpt\" --config-file ${src}/.config/nextest.toml";
+        cargoNextestExtraArgs = "--bins --lib --features \"skip-wpt\",\"v2_runtime\" --config-file ${src}/.config/nextest.toml";
       });
 
     cargo-test-int = craneLib.cargoNextest (commonWorkspace
@@ -191,7 +191,7 @@ in let
         #
         # FIXME(https://linear.app/tezos/issue/JSTZ-237):
         # Fix tests that only fail in CI/Nix
-        cargoNextestExtraArgs = "--test \"*\" --features \"skip-wpt\" --features \"skip-rollup-tests\" --config-file ${src}/.config/nextest.toml";
+        cargoNextestExtraArgs = "--test \"*\" --features \"skip-wpt\" --features \"skip-rollup-tests\",\"v2_runtime\" --config-file ${src}/.config/nextest.toml";
       });
 
     cargo-llvm-cov = craneLib.cargoLlvmCov (commonWorkspace
@@ -200,7 +200,7 @@ in let
         # Use nextest for test harness (instead of `cargo test`)
         cargoLlvmCovCommand = "nextest";
         # Generate coverage reports for codecov
-        cargoLlvmCovExtraArgs = "--codecov --output-path $out --features \"skip-rollup-tests\" --features \"skip-wpt\" --config-file ${src}/.config/nextest.toml";
+        cargoLlvmCovExtraArgs = "--codecov --output-path $out --features \"skip-rollup-tests\" --features \"skip-wpt\",\"v2_runtime\" --config-file ${src}/.config/nextest.toml";
       });
 
     cargo-clippy = craneLib.cargoClippy (commonWorkspace


### PR DESCRIPTION
# Context
We want to target v2 runtime

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
Add "v2_runtime" feature into nix check, fix breaking test
<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
* CI Builds
* `nix --accept-flake-config --log-format raw --log-lines 1500 -L flake check -j auto`
<!-- Describe how reviewers and approvers can test this PR. -->
