### PR TITLE
fix(docs): add info about the Axios example to docs

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -36,10 +36,9 @@ Because it keeps track of the messages it receives and the accounts that it has 
 The [`zod`](https://github.com/jstz-dev/jstz/tree/main/examples/zod) example shows how you can use third-party JavaScript libraries in Jstz smart functions.
 It uses [itty-router](https://github.com/kwhitley/itty-router) to route requests and [zod](https://github.com/colinhacks/zod) to validate user input.
 
-### Oracle
+### HTTP libraries and external APIs
 
-The [`oracle_basic`](https://github.com/jstz-dev/jstz/blob/main/examples/oracle_basic.js) example shows how to call an external API via the Jstz enshrined oracle and the JavaScript fetch API.
-This is the primary way that smart functions get information from outside Jstz because they cannot call external APIs directly.
+The [`Axios`](https://github.com/jstz-dev/jstz/tree/main/examples/axios) example shows how you can use the Axios HTTP request library both to call smart functions and to call external APIs via the Jstz [enshrined oracle](https://jstz.tezos.com/architecture/oracle).
 
 ### FA2 token
 

--- a/examples/axios/README.md
+++ b/examples/axios/README.md
@@ -4,9 +4,9 @@ This smart function shows how smart functions can use Axios as an HTTP client fo
 
 It includes two smart functions:
 
-- `echo.js`: A simple smart function that accepts a text string via a POST request and returns it, to simulate a simple asynchronous smart function
+- `echo.js`: A simple smart function that accepts a text string via a POST request and returns it, to simulate a simple smart function call
 
-- `index.ts`: A smart function that makes two calls with Axios: a call to the `echo.js` smart function and a call to the external API `http://httpbin.org/uuid` via the enshrined oracle
+- `index.ts`: A smart function that makes two calls with Axios: a call to the `echo.js` smart function and a call to the external API `http://httpbin.org/uuid` asynchronously via the enshrined oracle
 
 Follow these steps to deploy and use these smart functions:
 
@@ -18,7 +18,7 @@ Follow these steps to deploy and use these smart functions:
 
 2. From the folder with this README.md file, run `npm i` and `npm run build` to build the smart functions.
 
-3. Deploy the smart function to the sandbox by running `npm run deploy`. This script deploys both smart functions and prints their addresses and assigns the local alias `axios.example` to the `index.ts` smart function.
+3. Deploy the smart function to the sandbox by running `npm run deploy`. This script deploys both smart functions, prints their addresses and assigns the local alias `axios.example` to the `index.ts` smart function.
 
 4. Call the `index.ts` smart function with the Jstz CLI by running this command, replacing the placeholder `<ECHO_ADDRESS>` with the address of the echo smart function:
 

--- a/examples/axios/README.md
+++ b/examples/axios/README.md
@@ -1,27 +1,42 @@
 # Axios HTTP client
 
-This smart function shows how one can use Axios as an HTTP client for querying both http endpoints and jstz smart functions
+This smart function shows how smart functions can use Axios as an HTTP client for querying both HTTP endpoints and Jstz smart functions.
 
-Follow these steps to use it
+It includes two smart functions:
 
-1.  Set up the Jstz local sandbox
+- `echo.js`: A simple smart function that accepts a text string via a POST request and returns it, to simulate a simple asynchronous smart function
 
-    1. [Install Jstz](https://jstz.tezos.com/installation)
-    1. Start the [sandbox](https://jstz.tezos.com/sandbox)
-    1. Create a Jstz [account](https://jstz.tezos.com/architecture/accounts)
+- `index.ts`: A smart function that makes two calls with Axios: a call to the `echo.js` smart function and a call to the external API `http://httpbin.org/uuid` via the enshrined oracle
 
-2.  From the folder with this README.md file, run `npm i` and `npm run build` to build the smart function
+Follow these steps to deploy and use these smart functions:
 
-3.  Deploy the smart function to the sandbox by running `npm run deploy`. This will deploy 2 smart functions;
+1. Set up the Jstz local sandbox:
 
-    - `echo.js` accepts a post request and simply returns request's body in the response.
+   1. [Install Jstz](https://jstz.tezos.com/installation).
+   1. Start the [sandbox](https://jstz.tezos.com/sandbox).
+   1. Create a Jstz [account](https://jstz.tezos.com/architecture/accounts).
 
-    - `index.ts` makes a request to `jstz://<echo sf adddress>` and `http://httpbin.org/uuid` using the axios client. The bodies are logged and the smart function simply returns `OK!`
+2. From the folder with this README.md file, run `npm i` and `npm run build` to build the smart functions.
 
-4.  Call the smart function with the Jstz CLI by running this command, replacing `<ECHO ADDRESS>` with the address of the echo smart function address
+3. Deploy the smart function to the sandbox by running `npm run deploy`. This script deploys both smart functions and prints their addresses and assigns the local alias `axios.example` to the `index.ts` smart function.
+
+4. Call the `index.ts` smart function with the Jstz CLI by running this command, replacing the placeholder `<ECHO_ADDRESS>` with the address of the echo smart function:
 
 ```shell
-jstz run jstz://axios.example -m POST -d '{ "echoSf": "<ECHO ADDRESS>" }' -t --network dev
+jstz run jstz://axios.example -m POST -d '{ "echoSf": "<ECHO_ADDRESS>" }' -t --network dev
 ```
+
+The smart function logs the responses from the external API and the echo smart function, as in this example response:
+
+```
+Connected to trace smart function "KT1W6To7ubmoWLQPojrJKKsabpoqsk85Jqhw"
+[INFO]: UUID 72e20178-5a4b-49c2-b2ec-e1b75d298c2f
+
+[INFO]: { body: "Hello world!" }
+
+OK!
+```
+
+For more information about calling APIs with smart functions, including why you must call them before reading from or writing to the key-value store, see [Enshrined oracle](https://jstz.tezos.com/architecture/oracle) in the Jstz documentation.
 
 For more information about Jstz, see https://jstz.tezos.com/.


### PR DESCRIPTION
Builds on https://github.com/jstz-dev/jstz/pull/1190 to add some info about the Axios example to the docs. Will cause a conflict with https://github.com/jstz-dev/jstz/pull/1183 but we can work it out and probably put these two oracle examples in a single section. How's "HTTP libraries and external APIs" for a name for that section?