### PR TITLE
refactor: move KeyPair to jstz_utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3204,7 +3204,9 @@ name = "jstz_utils"
 version = "0.1.1-alpha.3"
 dependencies = [
  "anyhow",
+ "jstz_crypto",
  "reqwest",
+ "serde",
  "serde_json",
  "tokio",
 ]

--- a/crates/jstz_node/src/config.rs
+++ b/crates/jstz_node/src/config.rs
@@ -1,36 +1,10 @@
 use std::path::{Path, PathBuf};
 
-use jstz_crypto::{public_key::PublicKey, secret_key::SecretKey};
+use jstz_utils::KeyPair;
 use octez::r#async::endpoint::Endpoint;
 use serde::Serialize;
 
 use crate::RunMode;
-
-/// Jstz node's signer defaults to `injector` account in jstzd/resources/bootstrap_account/accounts.json
-/// Make sure to keep these two in sync.
-pub const JSTZ_NODE_DEFAULT_PK: &str =
-    "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav";
-pub const JSTZ_NODE_DEFAULT_SK: &str =
-    "edsk3gUfUPyBSfrS9CCgmCiQsTCHGkviBDusMxDJstFtojtc1zcpsh";
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-#[serde(into = "PublicKey")]
-pub struct KeyPair(pub PublicKey, pub SecretKey);
-
-impl Default for KeyPair {
-    fn default() -> Self {
-        Self(
-            PublicKey::from_base58(JSTZ_NODE_DEFAULT_PK).unwrap(),
-            SecretKey::from_base58(JSTZ_NODE_DEFAULT_SK).unwrap(),
-        )
-    }
-}
-
-impl From<KeyPair> for PublicKey {
-    fn from(value: KeyPair) -> Self {
-        value.0
-    }
-}
 
 #[derive(Clone, Serialize)]
 pub struct JstzNodeConfig {
@@ -90,6 +64,8 @@ impl JstzNodeConfig {
 
 #[cfg(test)]
 mod tests {
+    use jstz_crypto::{public_key::PublicKey, secret_key::SecretKey};
+
     use super::*;
 
     #[test]
@@ -142,23 +118,5 @@ mod tests {
                 "edpkukK9ecWxib28zi52nvbXTdsYt8rYcvmt5bdH8KjipWXm8sH3Qi"
             );
         }
-    }
-
-    #[test]
-    fn test_default_injector() {
-        let config = JstzNodeConfig::new(
-            &Endpoint::localhost(8932),
-            &Endpoint::localhost(8933),
-            Path::new("/tmp/preimages"),
-            Path::new("/tmp/kernel.log"),
-            KeyPair::default(),
-            RunMode::Default,
-            0,
-            Path::new("/tmp/debug.log"),
-            #[cfg(feature = "v2_runtime")]
-            None,
-        );
-
-        assert_eq!(config.injector, KeyPair::default());
     }
 }

--- a/crates/jstz_node/src/lib.rs
+++ b/crates/jstz_node/src/lib.rs
@@ -1,8 +1,9 @@
 use anyhow::{Context, Result};
 use api_doc::{modify, ApiDoc};
 use axum::{extract::DefaultBodyLimit, http, routing::get};
-use config::{JstzNodeConfig, KeyPair};
+use config::JstzNodeConfig;
 use jstz_core::reveal_data::MAX_REVEAL_SIZE;
+use jstz_utils::KeyPair;
 use octez::OctezRollupClient;
 #[cfg(not(test))]
 use sequencer::inbox;
@@ -265,6 +266,7 @@ mod test {
         time::SystemTime,
     };
 
+    use jstz_crypto::{public_key::PublicKey, secret_key::SecretKey};
     use octez::unused_port;
     use pretty_assertions::assert_eq;
     use tempfile::{NamedTempFile, TempDir};
