### PR TITLE
fix(image): change workdir in dockerfile

### DIFF
--- a/crates/jstz_cli/Dockerfile
+++ b/crates/jstz_cli/Dockerfile
@@ -4,7 +4,7 @@ FROM tezos/tezos:${OCTEZ_TAG} AS octez
 FROM rust:1.73.0-alpine AS builder
 RUN apk --no-cache add musl-dev libcrypto3 openssl-dev clang
 ENV OPENSSL_DIR=/usr
-WORKDIR /
+WORKDIR /jstz_build
 COPY . .
 ARG KERNEL_PATH
 COPY $KERNEL_PATH crates/jstz_cli/jstz_kernel.wasm
@@ -20,9 +20,9 @@ COPY --from=octez /usr/local/bin/octez-node /usr/bin/octez-node
 COPY --from=octez /usr/local/bin/octez-client /usr/bin/octez-client
 COPY --from=octez /usr/share/zcash-params /root/.zcash-params
 # Copy the jstz binary & dependencies
-COPY --from=builder /target/debug/jstz /usr/bin/jstz
-COPY --from=builder /crates/jstz_cli/jstz_kernel.wasm /usr/share/jstz/jstz_kernel.wasm
-COPY --from=builder /crates/jstz_cli/sandbox.json /usr/share/jstz/sandbox.json
+COPY --from=builder /jstz_build/target/debug/jstz /usr/bin/jstz
+COPY --from=builder /jstz_build/crates/jstz_cli/jstz_kernel.wasm /usr/share/jstz/jstz_kernel.wasm
+COPY --from=builder /jstz_build/crates/jstz_cli/sandbox.json /usr/share/jstz/sandbox.json
 # octez is the source of truth for the sandbox-params.json
 COPY --from=octez /usr/local/share/tezos/alpha-parameters/sandbox-parameters.json /usr/share/jstz/sandbox-params.json
 ENTRYPOINT [ "/usr/bin/jstz" ]

--- a/crates/jstz_node/Dockerfile
+++ b/crates/jstz_node/Dockerfile
@@ -1,5 +1,5 @@
 FROM rust:1.73.0 AS builder
-WORKDIR /
+WORKDIR /jstz_build
 COPY . .
 RUN cargo build --package jstz_node --release
 
@@ -7,5 +7,5 @@ FROM debian:bookworm-slim AS node
 RUN apt-get update && apt-get install -y openssl sqlite3
 ENV RUST_BACKTRACE=1
 ENV RUST_LOG=debug
-COPY --from=builder /target/release/jstz-node /usr/bin/jstz-node
+COPY --from=builder /jstz_build/target/release/jstz-node /usr/bin/jstz-node
 ENTRYPOINT [ "/usr/bin/jstz-node" ]

--- a/crates/jstz_rollup/Dockerfile
+++ b/crates/jstz_rollup/Dockerfile
@@ -6,7 +6,7 @@ FROM rust:1.73.0-alpine AS builder
 RUN apk --no-cache add musl-dev libcrypto3 openssl-dev clang
 ENV OPENSSL_DIR=/usr
 # Copy srcs
-WORKDIR /
+WORKDIR /jstz_build
 COPY . .
 # Build jstz-rollup
 # RUSTFLAGS is needed to avoid linking to the static version of the C runtime (provided by musl)
@@ -22,7 +22,7 @@ ENV RUST_BACKTRACE=1
 ENV RUST_LOG=debug
 COPY --from=octez /usr/local/bin/octez-smart-rollup-node /usr/bin/octez-smart-rollup-node
 COPY --from=octez /usr/local/bin/octez-client /usr/bin/octez-client
-COPY --from=builder /target/release/jstz-rollup /usr/bin/jstz-rollup
+COPY --from=builder /jstz_build/target/release/jstz-rollup /usr/bin/jstz-rollup
 ARG KERNEL_PATH
 COPY $KERNEL_PATH /root/jstz_kernel.wasm
 COPY ./crates/jstz_rollup/entrypoint.sh ./entrypoint.sh

--- a/crates/jstzd/Dockerfile
+++ b/crates/jstzd/Dockerfile
@@ -3,7 +3,7 @@ ARG FEATURES="build-image,v2_runtime"
 FROM rust:1.82.0-slim-bookworm AS builder
 RUN apt update && apt install -y curl pkg-config libssl-dev libsqlite3-dev
 
-WORKDIR /
+WORKDIR /jstz_build
 ADD . .
 ARG KERNEL_PATH
 # set default path to a non-existent path such that docker ignores the copy when the path is not given
@@ -29,7 +29,7 @@ RUN apt update && apt install -y curl gpg && \
         cd /usr/bin && rm octez-admin-client octez-dal-node octez-accuser-* octez-signer octez-codec
 
 # Copy the jstzd binary & dependencies
-COPY --from=builder /target/release/jstzd /usr/bin/jstzd
+COPY --from=builder /jstz_build/target/release/jstzd /usr/bin/jstzd
 COPY --from=builder /jstzd_kernel_files /usr/share/jstzd
 
 ENTRYPOINT [ "/usr/bin/jstzd" ]


### PR DESCRIPTION
# Context

[Image build](https://github.com/jstz-dev/jstz/actions/runs/15973401341) failed mysteriously.

# Description

Changed `WORKDIR` from `/` to `/jstz_build`. It seems that somehow the changes in dependencies introduced in #1153 do not work well with that root `WORKDIR`. Perhaps something got overwritten in the failed build and therefore led to the error.

# Manually testing the PR

[Test build](https://github.com/jstz-dev/jstz/actions/runs/15977019715)
