### PR TITLE
fix(kernel): fix leaking macos linking flags when compiling riscv kernel

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,17 +1,11 @@
 [target.riscv64gc-unknown-linux-musl]
 linker = "riscv64-unknown-linux-musl-g++"
 rustflags = [
-	"-C",
-	"target-feature=+crt-static",
-	"-C",
-	"link-arg=-latomic",
-	"-C",
-	"link-arg=-lstdc++",
-	"-C",
-	"link-arg=-lsupc++",
-	"-C",
-	"link-arg=-lgcc",
-	"-C",
-	"link-arg=-lc"
+  "-C",
+  "target-feature=+crt-static",
+  "-C",
+  "default-linker-libraries=y",
+  "-C",
+  "link-arg=-latomic"
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -77,14 +77,14 @@ riscv-v2-one-shot-kernel:
 
 .PHONY: riscv-pvm-kernel
 riscv-pvm-kernel:
-	@RUSTY_V8_ARCHIVE=$$RISCV_V8_ARCHIVE_DIR/librusty_v8.a \
+	@unset NIX_LDFLAGS && RUSTY_V8_ARCHIVE=$$RISCV_V8_ARCHIVE_DIR/librusty_v8.a \
 		RUSTY_V8_SRC_BINDING_PATH=$$RISCV_V8_ARCHIVE_DIR/src_binding.rs \
 		cargo build \
 		-p jstz_kernel \
 		--no-default-features \
 		--features riscv_kernel \
 		--release \
-		--target riscv64gc-unknown-linux-musl \
+		--target riscv64gc-unknown-linux-musl
 
 .PHONY: test
 test: test-unit test-int


### PR DESCRIPTION
# Context
Macos linking flags was being leaked into the RISCV musl compile. See `env | grep NIX_LDFLAGS`. This problem was unnoticeable when run on riscv sandbox but causes the rollup node to hand when ran

# Description
- Unset `NIX_LDFLAGS` on build
- Revert to `default-linker-libraries=y`
- Link atomics

# Manually testing the PR
`make riscv-pvm-kernel`
<!-- Describe how reviewers and approvers can test this PR. -->
