### PR TITLE
feat(oracle): use global level to calculate ttl

### DIFF
--- a/crates/jstz_proto/src/runtime/v2/fetch/fetch_handler.rs
+++ b/crates/jstz_proto/src/runtime/v2/fetch/fetch_handler.rs
@@ -255,11 +255,11 @@ fn dispatch_oracle(
         .boxed_local());
     }
     let response_rx = {
-        let ctx = PROTOCOL_CONTEXT
+        let oracle_ctx = PROTOCOL_CONTEXT
             .get()
-            .expect("Protocol context should be initialized");
-        let mut ctx_lock = ctx.lock();
-        let oracle = ctx_lock.oracle();
+            .expect("Protocol context should be initialized")
+            .oracle();
+        let mut oracle = oracle_ctx.lock();
         oracle.send_request(
             host,
             tx,
@@ -2105,7 +2105,7 @@ mod test {
             tx.commit(&mut host).unwrap();
 
             let run_address = hashes[0].clone();
-            ProtocolContext::init_global(&mut host).unwrap();
+            ProtocolContext::init_global(&mut host, 0).unwrap();
             tokio::pin! {
                 let response_fut = process_and_dispatch_request(
                     JsHostRuntime::new(&mut host),
@@ -2147,8 +2147,8 @@ mod test {
                         Url::parse("http://example.com").unwrap()
                     );
                     assert_eq!(oracle_request.caller, source_address);
-                    let mut locked = PROTOCOL_CONTEXT.get().unwrap().lock();
-                    let oracle = locked.oracle();
+                    let oracle_ctx = PROTOCOL_CONTEXT.get().unwrap().oracle();
+                    let mut oracle = oracle_ctx.lock();
 
                     oracle
                         .respond(&mut host, oracle_request.id, response.clone())

--- a/crates/jstz_proto/src/runtime/v2/protocol_context.rs
+++ b/crates/jstz_proto/src/runtime/v2/protocol_context.rs
@@ -20,8 +20,15 @@ impl ProtocolContext {
         self.oracle.clone()
     }
 
-    pub fn current_level(&self) -> &Arc<Mutex<BlockLevel>> {
-        &self.current_level
+    pub fn current_level(&self) -> BlockLevel {
+        let level = self.current_level.lock();
+        *level
+    }
+
+    #[cfg(test)]
+    pub fn set_level(&self, new_level: BlockLevel) {
+        let mut level = self.current_level.lock();
+        *level = new_level
     }
 
     /// Initialize the global protocol context

--- a/crates/jstz_proto/src/runtime/v2/protocol_context.rs
+++ b/crates/jstz_proto/src/runtime/v2/protocol_context.rs
@@ -3,24 +3,38 @@ use std::sync::{Arc, OnceLock};
 use jstz_core::host::HostRuntime;
 use parking_lot::Mutex;
 
+use crate::BlockLevel;
+
 use super::oracle::{Oracle, OracleError};
 
 /// Holds stateful globals required by the protocol
-pub static PROTOCOL_CONTEXT: OnceLock<Arc<Mutex<ProtocolContext>>> = OnceLock::new();
+pub static PROTOCOL_CONTEXT: OnceLock<ProtocolContext> = OnceLock::new();
 
 pub struct ProtocolContext {
-    oracle: Oracle,
+    oracle: Arc<Mutex<Oracle>>,
+    current_level: Arc<Mutex<BlockLevel>>,
 }
 
 impl ProtocolContext {
-    pub fn oracle(&mut self) -> &mut Oracle {
-        &mut self.oracle
+    pub fn oracle(&self) -> Arc<Mutex<Oracle>> {
+        self.oracle.clone()
+    }
+
+    pub fn current_level(&self) -> &Arc<Mutex<BlockLevel>> {
+        &self.current_level
     }
 
     /// Initialize the global protocol context
-    pub fn init_global(rt: &mut impl HostRuntime) -> Result<(), ProtocolContextError> {
+    pub fn init_global(
+        rt: &mut impl HostRuntime,
+        current_level: BlockLevel,
+    ) -> Result<(), ProtocolContextError> {
+        let current_level = Arc::new(Mutex::new(current_level));
         let oracle = Oracle::new(rt, None)?;
-        PROTOCOL_CONTEXT.get_or_init(|| Arc::new(Mutex::new(ProtocolContext { oracle })));
+        PROTOCOL_CONTEXT.get_or_init(|| ProtocolContext {
+            oracle: Arc::new(Mutex::new(oracle)),
+            current_level,
+        });
         Ok(())
     }
 }


### PR DESCRIPTION
# Context
We need to gc requests when they reach TTL based on the current block level
<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->
Part of https://linear.app/tezos/issue/JSTZ-541/handle-oracleresponse-operation-in-kernel 

# Description
* Adds read only current level to the global protocol context with mutator exposed for testing. The write mechanism will be implemented in next PR
* Update protocol context to expose Arc<Mutex<>> over each field rather than on the entire struct
* Set default TTL to 80 levels and calculate the timeout in send request. The block time in jstzd is 1s allowing 80 seconds to respond.
* Update gc to run compare against the global current level

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
`cargo nextest run -p jstz_proto oracle  --features v2_runtime`
<!-- Describe how reviewers and approvers can test this PR. -->
