### PR TITLE
chore(jstzd): read injector from file

### DIFF
--- a/crates/jstz_node/src/config.rs
+++ b/crates/jstz_node/src/config.rs
@@ -6,8 +6,8 @@ use serde::Serialize;
 
 use crate::RunMode;
 
-/// Jstz node's signer defaults to `bootstrap1` account
-/// Make sure to update　the `INJECTOR_PK` in `jstzd/build_config.rs` if you change this
+/// Jstz node's signer defaults to `injector` account in jstzd/resources/bootstrap_account/accounts.json
+/// Make sure to keep these two in sync.
 pub const JSTZ_NODE_DEFAULT_PK: &str =
     "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav";
 pub const JSTZ_NODE_DEFAULT_SK: &str =

--- a/crates/jstzd/build.rs
+++ b/crates/jstzd/build.rs
@@ -4,7 +4,7 @@ use jstz_crypto::{
 };
 use jstz_kernel::{INJECTOR, TICKETER};
 use std::{
-    collections::HashSet,
+    collections::HashMap,
     env, fs,
     path::{Path, PathBuf},
 };
@@ -28,6 +28,7 @@ const JSTZ_ROLLUP_PATH: &str = "jstz_rollup_path.rs";
 const BOOTSTRAP_ACCOUNT_PATH: &str = "./resources/bootstrap_account/accounts.json";
 // This alias is also used by jstzd during config validation.
 const ACTIVATOR_BOOTSTRAP_ACCOUNT_ALIAS: &str = "activator";
+const INJECTOR_BOOTSTRAP_ACCOUNT_ALIAS: &str = "injector";
 
 /// Build script that validates built-in bootstrap accounts and generates and saves
 /// the following files in OUT_DIR:
@@ -55,18 +56,28 @@ fn main() {
     fs::copy(JSTZ_PARAMETERS_TY_PATH, out_dir.join("parameters_ty.json"))
         .expect("Failed to copy parameters_ty.json to OUT_DIR");
 
-    // 2. Create preimages directory and the kernel installer in OUT_DIR
+    // 2. Validate built-in bootstrap accounts stored in the resource file
+    let bootstrap_accounts = validate_builtin_bootstrap_accounts();
+
+    // 3. Create preimages directory and the kernel installer in OUT_DIR
     let preimages_dir = out_dir.join("preimages");
     fs::create_dir_all(&preimages_dir).expect("Failed to create preimages directory");
-    let kernel_installer =
-        make_kernel_installer(PathBuf::from(JSTZ_KERNEL_PATH).as_path(), &preimages_dir)
-            .expect("Failed to make kernel installer");
+    let injector_pk = bootstrap_accounts
+        .get(INJECTOR_BOOTSTRAP_ACCOUNT_ALIAS)
+        .expect("injector bootstrap account should exist")
+        .clone();
+    let kernel_installer = make_kernel_installer(
+        PathBuf::from(JSTZ_KERNEL_PATH).as_path(),
+        &preimages_dir,
+        injector_pk,
+    )
+    .expect("Failed to make kernel installer");
 
-    // 3. Save hex-encoded kernel installer to OUT_DIR
+    // 4. Save hex-encoded kernel installer to OUT_DIR
     fs::write(out_dir.join("kernel_installer.hex"), kernel_installer)
         .expect("Failed to write kernel_installer.hex");
 
-    // 4. Generate path getter code in OUT_DIR
+    // 5. Generate path getter code in OUT_DIR
     generate_code(&out_dir);
 
     println!(
@@ -85,9 +96,6 @@ fn main() {
             panic!("Failed to copy kernel files to '{}': {:?}", &p, e)
         });
     }
