### PR TITLE
feat(gh): support merge queues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: Continuous Integration
 
 on:
   pull_request:
+  merge_group:
   push:
     branches: [main]
 


### PR DESCRIPTION
# Context
Improve merge velocity of unrelated changes

# Description
Implements merge queues by adding `merge_queue` action trigger to CI and enabling the require merge queue setting in repo configurations.

The merge queue is configured with
- Maximum 10 concurrent builds at one time 
- Enforce a maximum of 10 PRs to merge in a single batch which should be well over our current velocity
- Merge every 2 minutes - PRs in the queue that pass checks will be flushed every 2 minutes


# Manually testing the PR
* Merge queue support was tested in https://github.com/jstz-dev/jstz/pull/1203 

<!-- Describe how reviewers and approvers can test this PR. -->
