### PR TITLE
fix(docs): add docs for kv cli command

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -11,6 +11,8 @@ It provides these main commands:
 - [`deploy`](#deploy) - Deploy smart functions
 - [`run`](#run) - Send requests to smart functions
 - [`transfer`](#transfer) - Transfer XTZ between Jstz accounts
+- [`logs`](#logs) - Get smart function logs
+- [`kv`](#kv) - Get data from the key-value store
 
 :::tip
 
@@ -279,4 +281,39 @@ In a new terminal, run the counter function and you will see the following outpu
 [WARN]: warn
 [ERROR]: error
 [ERROR]: Assertion failed
+```
+
+### KV
+
+The `kv` commands get information from the Jstz key-value store.
+They cannot change that information because only smart functions can write to the key-value store.
+To get or change key-value data in a smart function, see [KV](/api/kv).
+
+The `list` command lists sub-keys for a given key.
+Sub-keys are separated with slashes, so if a smart function stores data with the keys `primaryKey/subKeyA` and `primaryKey/subKeyB`, the command `jstz kv list primaryKey` returns `subKeyA` and `subKeyB`.
+
+#### Commands
+
+- `get`: Gets a value from the key-value store.
+
+- `list`: Lists sub-keys for a given key.
+
+#### Usage
+
+```bash
+export counter=tz4CYGgcFtphw3AXS2Mx2CMmfj6voV5mPc9b # Address of the previously deployed smart function examples/counter.js
+jstz run "jstz://${counter}/"
+jstz kv get -a $counter counter
+```
+
+#### Options
+
+- `--account (-a) <ADDRESS>`: The address of the smart function to get the key-value data for.
+
+- `--network (-n) <NETWORK>`: The network from the config file, such as `dev` for the local sandbox.
+
+#### Example
+
+```bash
+jstz kv get -a $counter counter
 ```


### PR DESCRIPTION
We didn't have the `kv` cli command in the docs -- this PR adds it. Also the logs command was not listed in the internal TOC.