### PR TITLE
chore(jstzd): create dedicated account as rollup operator

### DIFF
--- a/crates/jstzd/build.rs
+++ b/crates/jstzd/build.rs
@@ -26,9 +26,10 @@ const JSTZ_PARAMETERS_TY_PATH: &str = "./resources/jstz_rollup/parameters_ty.jso
 /// Generated file that contains path getter functions
 const JSTZ_ROLLUP_PATH: &str = "jstz_rollup_path.rs";
 const BOOTSTRAP_ACCOUNT_PATH: &str = "./resources/bootstrap_account/accounts.json";
-// This alias is also used by jstzd during config validation.
+// These aliases are also used by jstzd during config validation.
 const ACTIVATOR_BOOTSTRAP_ACCOUNT_ALIAS: &str = "activator";
 const INJECTOR_BOOTSTRAP_ACCOUNT_ALIAS: &str = "injector";
+const ROLLUP_OPERATOR_BOOTSTRAP_ACCOUNT_ALIAS: &str = "rollup_operator";
 
 /// Build script that validates built-in bootstrap accounts and generates and saves
 /// the following files in OUT_DIR:
@@ -254,6 +255,7 @@ fn validate_builtin_bootstrap_accounts() -> HashMap<String, PublicKey> {
     for required_alias in [
         INJECTOR_BOOTSTRAP_ACCOUNT_ALIAS,
         ACTIVATOR_BOOTSTRAP_ACCOUNT_ALIAS,
+        ROLLUP_OPERATOR_BOOTSTRAP_ACCOUNT_ALIAS,
     ] {
         if !mapping.contains_key(ACTIVATOR_BOOTSTRAP_ACCOUNT_ALIAS) {
             panic!("there must be one built-in bootstrap account with alias '{required_alias}'");

--- a/crates/jstzd/resources/bootstrap_account/accounts.json
+++ b/crates/jstzd/resources/bootstrap_account/accounts.json
@@ -12,6 +12,12 @@
     100000000000
   ],
   [
+    "rollup_operator",
+    "edpktoeTraS2WW9iaceu8hvHJ1sUJFSKavtzrMcp4jwMoJWWBts8AK",
+    "unencrypted:edsk3D6aGWpSiMMiEfNZ7Jyi52S9AtjvLCutqnCi3qev65WShKLKW4",
+    100000000000
+  ],
+  [
     "bootstrap1",
     "edpkuumXzkHj1AhFmjEVLRq4z54iU2atLPUKt4fcu7ihqsEBiUT4wK",
     "unencrypted:edsk3Admhyr2GZe5bz7LAx5KEjz6U8U56ouvdsgCuFRf2m6Wakhebz",

--- a/crates/jstzd/src/config.rs
+++ b/crates/jstzd/src/config.rs
@@ -38,7 +38,7 @@ pub const BOOTSTRAP_CONTRACT_NAMES: [(&str, &str); 2] = [
     ("exchanger", EXCHANGER_ADDRESS),
     ("jstz_native_bridge", JSTZ_NATIVE_BRIDGE_ADDRESS),
 ];
-pub const ROLLUP_OPERATOR_ACCOUNT_ALIAS: &str = "bootstrap1";
+pub(crate) const ROLLUP_OPERATOR_ACCOUNT_ALIAS: &str = "rollup_operator";
 pub(crate) const ACTIVATOR_ACCOUNT_ALIAS: &str = "activator";
 pub(crate) const INJECTOR_ACCOUNT_ALIAS: &str = "injector";
 
@@ -804,7 +804,7 @@ mod tests {
         assert_eq!(contracts.len(), 2);
 
         let accounts = read_bootstrap_accounts_from_param_file(&config_path).await;
-        assert_eq!(accounts.len(), 8);
+        assert_eq!(accounts.len(), 9);
 
         assert_eq!(
             config.octez_rollup_config().address.to_base58_check(),
@@ -857,7 +857,7 @@ mod tests {
             .unwrap()
             .as_array()
             .unwrap();
-        assert_eq!(accounts.len(), 7);
+        assert_eq!(accounts.len(), 8);
 
         let bootstrap_accounts = accounts
             .iter()

--- a/crates/jstzd/src/task/jstzd.rs
+++ b/crates/jstzd/src/task/jstzd.rs
@@ -1,5 +1,6 @@
 use crate::config::{
     builtin_bootstrap_accounts, ACTIVATOR_ACCOUNT_ALIAS, INJECTOR_ACCOUNT_ALIAS,
+    ROLLUP_OPERATOR_ACCOUNT_ALIAS,
 };
 
 use super::{
@@ -512,7 +513,11 @@ fn print_bootstrap_accounts<'a>(
         Cell::new("XTZ Balance (mutez)"),
     ]));
 
-    let internal_accounts = [ACTIVATOR_ACCOUNT_ALIAS, INJECTOR_ACCOUNT_ALIAS];
+    let internal_accounts = [
+        ACTIVATOR_ACCOUNT_ALIAS,
+        INJECTOR_ACCOUNT_ALIAS,
+        ROLLUP_OPERATOR_ACCOUNT_ALIAS,
+    ];
     let mut lines = accounts
         .into_iter()
         .filter_map(|account| {
@@ -752,6 +757,12 @@ mod tests {
                 &BootstrapAccount::new(
                     "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav",
                     4,
+                )
+                .unwrap(),
+                // Rollup operator should not be printed out.
+                &BootstrapAccount::new(
+                    "edpktoeTraS2WW9iaceu8hvHJ1sUJFSKavtzrMcp4jwMoJWWBts8AK",
+                    5,
                 )
                 .unwrap(),
                 &BootstrapAccount::new(

--- a/crates/jstzd/tests/jstzd_test.rs
+++ b/crates/jstzd/tests/jstzd_test.rs
@@ -31,8 +31,8 @@ use tokio::time::{sleep, timeout};
 const ACTIVATOR_PK: &str = "edpkuSLWfVU1Vq7Jg9FucPyKmma6otcMHac9zG4oU1KMHSTBpJuGQ2";
 const CONTRACT_INIT_BALANCE: f64 = 1.0;
 pub const JSTZ_ROLLUP_OPERATOR_PK: &str =
-    "edpkuumXzkHj1AhFmjEVLRq4z54iU2atLPUKt4fcu7ihqsEBiUT4wK";
-pub const JSTZ_ROLLUP_OPERATOR_ALIAS: &str = "bootstrap1";
+    "edpktoeTraS2WW9iaceu8hvHJ1sUJFSKavtzrMcp4jwMoJWWBts8AK";
+pub const JSTZ_ROLLUP_OPERATOR_ALIAS: &str = "rollup_operator";
 
 #[cfg_attr(feature = "skip-rollup-tests", ignore)]
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
# Context

Completes JSTZ-713.
[JSTZ-713](https://linear.app/tezos/issue/JSTZ-713/set-rollup-operator)

It is actually fine to use bootstrap1 as the operator, but since we might not always have bootstrap1 in the list of built-in bootstrap accounts, it's better to set up a dedicated account as the rollup operator.

# Description

Added one required bootstrap account `rollup_operator` to the list of built-in bootstrap accounts. This account will be the rollup operator and will not be exposed to users. This account being missing in the bootstrap account list will lead to a build error.

# Manually testing the PR

Ran the integration test `jstzd_test` locally and it worked.
