### PR TITLE
fix: fix error message 'unsupported scheme'

### DIFF
--- a/crates/jstz_cli/src/run.rs
+++ b/crates/jstz_cli/src/run.rs
@@ -305,7 +305,7 @@ fn validate_scheme(url: &Uri) -> Result<()> {
     match url.scheme_str() {
         Some("jstz") => Ok(()),
         Some(invalid_scheme) => bail!(format!(
-            "Unsupport scheme '{invalid_scheme}'. {supported_scheme_msg}"
+            "Unsupported scheme '{invalid_scheme}'. {supported_scheme_msg}"
         )),
         None => bail!(format!("Missing scheme. {supported_scheme_msg}")),
     }

--- a/crates/jstz_proto/src/executor/mod.rs
+++ b/crates/jstz_proto/src/executor/mod.rs
@@ -365,7 +365,7 @@ mod tests {
                 assert_eq!(r.status_code, 500);
                 assert_eq!(
                     String::from_utf8(r.body.unwrap()).unwrap(),
-                    "{\"class\":\"TypeError\",\"message\":\"Unsupport scheme 'tezos'\"}"
+                    "{\"class\":\"TypeError\",\"message\":\"Unsupported scheme 'tezos'\"}"
                 );
             } else {
                 unreachable!()

--- a/crates/jstz_proto/src/runtime/v2/fetch/error.rs
+++ b/crates/jstz_proto/src/runtime/v2/fetch/error.rs
@@ -17,7 +17,7 @@ pub enum FetchError {
     #[error("Invalid Header type")]
     InvalidHeaderType,
     #[class(type)]
-    #[error("Unsupport scheme '{0}'")]
+    #[error("Unsupported scheme '{0}'")]
     UnsupportedScheme(String),
     #[class(uri)]
     #[error(transparent)]

--- a/crates/jstz_proto/src/runtime/v2/fetch/fetch_handler.rs
+++ b/crates/jstz_proto/src/runtime/v2/fetch/fetch_handler.rs
@@ -858,7 +858,7 @@ mod test {
         assert_eq!(response.status, 500);
         assert_eq!(response.status_text, "InternalServerError");
         assert_eq!(
-            json!({"class":"TypeError","message":"Unsupport scheme 'tezos'"}),
+            json!({"class":"TypeError","message":"Unsupported scheme 'tezos'"}),
             serde_json::from_slice::<JsonValue>(response.body.to_vec().as_slice())
                 .unwrap()
         );


### PR DESCRIPTION
# Context

The error message `Unsupport scheme 'tezos'` is grammatically incorrect.

# Description

Changed the error message to `Unsupported scheme`. The error enum value is correct, but the message needs to be updated.

# Manually testing the PR

All existing tests should still work.