-
-    // Validate built-in bootstrap accounts stored in the resource file
-    validate_builtin_bootstrap_accounts();
 }
 
 fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io::Result<()> {
@@ -113,7 +121,11 @@ fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io::Result
 ///
 /// # Returns
 /// Hex-encoded kernel installer string
-fn make_kernel_installer(kernel_file: &Path, preimages_dir: &Path) -> Result<String> {
+fn make_kernel_installer(
+    kernel_file: &Path,
+    preimages_dir: &Path,
+    injector_pk: PublicKey,
+) -> Result<String> {
     if !kernel_file.exists() {
         return Err(anyhow::anyhow!(
             "kernel file not found: {}",
@@ -144,7 +156,7 @@ fn make_kernel_installer(kernel_file: &Path, preimages_dir: &Path) -> Result<Str
         // 3. Set `jstz` injector as the `jstz_node` account
         OwnedConfigInstruction::set_instr(
             OwnedBytes(bincode::encode_to_vec(
-                PublicKey::from_base58(INJECTOR_PK)?,
+                injector_pk,
                 bincode::config::legacy(),
             )?),
             OwnedPath::from(INJECTOR),
@@ -217,17 +229,14 @@ fn generate_path_getter_code(out_dir: &Path, fn_name: &str, path_suffix: &str) -
     )
 }
 
-fn validate_builtin_bootstrap_accounts() {
+fn validate_builtin_bootstrap_accounts() -> HashMap<String, PublicKey> {
     let bytes =
         fs::read(BOOTSTRAP_ACCOUNT_PATH).expect("failed to read bootstrap account file");
     let raw_accounts: Vec<(String, String, String, u64)> = serde_json::from_slice(&bytes)
         .unwrap_or_else(|e| panic!("failed to parse built-in bootstrap accounts: {e:?}"));
-    let mut seen_names = HashSet::new();
+    let mut mapping = HashMap::new();
     for (name, pk, raw_sk, _) in raw_accounts {
-        if !seen_names.insert(name.clone()) {
-            panic!("bootstrap account name '{name}' already exists");
-        }
-        PublicKey::from_base58(&pk).unwrap_or_else(|e| {
+        let public_key = PublicKey::from_base58(&pk).unwrap_or_else(|e| {
             panic!("failed to parse public key of bootstrap account '{name}': {e:?}")
         });
         let sk = if raw_sk.starts_with("unencrypted") {
@@ -238,8 +247,17 @@ fn validate_builtin_bootstrap_accounts() {
         SecretKey::from_base58(sk).unwrap_or_else(|e| {
             panic!("failed to parse secret key of bootstrap account '{name}': {e:?}")
         });
+        if mapping.insert(name.clone(), public_key).is_some() {
+            panic!("bootstrap account name '{name}' already exists");
+        }
     }
-    if !seen_names.contains(ACTIVATOR_BOOTSTRAP_ACCOUNT_ALIAS) {
-        panic!("there must be one built-in bootstrap account with alias '{ACTIVATOR_BOOTSTRAP_ACCOUNT_ALIAS}'");
+    for required_alias in [
+        INJECTOR_BOOTSTRAP_ACCOUNT_ALIAS,
+        ACTIVATOR_BOOTSTRAP_ACCOUNT_ALIAS,
+    ] {
+        if !mapping.contains_key(ACTIVATOR_BOOTSTRAP_ACCOUNT_ALIAS) {
+            panic!("there must be one built-in bootstrap account with alias '{required_alias}'");
+        }
     }
+    mapping
 }

--- a/crates/jstzd/build_config.rs
+++ b/crates/jstzd/build_config.rs
@@ -1,5 +1,1 @@
 pub const EXCHANGER_ADDRESS: &str = "KT1F3MuqvT9Yz57TgCS3EkDcKNZe9HpiavUJ";
-
-/// jstz node's injector used (bootstrap1) to sign `RevealLargePayload` operation.
-/// make sure to update jstzd/src/config.rs if you change this.
-pub const INJECTOR_PK: &str = "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav";

--- a/crates/jstzd/resources/bootstrap_account/accounts.json
+++ b/crates/jstzd/resources/bootstrap_account/accounts.json
@@ -6,9 +6,15 @@
     1
   ],
   [
-    "bootstrap1",
+    "injector",
     "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav",
     "unencrypted:edsk3gUfUPyBSfrS9CCgmCiQsTCHGkviBDusMxDJstFtojtc1zcpsh",
+    100000000000
+  ],
+  [
+    "bootstrap1",
+    "edpkuumXzkHj1AhFmjEVLRq4z54iU2atLPUKt4fcu7ihqsEBiUT4wK",
+    "unencrypted:edsk3Admhyr2GZe5bz7LAx5KEjz6U8U56ouvdsgCuFRf2m6Wakhebz",
     100000000000
   ],
   [

--- a/crates/jstzd/src/config.rs
+++ b/crates/jstzd/src/config.rs
@@ -38,6 +38,7 @@ pub const BOOTSTRAP_CONTRACT_NAMES: [(&str, &str); 2] = [
 ];
 pub const ROLLUP_OPERATOR_ACCOUNT_ALIAS: &str = "bootstrap1";
 pub(crate) const ACTIVATOR_ACCOUNT_ALIAS: &str = "activator";
+pub(crate) const INJECTOR_ACCOUNT_ALIAS: &str = "injector";
 
 #[derive(Embed)]
 #[folder = "$CARGO_MANIFEST_DIR/resources/bootstrap_contract/"]
@@ -778,7 +779,7 @@ mod tests {
         assert_eq!(contracts.len(), 2);
 
         let accounts = read_bootstrap_accounts_from_param_file(&config_path).await;
-        assert_eq!(accounts.len(), 7);
+        assert_eq!(accounts.len(), 8);
 
         assert_eq!(
             config.octez_rollup_config().address.to_base58_check(),
@@ -823,7 +824,7 @@ mod tests {
             .unwrap();
         let params = serde_json::from_str::<serde_json::Value>(&buf).unwrap();
 
-        // two bootstrap account should have been inserted: the activator account and the rollup operator account
+        // built-in bootstrap accounts
         let accounts = params
             .as_object()
             .unwrap()
@@ -831,7 +832,7 @@ mod tests {
             .unwrap()
             .as_array()
             .unwrap();
-        assert_eq!(accounts.len(), 6);
+        assert_eq!(accounts.len(), 7);
 
         let bootstrap_accounts = accounts
             .iter()

--- a/crates/jstzd/src/task/jstzd.rs
+++ b/crates/jstzd/src/task/jstzd.rs
@@ -1,4 +1,6 @@
-use crate::config::{builtin_bootstrap_accounts, ACTIVATOR_ACCOUNT_ALIAS};
+use crate::config::{
+    builtin_bootstrap_accounts, ACTIVATOR_ACCOUNT_ALIAS, INJECTOR_ACCOUNT_ALIAS,
+};
 
 use super::{
     child_wrapper::Shared,
@@ -510,13 +512,14 @@ fn print_bootstrap_accounts<'a>(
         Cell::new("XTZ Balance (mutez)"),
     ]));
 
+    let internal_accounts = [ACTIVATOR_ACCOUNT_ALIAS, INJECTOR_ACCOUNT_ALIAS];
     let mut lines = accounts
         .into_iter()
         .filter_map(|account| {
             let amount = account.amount().to_string();
             match alias_address_mapping.get(&account.address()) {
                 Some(alias) => {
-                    if alias == ACTIVATOR_ACCOUNT_ALIAS {
+                    if internal_accounts.contains(&alias.as_str()) {
                         None
                     } else {
                         Some((format!("({alias}) {}", account.address()), amount))
@@ -743,6 +746,12 @@ mod tests {
                 &BootstrapAccount::new(
                     "edpkuSLWfVU1Vq7Jg9FucPyKmma6otcMHac9zG4oU1KMHSTBpJuGQ2",
                     3,
+                )
+                .unwrap(),
+                // Injector should not be printed out.
+                &BootstrapAccount::new(
+                    "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav",
+                    4,
                 )
                 .unwrap(),
                 &BootstrapAccount::new(

--- a/crates/jstzd/tests/jstzd_test.rs
+++ b/crates/jstzd/tests/jstzd_test.rs
@@ -31,7 +31,7 @@ use tokio::time::{sleep, timeout};
 const ACTIVATOR_PK: &str = "edpkuSLWfVU1Vq7Jg9FucPyKmma6otcMHac9zG4oU1KMHSTBpJuGQ2";
 const CONTRACT_INIT_BALANCE: f64 = 1.0;
 pub const JSTZ_ROLLUP_OPERATOR_PK: &str =
-    "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav";
+    "edpkuumXzkHj1AhFmjEVLRq4z54iU2atLPUKt4fcu7ihqsEBiUT4wK";
 pub const JSTZ_ROLLUP_OPERATOR_ALIAS: &str = "bootstrap1";
 
 #[cfg_attr(feature = "skip-rollup-tests", ignore)]


### PR DESCRIPTION
# Context

Part of JSTZ-711.
[JSTZ-711](https://linear.app/tezos/issue/JSTZ-711/replace-injector)

Injector cannot be hardcoded either.

# Description

Removed the hard-coded injector public key and instead added it to the list of built-in bootstrap accounts.

# Manually testing the PR

* Manual testing: ran jstzd locally without any issue.
