### PR TITLE
feat(kernel): activate experimental in memory host and preset ticketer & injector in riscv kernel 

### DIFF
--- a/crates/jstz_kernel/Cargo.toml
+++ b/crates/jstz_kernel/Cargo.toml
@@ -43,4 +43,4 @@ tokio.workspace = true
 
 [features]
 v2_runtime = ["jstz_proto/v2_runtime", "jstz_proto/kernel"]
-riscv_kernel = ["v2_runtime", "dep:tokio"]
+riscv_kernel = ["v2_runtime", "dep:tokio", "tezos-smart-rollup/experimental-host-in-memory-store"]

--- a/crates/jstz_kernel/build.rs
+++ b/crates/jstz_kernel/build.rs
@@ -1,0 +1,11 @@
+use std::env;
+
+fn main() {
+    let ticketer_pk = env::var("TICKETER")
+        .unwrap_or("KT1F3MuqvT9Yz57TgCS3EkDcKNZe9HpiavUJ".to_string());
+    let injector_pk = env::var("INJECTOR")
+        .unwrap_or("edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav".to_string());
+
+    println!("cargo:rustc-env=TICKETER={}", ticketer_pk);
+    println!("cargo:rustc-env=INJECTOR={}", injector_pk);
+}

--- a/crates/jstz_kernel/src/riscv_kernel.rs
+++ b/crates/jstz_kernel/src/riscv_kernel.rs
@@ -1,6 +1,12 @@
 use std::sync::Arc;
 
-use jstz_core::{host::JsHostRuntime, kv::Transaction};
+use jstz_core::{
+    host::JsHostRuntime,
+    kv::{Storage, Transaction},
+};
+use jstz_crypto::{
+    hash::Hash, public_key::PublicKey, smart_function_hash::SmartFunctionHash,
+};
 use jstz_proto::runtime::{ProtocolContext, PROTOCOL_CONTEXT};
 use tezos_crypto_rs::hash::ContractKt1Hash;
 use tezos_smart_rollup::prelude::{debug_msg, Runtime};
@@ -8,8 +14,11 @@ use tezos_smart_rollup::prelude::{debug_msg, Runtime};
 use crate::{
     handle_message,
     inbox::{self, LevelInfo, ParsedInboxMessage},
-    read_injector, read_ticketer,
+    read_injector, read_ticketer, INJECTOR, TICKETER,
 };
+
+const TICKETER_PK: &str = std::env!("TICKETER");
+const INJECTOR_PKH: &str = std::env!("INJECTOR");
 
 /// Runs the event loop within LocalSet which maintains a task FIFO queue. This is
 /// desirable because there is an expectation within blockchains to process operations
@@ -19,6 +28,13 @@ use crate::{
 /// Additionally, LocalSet supports support `!Send` futures which is currently required
 /// by [`JsHostRuntime`]
 pub fn run(rt: &mut impl Runtime) {
+    // Set up ticketer and injector
+    let ticketer = SmartFunctionHash::from_base58(TICKETER_PK).unwrap();
+    Storage::insert(rt, &TICKETER, &ticketer).unwrap();
+
+    let injector = PublicKey::from_base58(INJECTOR_PKH).unwrap();
+    Storage::insert(rt, &INJECTOR, &injector).unwrap();
+
     let tokio_runtime = match tokio::runtime::Builder::new_current_thread().build() {
         Ok(runtime) => runtime,
         Err(e) => {


### PR DESCRIPTION
# Context
<!-- Why is this change required? What problem does it solve? -->
- In memory host required because RISCV doesn't support persistent storage
- Presets required because there is no installer equivalent
<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
`make`

Run in mem increased RISCV sandbox  
```
make riscv-pvm-kernel 
git clone git@github.com:jstz-dev/riscv-pvm.git
cd riscv-pvm
nix develop
cd src/riscv
cargo run --release  run -i <path to jstz>/target/riscv64gc-unknown-linux-musl/release/kernel-executable
```
<!-- Describe how reviewers and approvers can test this PR. -->
