### PR TITLE
feat(gh): add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,7 @@
+# Entire codebase
+*           @alanmarkoTrilitech @huancheng-trili @johnyob @ryutamago @zcabter
+
+# Docs
+/docs/      @timothymcmackin @NicNomadic @alanmarkoTrilitech @huancheng-trili @johnyob @ryutamago @zcabter
+/examples/  @timothymcmackin @NicNomadic @alanmarkoTrilitech @huancheng-trili @johnyob @ryutamago @zcabter
+README.md   @timothymcmackin @NicNomadic @alanmarkoTrilitech @huancheng-trili @johnyob @ryutamago @zcabter


### PR DESCRIPTION
# Context
Adds CODEOWNERS which will automatically add developers as reviewers and require at least 1 approval from the CO set
<!-- Why is this change required? What problem does it solve? -->

# Manually testing
* COs brought in as reviewers in BAU code - https://github.com/jstz-dev/jstz/pull/1200
* COs brought in as reviewer in doc code - https://github.com/jstz-dev/jstz/pull/1201