### PR TITLE
fix(wasm-kernel): move mark for reboot back into read message

### DIFF
--- a/crates/jstz_kernel/src/inbox.rs
+++ b/crates/jstz_kernel/src/inbox.rs
@@ -43,6 +43,7 @@ pub fn read_message(
     ticketer: &ContractKt1Hash,
 ) -> Option<Message> {
     let input = rt.read_input().ok()??;
+    let _ = rt.mark_for_reboot();
     let jstz_rollup_address = rt.reveal_metadata().address();
     match parse_inbox_message(
         rt,

--- a/crates/jstz_kernel/src/wasm_kernel.rs
+++ b/crates/jstz_kernel/src/wasm_kernel.rs
@@ -11,7 +11,6 @@ pub fn run(rt: &mut impl Runtime) {
         let injector = crate::read_injector(rt);
         let mut tx = Transaction::default();
         tx.begin();
-        let _ = rt.mark_for_reboot();
         if let Some(message) = read_message(rt, &ticketer) {
             handle_message(rt, message, &ticketer, &mut tx, &injector)
                 .await


### PR DESCRIPTION
# Context
Kernel was stalled because mark for reboot was set too early. It was preventing the kernel to progress to the next level (My guess is that it was stuck in the install phase).

I've tested without mark for reboot and it looked like everything worked just fine but I've kept it in case there are hidden issues down the line.
<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
Move mark for reboot back into `read_message`
<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
`make build-jstzd-kernel && cargo run --bin jstzd run ~/jstzd-config.json`
`cargo run --bin jstz bridge deposit --from bootstrap1 --to ryan --amount 1000 -n dev`
`cargo run -- deploy examples/get-tez/dist/index.js  -n dev`
`cargo run -- run jstz://KT1SXBizWUHDEYTpcRqfethonWSdESy1M9nD/ --data '{"message":"please give me tez"}'  -n dev`
<!-- Describe how reviewers and approvers can test this PR. -->
