### PR TITLE
chore(jstzd): check bootstrap account 'activator'

### DIFF
--- a/crates/jstzd/build.rs
+++ b/crates/jstzd/build.rs
@@ -26,6 +26,8 @@ const JSTZ_PARAMETERS_TY_PATH: &str = "./resources/jstz_rollup/parameters_ty.jso
 /// Generated file that contains path getter functions
 const JSTZ_ROLLUP_PATH: &str = "jstz_rollup_path.rs";
 const BOOTSTRAP_ACCOUNT_PATH: &str = "./resources/bootstrap_account/accounts.json";
+// This alias is also used by jstzd during config validation.
+const ACTIVATOR_BOOTSTRAP_ACCOUNT_ALIAS: &str = "activator";
 
 /// Build script that validates built-in bootstrap accounts and generates and saves
 /// the following files in OUT_DIR:
@@ -236,5 +238,8 @@ fn validate_builtin_bootstrap_accounts() {
         SecretKey::from_base58(sk).unwrap_or_else(|e| {
             panic!("failed to parse secret key of bootstrap account '{name}': {e:?}")
         });
+    }
+    if !seen_names.contains(ACTIVATOR_BOOTSTRAP_ACCOUNT_ALIAS) {
+        panic!("there must be one built-in bootstrap account with alias '{ACTIVATOR_BOOTSTRAP_ACCOUNT_ALIAS}'");
     }
 }

--- a/crates/jstzd/resources/bootstrap_account/accounts.json
+++ b/crates/jstzd/resources/bootstrap_account/accounts.json
@@ -1,9 +1,9 @@
 [
   [
-    "bootstrap0",
+    "activator",
     "edpkuSLWfVU1Vq7Jg9FucPyKmma6otcMHac9zG4oU1KMHSTBpJuGQ2",
     "unencrypted:edsk31vznjHSSpGExDMHYASz45VZqXN4DPxvsa4hAyY8dHM28cZzp6",
-    100000000000
+    1
   ],
   [
     "bootstrap1",


### PR DESCRIPTION
# Context

Part of JSTZ-709.
[JSTZ-709](https://linear.app/tezos/issue/JSTZ-709/set-activator-account-properly)

We need a mechanism to rotate bootstrap accounts while making sure that octez node can still activate the protocol successfully.

# Description

Added validation for built-in bootstrap accounts to jstzd so that invalid bootstrap account config values are failed early. If the account alias `activator` is unknown to octez client, it will not be able to activate the protocol. Seriously speaking, for releases, the validation in the build script is sufficient, but I added similar logic to jstzd as well just to be safe, especially for local dev.

Also updated the bootstrap account display part. The activator account will not be printed out since this account should be purely internal.

# Manually testing the PR

* Unit testing: updated relevant tests.
* Manual testing: ran octez node with a designated path and observed that the activator account was not printed out.
