### PR TITLE
chore(jstzd): add balance to built-in bootstrap accounts

### DIFF
--- a/crates/jstzd/build.rs
+++ b/crates/jstzd/build.rs
@@ -218,10 +218,10 @@ fn generate_path_getter_code(out_dir: &Path, fn_name: &str, path_suffix: &str) -
 fn validate_builtin_bootstrap_accounts() {
     let bytes =
         fs::read(BOOTSTRAP_ACCOUNT_PATH).expect("failed to read bootstrap account file");
-    let raw_accounts: Vec<(String, String, String)> = serde_json::from_slice(&bytes)
+    let raw_accounts: Vec<(String, String, String, u64)> = serde_json::from_slice(&bytes)
         .unwrap_or_else(|e| panic!("failed to parse built-in bootstrap accounts: {e:?}"));
     let mut seen_names = HashSet::new();
-    for (name, pk, raw_sk) in raw_accounts {
+    for (name, pk, raw_sk, _) in raw_accounts {
         if !seen_names.insert(name.clone()) {
             panic!("bootstrap account name '{name}' already exists");
         }

--- a/crates/jstzd/resources/bootstrap_account/accounts.json
+++ b/crates/jstzd/resources/bootstrap_account/accounts.json
@@ -2,31 +2,37 @@
   [
     "bootstrap0",
     "edpkuSLWfVU1Vq7Jg9FucPyKmma6otcMHac9zG4oU1KMHSTBpJuGQ2",
-    "unencrypted:edsk31vznjHSSpGExDMHYASz45VZqXN4DPxvsa4hAyY8dHM28cZzp6"
+    "unencrypted:edsk31vznjHSSpGExDMHYASz45VZqXN4DPxvsa4hAyY8dHM28cZzp6",
+    100000000000
   ],
   [
     "bootstrap1",
     "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav",
-    "unencrypted:edsk3gUfUPyBSfrS9CCgmCiQsTCHGkviBDusMxDJstFtojtc1zcpsh"
+    "unencrypted:edsk3gUfUPyBSfrS9CCgmCiQsTCHGkviBDusMxDJstFtojtc1zcpsh",
+    100000000000
   ],
   [
     "bootstrap2",
     "edpktzNbDAUjUk697W7gYg2CRuBQjyPxbEg8dLccYYwKSKvkPvjtV9",
-    "unencrypted:edsk39qAm1fiMjgmPkw1EgQYkMzkJezLNewd7PLNHTkr6w9XA2zdfo"
+    "unencrypted:edsk39qAm1fiMjgmPkw1EgQYkMzkJezLNewd7PLNHTkr6w9XA2zdfo",
+    100000000000
   ],
   [
     "bootstrap3",
     "edpkuTXkJDGcFd5nh6VvMz8phXxU3Bi7h6hqgywNFi1vZTfQNnS1RV",
-    "unencrypted:edsk4ArLQgBTLWG5FJmnGnT689VKoqhXwmDPBuGx3z4cvwU9MmrPZZ"
+    "unencrypted:edsk4ArLQgBTLWG5FJmnGnT689VKoqhXwmDPBuGx3z4cvwU9MmrPZZ",
+    100000000000
   ],
   [
     "bootstrap4",
     "edpkuFrRoDSEbJYgxRtLx2ps82UdaYc1WwfS9sE11yhauZt5DgCHbU",
-    "unencrypted:edsk2uqQB9AY4FvioK2YMdfmyMrer5R8mGFyuaLLFfSRo8EoyNdht3"
+    "unencrypted:edsk2uqQB9AY4FvioK2YMdfmyMrer5R8mGFyuaLLFfSRo8EoyNdht3",
+    100000000000
   ],
   [
     "bootstrap5",
     "edpkv8EUUH68jmo3f7Um5PezmfGrRF24gnfLpH3sVNwJnV5bVCxL2n",
-    "unencrypted:edsk4QLrcijEffxV31gGdN2HU7UpyJjA8drFoNcmnB28n89YjPNRFm"
+    "unencrypted:edsk4QLrcijEffxV31gGdN2HU7UpyJjA8drFoNcmnB28n89YjPNRFm",
+    100000000000
   ]
 ]

--- a/crates/jstzd/src/task/jstzd.rs
+++ b/crates/jstzd/src/task/jstzd.rs
@@ -138,7 +138,7 @@ impl Task for Jstzd {
                 // we need secret keys
                 builtin_bootstrap_accounts()?
                     .into_iter()
-                    .map(|(alias, _, sk)| (alias, sk)),
+                    .map(|(alias, _, sk, _)| (alias, sk)),
             ),
         )
         .await?;
@@ -501,11 +501,10 @@ fn print_bootstrap_accounts<'a>(
     writer: &mut impl Write,
     accounts: impl IntoIterator<Item = &'a BootstrapAccount>,
 ) -> Result<()> {
-    let alias_address_mapping: HashMap<String, String> = HashMap::from_iter(
-        builtin_bootstrap_accounts()?
-            .into_iter()
-            .map(|(alias, pk, _)| (PublicKey::from_base58(&pk).unwrap().hash(), alias)),
-    );
+    let alias_address_mapping: HashMap<String, String> =
+        HashMap::from_iter(builtin_bootstrap_accounts()?.into_iter().map(
+            |(alias, pk, _, _)| (PublicKey::from_base58(&pk).unwrap().hash(), alias),
+        ));
 
     let mut table = Table::new();
     table.set_titles(Row::new(vec![


### PR DESCRIPTION
# Context

Part of JSTZ-709.
[JSTZ-709](https://linear.app/tezos/issue/JSTZ-709/set-activator-account-properly)

We need a mechanism to rotate bootstrap accounts while making sure that octez node can still activate the protocol successfully.

# Description

Updated the format of `accounts.json`. Now the balance of each bootstrap account is specified in that file as well. This makes it easier to set the balance of individual bootstrap account.

Each entry can actually be transformed into a proper mapping as there are a bit too many fields now, but I'm keeping it simple here temporarily.

# Manually testing the PR

All tests should still work.
