### PR TITLE
chore(release): bump version to 0.1.1-alpha.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2821,7 +2821,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_api"
-version = "0.1.1-alpha.1"
+version = "0.1.1-alpha.2"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2850,7 +2850,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_cli"
-version = "0.1.1-alpha.1"
+version = "0.1.1-alpha.2"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_client"
-version = "0.1.1-alpha.1"
+version = "0.1.1-alpha.2"
 dependencies = [
  "anyhow",
  "jstz_crypto",
@@ -2931,7 +2931,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_core"
-version = "0.1.1-alpha.1"
+version = "0.1.1-alpha.2"
 dependencies = [
  "anyhow",
  "bincode 2.0.0-rc.3",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_crypto"
-version = "0.1.1-alpha.1"
+version = "0.1.1-alpha.2"
 dependencies = [
  "anyhow",
  "bincode 2.0.0-rc.3",
@@ -2979,7 +2979,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_kernel"
-version = "0.1.1-alpha.1"
+version = "0.1.1-alpha.2"
 dependencies = [
  "anyhow",
  "bincode 2.0.0-rc.3",
@@ -3003,7 +3003,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_mock"
-version = "0.1.1-alpha.1"
+version = "0.1.1-alpha.2"
 dependencies = [
  "derive_more",
  "jstz_core",
@@ -3016,7 +3016,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_node"
-version = "0.1.1-alpha.1"
+version = "0.1.1-alpha.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3070,7 +3070,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_oracle_node"
-version = "0.1.1-alpha.1"
+version = "0.1.1-alpha.2"
 dependencies = [
  "anyhow",
  "bincode 2.0.0-rc.3",
@@ -3103,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_proto"
-version = "0.1.1-alpha.1"
+version = "0.1.1-alpha.2"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "boa_engine",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_rollup"
-version = "0.1.1-alpha.1"
+version = "0.1.1-alpha.2"
 dependencies = [
  "anyhow",
  "bincode 2.0.0-rc.3",
@@ -3163,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_runtime"
-version = "0.1.1-alpha.1"
+version = "0.1.1-alpha.2"
 dependencies = [
  "anyhow",
  "bincode 2.0.0-rc.3",
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_sdk"
-version = "0.1.1-alpha.1"
+version = "0.1.1-alpha.2"
 dependencies = [
  "jstz_crypto",
  "jstz_proto",
@@ -3205,7 +3205,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_tps_bench"
-version = "0.1.1-alpha.1"
+version = "0.1.1-alpha.2"
 dependencies = [
  "base64 0.21.7",
  "bincode 2.0.0-rc.3",
@@ -3229,7 +3229,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_utils"
-version = "0.1.1-alpha.1"
+version = "0.1.1-alpha.2"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_wpt"
-version = "0.1.1-alpha.1"
+version = "0.1.1-alpha.2"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "jstzd"
-version = "0.1.1-alpha.1"
+version = "0.1.1-alpha.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3735,7 +3735,7 @@ dependencies = [
 
 [[package]]
 name = "octez"
-version = "0.1.1-alpha.1"
+version = "0.1.1-alpha.2"
 dependencies = [
  "anyhow",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.1.1-alpha.1"
+version = "0.1.1-alpha.2"
 authors = ["TriliTech <contact@trili.tech>"]
 repository = "https://github.com/jstz-dev/jstz"
 homepage = "https://github.com/jstz-dev/jstz"

--- a/crates/jstz_cli/src/sandbox/mod.rs
+++ b/crates/jstz_cli/src/sandbox/mod.rs
@@ -10,7 +10,7 @@ pub use consts::*;
 use container::*;
 
 const SANDBOX_CONTAINER_NAME: &str = "jstz-sandbox";
-const SANDBOX_IMAGE: &str = "ghcr.io/jstz-dev/jstz/jstzd:0.1.1-alpha.1";
+const SANDBOX_IMAGE: &str = "ghcr.io/jstz-dev/jstz/jstzd:0.1.1-alpha.2";
 
 pub async fn assert_sandbox_running(sandbox_base_url: &str) -> Result<()> {
     match jstzd::is_jstzd_running(sandbox_base_url).await {

--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -627,6 +627,28 @@
               }
             ],
             "title": "RevealLargePayload"
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OracleResponse"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "_type"
+                ],
+                "properties": {
+                  "_type": {
+                    "type": "string",
+                    "enum": [
+                      "OracleResponse"
+                    ]
+                  }
+                }
+              }
+            ],
+            "title": "OracleResponse"
           }
         ],
         "discriminator": {
@@ -807,6 +829,37 @@
           }
         }
       },
+      "OracleResponse": {
+        "type": "object",
+        "description": "Response to an OracleRequest sent by the enshrined Oracle node",
+        "required": [
+          "requestId",
+          "response"
+        ],
+        "properties": {
+          "requestId": {
+            "type": "string",
+            "description": "The request id of the OracleRequest that is being responded to"
+          },
+          "response": {
+            "type": "string",
+            "description": "The response to the OracleRequest"
+          }
+        }
+      },
+      "OracleResponseReceipt": {
+        "type": "object",
+        "required": [
+          "requestId"
+        ],
+        "properties": {
+          "requestId": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          }
+        }
+      },
       "ParsedCode": {
         "type": "string",
         "format": "javascript",
@@ -978,6 +1031,28 @@
               }
             ],
             "title": "FaWithdraw"
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OracleResponseReceipt"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "_type"
+                ],
+                "properties": {
+                  "_type": {
+                    "type": "string",
+                    "enum": [
+                      "OracleResponse"
+                    ]
+                  }
+                }
+              }
+            ],
+            "title": "OracleResponse"
           }
         ],
         "discriminator": {

--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -11,7 +11,7 @@
       "name": "MIT",
       "url": "https://github.com/jstz-dev/jstz/blob/main/LICENSE"
     },
