### PR TITLE
fix(axios-example): generate package-lock, remove incorrect line

### DIFF
--- a/examples/axios/README.md
+++ b/examples/axios/README.md
@@ -24,6 +24,4 @@ Follow these steps to use it
 jstz run jstz://axios.example -m POST -d '{ "echoSf": "<ECHO ADDRESS>" }' -t --network dev
 ```
 
-The response shows that the number in storage was incremented and what the current number is/
-
 For more information about Jstz, see https://jstz.tezos.com/.

--- a/examples/axios/package-lock.json
+++ b/examples/axios/package-lock.json
@@ -8,7 +8,6 @@
       "name": "@jstz-dev/get-tez",
       "version": "0.0.0",
       "dependencies": {
-        "@jstz-dev/jstz": "^0.0.0",
         "axios": "^1.10.0"
       },
       "devDependencies": {
@@ -405,19 +404,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/@jstz-dev/jstz": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/@jstz-dev/jstz/-/jstz-0.0.0.tgz",
-      "integrity": "sha512-/6TnpZ/4zmGi2sOBchZ4+l56xRJGC6azbeOlHCoXQ6ZGWaExyp6FXR1XApU2ZhMV0ZDv1gvhpThNn76qsNfhBA==",
-      "dependencies": {
-        "@jstz-dev/types": "^0.0.0"
-      }
-    },
-    "node_modules/@jstz-dev/types": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/@jstz-dev/types/-/types-0.0.0.tgz",
-      "integrity": "sha512-RsuX2suEOmvCsdCv5gHtUtk9OpiE/TRImDvO/w7OOd/nQtySgBh6+BhCjbQ5pznuZUsKeVLguQHkcAO9JZkHxA=="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",


### PR DESCRIPTION
# Context
* Removes line that was incorrectly copy pasted into `axios/README.md`
* Re-generate package-lock