@@ -273,6 +275,19 @@ mod test {
     use crate::{
         run, services::utils::tests::mock_app_state, KeyPair, RunMode, RunOptions,
     };
+
+    pub fn default_injector() -> KeyPair {
+        KeyPair(
+            PublicKey::from_base58(
+                "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav",
+            )
+            .unwrap(),
+            SecretKey::from_base58(
+                "edsk3gUfUPyBSfrS9CCgmCiQsTCHGkviBDusMxDJstFtojtc1zcpsh",
+            )
+            .unwrap(),
+        )
+    }
 
     #[test]
     fn api_doc_regression() {
@@ -324,7 +339,7 @@ mod test {
                 rollup_endpoint: "0.0.0.0:5678".to_string(),
                 rollup_preimages_dir: TempDir::new().unwrap().into_path(),
                 kernel_log_path: kernel_log_file.path().to_path_buf(),
-                injector: KeyPair::default(),
+                injector: default_injector(),
                 mode: mode.clone(),
                 capacity: 0,
                 debug_log_path: debug_log_file.path().to_path_buf(),
@@ -391,7 +406,7 @@ mod test {
                 rollup_endpoint,
                 rollup_preimages_dir,
                 kernel_log_path: kernel_log_file.path().to_path_buf(),
-                injector: KeyPair::default(),
+                injector: default_injector(),
                 mode,
                 capacity: 0,
                 debug_log_path: debug_log_file.path().to_path_buf(),

--- a/crates/jstz_node/src/main.rs
+++ b/crates/jstz_node/src/main.rs
@@ -3,7 +3,8 @@ use std::path::PathBuf;
 use anyhow::Context;
 use clap::Parser;
 use env_logger::Env;
-use jstz_node::{config::KeyPair, RunMode, RunOptions};
+use jstz_node::{RunMode, RunOptions};
+use jstz_utils::KeyPair;
 use tempfile::NamedTempFile;
 
 const DEFAULT_ROLLUP_NODE_RPC_ADDR: &str = "127.0.0.1";
@@ -144,7 +145,7 @@ mod tests {
     };
 
     use jstz_crypto::{public_key::PublicKey, secret_key::SecretKey};
-    use jstz_node::config::KeyPair;
+    use jstz_utils::KeyPair;
     use tempfile::NamedTempFile;
 
     #[test]

--- a/crates/jstz_node/src/sequencer/runtime.rs
+++ b/crates/jstz_node/src/sequencer/runtime.rs
@@ -11,7 +11,8 @@ use tezos_smart_rollup::{
     storage::path::RefPath,
 };
 
-use crate::{config::KeyPair, sequencer::inbox::parsing::Message};
+use crate::sequencer::inbox::parsing::Message;
+use jstz_utils::KeyPair;
 
 use super::{db::Db, host::Host};
 
@@ -116,7 +117,7 @@ mod tests {
         storage::path::{OwnedPath, RefPath},
     };
 
-    use crate::sequencer::db::Db;
+    use crate::{sequencer::db::Db, test::default_injector};
 
     fn dummy_op(
         sig_str: &str,
@@ -171,7 +172,7 @@ mod tests {
         let db_file = NamedTempFile::new().unwrap();
         let db = Db::init(Some(db_file.path().to_str().unwrap())).unwrap();
         let debug_log_file = NamedTempFile::new().unwrap();
-        let mut h = super::init_host(db, PathBuf::new(), &KeyPair::default())
+        let mut h = super::init_host(db, PathBuf::new(), &default_injector())
             .unwrap()
             .with_debug_log_file(debug_log_file.path())
             .unwrap();
@@ -254,7 +255,7 @@ mod tests {
         // Using a slightly complicated scenario here to check if transaction works properly.
         let db_file = NamedTempFile::new().unwrap();
         let db = Db::init(Some(db_file.path().to_str().unwrap())).unwrap();
-        let mut h = super::init_host(db, PathBuf::new(), &KeyPair::default()).unwrap();
+        let mut h = super::init_host(db, PathBuf::new(), &default_injector()).unwrap();
 
         let receiver =
             Address::from_base58("tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx").unwrap();
@@ -311,7 +312,7 @@ mod tests {
         // Using a slightly complicated scenario here to check if transaction works properly.
         let db_file = NamedTempFile::new().unwrap();
         let db = Db::init(Some(db_file.path().to_str().unwrap())).unwrap();
-        let mut h = super::init_host(db, PathBuf::new(), &KeyPair::default()).unwrap();
+        let mut h = super::init_host(db, PathBuf::new(), &default_injector()).unwrap();
 
         let receiver =
             Address::from_base58("tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx").unwrap();
@@ -399,7 +400,7 @@ mod tests {
         let signature = injector_sk.sign(large_payload.hash()).unwrap();
         let signed_large_payload = SignedOperation::new(signature, large_payload);
 
-        let mut h = super::init_host(db, path, &KeyPair::default()).unwrap();
+        let mut h = super::init_host(db, path, &default_injector()).unwrap();
 
         super::process_message(&mut h, Message::External(signed_large_payload))
             .await

--- a/crates/jstz_node/src/sequencer/worker.rs
+++ b/crates/jstz_node/src/sequencer/worker.rs
@@ -1,7 +1,4 @@
-use crate::{
-    config::KeyPair,
-    sequencer::runtime::{init_host, process_message},
-};
+use crate::sequencer::runtime::{init_host, process_message};
 use std::{
     path::{Path, PathBuf},
     sync::{
@@ -14,6 +11,7 @@ use std::{
 };
 
 use anyhow::Context;
+use jstz_utils::KeyPair;
 use log::warn;
 
 use super::{db::Db, inbox::parsing::ParsedInboxMessage, queue::OperationQueue};
@@ -199,7 +197,7 @@ mod tests {
     };
 
     use crate::sequencer::{db::Db, queue::OperationQueue, tests::dummy_op};
-    use crate::{config::KeyPair, sequencer::inbox::test_utils::hash_of};
+    use crate::{sequencer::inbox::test_utils::hash_of, test::default_injector};
     use tempfile::NamedTempFile;
 
     #[test]
@@ -210,7 +208,7 @@ mod tests {
         let worker = super::spawn(
             q,
             Db::init(Some("")).unwrap(),
-            &KeyPair::default(),
+            &default_injector(),
             PathBuf::new(),
             None,
             move || {
@@ -253,7 +251,7 @@ mod tests {
         let _worker = super::spawn(
             wrapper.clone(),
             cp,
-            &KeyPair::default(),
+            &default_injector(),
             PathBuf::new(),
             Some(log_file.path()),
             move || {},

--- a/crates/jstz_node/src/services/operations.rs
+++ b/crates/jstz_node/src/services/operations.rs
@@ -3,7 +3,6 @@ use std::path;
 use std::sync::Arc;
 use std::sync::RwLock;
 
-use crate::config::KeyPair;
 use crate::sequencer::inbox::parsing::Message;
 use crate::sequencer::inbox::parsing::ParsedInboxMessage;
 use crate::sequencer::queue::OperationQueue;
@@ -24,6 +23,7 @@ use jstz_core::reveal_data::{PreimageHash, RevealData, MAX_REVEAL_SIZE};
 use jstz_core::BinEncodable;
 use jstz_proto::operation::{Content, Operation, SignedOperation};
 use jstz_proto::receipt::Receipt;
+use jstz_utils::KeyPair;
 use octez::OctezRollupClient;
 use tezos_data_encoding::enc::BinWriter;
 use tezos_smart_rollup::inbox::ExternalMessageFrame;
@@ -288,6 +288,7 @@ mod tests {
         receipt::{DeployFunctionReceipt, Receipt},
         runtime::ParsedCode,
     };
+    use jstz_utils::KeyPair;
     use octez::OctezRollupClient;
     use tempfile::{NamedTempFile, TempDir};
     use tezos_crypto_rs::hash::ContractKt1Hash;
@@ -296,7 +297,6 @@ mod tests {
     use crate::sequencer::inbox::parsing::{Message, ParsedInboxMessage};
     use crate::services::utils::StoreWrapper;
     use crate::{
-        config::KeyPair,
         services::{
             error::ServiceError,
             operations::{encode_operation, OperationsService},

--- a/crates/jstz_node/src/services/utils.rs
+++ b/crates/jstz_node/src/services/utils.rs
@@ -71,9 +71,9 @@ pub(crate) mod tests {
     use tower::util::ServiceExt;
 
     use crate::{
-        config::KeyPair,
         sequencer::queue::OperationQueue,
         services::{logs::broadcaster::Broadcaster, utils::StoreWrapper},
+        test::default_injector,
         AppState, RunMode,
     };
 
@@ -99,7 +99,7 @@ pub(crate) mod tests {
             rollup_preimages_dir,
             broadcaster: Broadcaster::new(),
             db: crate::services::logs::db::Db::init().await.unwrap(),
-            injector: KeyPair::default(),
+            injector: default_injector(),
             mode,
             queue: Arc::new(RwLock::new(OperationQueue::new(1))),
             runtime_db: crate::sequencer::db::Db::init(Some(db_path)).unwrap(),

--- a/crates/jstz_utils/Cargo.toml
+++ b/crates/jstz_utils/Cargo.toml
@@ -12,6 +12,8 @@ description = "Utility functions"
 
 [dependencies]
 anyhow.workspace = true
+jstz_crypto = { path = "../jstz_crypto" }
 reqwest.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/jstz_utils/src/lib.rs
+++ b/crates/jstz_utils/src/lib.rs
@@ -1,3 +1,6 @@
+use jstz_crypto::{public_key::PublicKey, secret_key::SecretKey};
+use serde::Serialize;
+
 pub mod tailed_file;
 
 pub async fn poll<'a, F, T>(
@@ -16,6 +19,16 @@ where
         }
     }
     None
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(into = "PublicKey")]
+pub struct KeyPair(pub PublicKey, pub SecretKey);
+
+impl From<KeyPair> for PublicKey {
+    fn from(value: KeyPair) -> Self {
+        value.0
+    }
 }
 
 // WARNING: Should only be used in tests!

--- a/crates/jstzd/src/config.rs
+++ b/crates/jstzd/src/config.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use jstz_crypto::public_key::PublicKey;
 use jstz_crypto::secret_key::SecretKey;
 use jstz_node::RunMode;
+use jstz_utils::KeyPair;
 use octez::r#async::node_config::{OctezNodeHistoryMode, OctezNodeRunOptionsBuilder};
 use rust_embed::Embed;
 use tempfile::NamedTempFile;
@@ -15,7 +16,6 @@ use crate::{
 use anyhow::{Context, Result};
 use http::Uri;
 use jstz_node::config::JstzNodeConfig;
-use jstz_node::config::KeyPair;
 use octez::r#async::endpoint::Endpoint;
 use octez::r#async::protocol::{
     BootstrapContract, BootstrapSmartRollup, ProtocolParameter, SmartRollupPvmKind,

--- a/crates/jstzd/src/task/jstzd.rs
+++ b/crates/jstzd/src/task/jstzd.rs
@@ -680,13 +680,13 @@ async fn call_contract_handler(
 mod tests {
     use axum::{body::to_bytes, response::IntoResponse};
     use indicatif::ProgressBar;
-    #[cfg(feature = "v2_runtime")]
     use jstz_crypto::secret_key::SecretKey;
     use jstz_crypto::{public_key::PublicKey, public_key_hash::PublicKeyHash};
+    use jstz_utils::KeyPair;
     use std::path::PathBuf;
     use std::str::FromStr;
 
-    use jstz_node::config::{JstzNodeConfig, KeyPair};
+    use jstz_node::config::JstzNodeConfig;
     use octez::r#async::{
         baker::{BakerBinaryPath, OctezBakerConfigBuilder},
         client::{Address, OctezClientConfigBuilder},
@@ -826,7 +826,16 @@ mod tests {
                 &Endpoint::default(),
                 &PathBuf::from("/foo"),
                 &PathBuf::from("/foo"),
-                KeyPair::default(),
+                KeyPair(
+                    PublicKey::from_base58(
+                        "edpkukK9ecWxib28zi52nvbXTdsYt8rYcvmt5bdH8KjipWXm8sH3Qi",
+                    )
+                    .unwrap(),
+                    SecretKey::from_base58(
+                        "edsk3AbxMYLgdY71xPEjWjXi5JCx6tSS8jhQ2mc1KczZ1JfPrTqSgM",
+                    )
+                    .unwrap(),
+                ),
                 jstz_node::RunMode::Default,
                 0,
                 &PathBuf::from("/log"),

--- a/crates/jstzd/tests/jstz_node_test.rs
+++ b/crates/jstzd/tests/jstz_node_test.rs
@@ -1,4 +1,6 @@
-use jstz_node::config::{JstzNodeConfig, KeyPair};
+use jstz_crypto::{public_key::PublicKey, secret_key::SecretKey};
+use jstz_node::config::JstzNodeConfig;
+use jstz_utils::KeyPair;
 use jstzd::task::{utils::retry, Task};
 use octez::{r#async::endpoint::Endpoint, unused_port};
 use tempfile::{NamedTempFile, TempDir};
@@ -17,7 +19,16 @@ async fn jstz_node_test() {
         &mock_rollup_endpoint,
         &preimages_dir_path,
         &path,
-        KeyPair::default(),
+        KeyPair(
+            PublicKey::from_base58(
+                "edpkukK9ecWxib28zi52nvbXTdsYt8rYcvmt5bdH8KjipWXm8sH3Qi",
+            )
+            .unwrap(),
+            SecretKey::from_base58(
+                "edsk3AbxMYLgdY71xPEjWjXi5JCx6tSS8jhQ2mc1KczZ1JfPrTqSgM",
+            )
+            .unwrap(),
+        ),
         jstz_node::RunMode::Default,
         0,
         debug_log_file.path(),

--- a/crates/jstzd/tests/jstzd_test.rs
+++ b/crates/jstzd/tests/jstzd_test.rs
@@ -6,7 +6,10 @@ use std::time::Duration;
 
 #[cfg(feature = "v2_runtime")]
 use jstz_crypto::keypair_from_mnemonic;
-use jstz_node::config::{JstzNodeConfig, KeyPair};
+use jstz_crypto::public_key::PublicKey;
+use jstz_crypto::secret_key::SecretKey;
+use jstz_node::config::JstzNodeConfig;
+use jstz_utils::KeyPair;
 use jstzd::jstz_rollup_path::*;
 
 use http::Uri;
@@ -184,7 +187,16 @@ async fn create_jstzd_server(
         &rollup_config.rpc_endpoint,
         &preimages_dir_path,
         &kernel_debug_file_path,
-        KeyPair::default(),
+        KeyPair(
+            PublicKey::from_base58(
+                "edpkukK9ecWxib28zi52nvbXTdsYt8rYcvmt5bdH8KjipWXm8sH3Qi",
+            )
+            .unwrap(),
+            SecretKey::from_base58(
+                "edsk3AbxMYLgdY71xPEjWjXi5JCx6tSS8jhQ2mc1KczZ1JfPrTqSgM",
+            )
+            .unwrap(),
+        ),
         jstz_node::RunMode::Default,
         0,
         &debug_log_path,
@@ -448,7 +460,16 @@ fn oracle_config_serialization_test() {
         &Endpoint::localhost(8933),
         PathBuf::from("/tmp/preimages").as_path(),
         PathBuf::from("/tmp/kernel.log").as_path(),
-        KeyPair::default(),
+        KeyPair(
+            PublicKey::from_base58(
+                "edpkukK9ecWxib28zi52nvbXTdsYt8rYcvmt5bdH8KjipWXm8sH3Qi",
+            )
+            .unwrap(),
+            SecretKey::from_base58(
+                "edsk3AbxMYLgdY71xPEjWjXi5JCx6tSS8jhQ2mc1KczZ1JfPrTqSgM",
+            )
+            .unwrap(),
+        ),
         jstz_node::RunMode::Default,
         0,
         PathBuf::from("/tmp/debug.log").as_path(),


### PR DESCRIPTION
# Context

Some housekeeping.

# Description

Moved `KeyPair` from crate jstz_node to jstz_utils since it is going to be used by more than one crate. This is for #1194. Also removed the default implementation for `KeyPair` as mentioned in https://github.com/jstz-dev/jstz/pull/1148#discussion_r2171399218.

# Manually testing the PR

All tests should still work.