-    "version": "0.1.1-alpha.1"
+    "version": "0.1.1-alpha.2"
   },
   "paths": {
     "/accounts/{address}": {
@@ -627,28 +627,6 @@
               }
             ],
             "title": "RevealLargePayload"
-          },
-          {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OracleResponse"
-              },
-              {
-                "type": "object",
-                "required": [
-                  "_type"
-                ],
-                "properties": {
-                  "_type": {
-                    "type": "string",
-                    "enum": [
-                      "OracleResponse"
-                    ]
-                  }
-                }
-              }
-            ],
-            "title": "OracleResponse"
           }
         ],
         "discriminator": {
@@ -829,37 +807,6 @@
           }
         }
       },
-      "OracleResponse": {
-        "type": "object",
-        "description": "Response to an OracleRequest sent by the enshrined Oracle node",
-        "required": [
-          "requestId",
-          "response"
-        ],
-        "properties": {
-          "requestId": {
-            "type": "string",
-            "description": "The request id of the OracleRequest that is being responded to"
-          },
-          "response": {
-            "type": "string",
-            "description": "The response to the OracleRequest"
-          }
-        }
-      },
-      "OracleResponseReceipt": {
-        "type": "object",
-        "required": [
-          "requestId"
-        ],
-        "properties": {
-          "requestId": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0
-          }
-        }
-      },
       "ParsedCode": {
         "type": "string",
         "format": "javascript",
@@ -1031,28 +978,6 @@
               }
             ],
             "title": "FaWithdraw"
-          },
-          {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OracleResponseReceipt"
-              },
-              {
-                "type": "object",
-                "required": [
-                  "_type"
-                ],
-                "properties": {
-                  "_type": {
-                    "type": "string",
-                    "enum": [
-                      "OracleResponse"
-                    ]
-                  }
-                }
-              }
-            ],
-            "title": "OracleResponse"
           }
         ],
         "discriminator": {

--- a/crates/jstz_node/openapi_v1.json
+++ b/crates/jstz_node/openapi_v1.json
@@ -11,7 +11,7 @@
       "name": "MIT",
       "url": "https://github.com/jstz-dev/jstz/blob/main/LICENSE"
     },
-    "version": "0.1.1-alpha.1"
+    "version": "0.1.1-alpha.2"
   },
   "paths": {
     "/accounts/{address}": {

--- a/packages/cli/main/package.json
+++ b/packages/cli/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jstz-dev/cli",
-  "version": "0.1.1-alpha.1",
+  "version": "0.1.1-alpha.2",
   "dependencies": {},
   "scripts": {
     "postinstall": "node install.js"


### PR DESCRIPTION
# Context
Bump version to 0.1.1-alpha.2 for the next release

# Description
* Bump version in workspace `Cargo.toml`
* Bump version in `packages/cli/main/package.json`
* Bump version of `SANDBOX_IMAGE` in `crates/jstz_cli/src/sandbox/mod.rs`
* Regenerate openapi schema - 
 ```
cargo run --bin jstz-node --features v2_runtime -- spec -o crates/jstz_node/openapi.json
cargo run --bin jstz-node -- spec -o crates/jstz_node/openapi_v1.json
   ```
* Synched `Cargo.lock` with compatible dependency versions

