### PR TITLE
feat(kernel): warm up runtime on kernel start

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,17 +1,11 @@
 [target.riscv64gc-unknown-linux-musl]
 linker = "riscv64-unknown-linux-musl-g++"
 rustflags = [
-	"-C",
-	"target-feature=+crt-static",
-	"-C",
-	"link-arg=-latomic",
-	"-C",
-	"link-arg=-lstdc++",
-	"-C",
-	"link-arg=-lsupc++",
-	"-C",
-	"link-arg=-lgcc",
-	"-C",
-	"link-arg=-lc"
+  "-C",
+  "target-feature=+crt-static",
+  "-C",
+  "default-linker-libraries=y",
+  "-C",
+  "link-arg=-latomic"
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2963,6 +2963,7 @@ dependencies = [
  "jstz_crypto",
  "jstz_mock",
  "jstz_proto",
+ "jstz_runtime",
  "jstz_utils",
  "num-traits",
  "serde",

--- a/Makefile
+++ b/Makefile
@@ -77,14 +77,14 @@ riscv-v2-one-shot-kernel:
 
 .PHONY: riscv-pvm-kernel
 riscv-pvm-kernel:
-	@RUSTY_V8_ARCHIVE=$$RISCV_V8_ARCHIVE_DIR/librusty_v8.a \
+	@unset NIX_LDFLAGS && RUSTY_V8_ARCHIVE=$$RISCV_V8_ARCHIVE_DIR/librusty_v8.a \
 		RUSTY_V8_SRC_BINDING_PATH=$$RISCV_V8_ARCHIVE_DIR/src_binding.rs \
 		cargo build \
 		-p jstz_kernel \
 		--no-default-features \
 		--features riscv_kernel \
 		--release \
-		--target riscv64gc-unknown-linux-musl \
+		--target riscv64gc-unknown-linux-musl
 
 .PHONY: test
 test: test-unit test-int

--- a/crates/jstz_kernel/Cargo.toml
+++ b/crates/jstz_kernel/Cargo.toml
@@ -27,6 +27,7 @@ tokio = { workspace = true, optional = true }
 jstz_core = { path = "../jstz_core" }
 jstz_crypto = { path = "../jstz_crypto" }
 jstz_proto = { path = "../jstz_proto" }
+jstz_runtime = { path = "../jstz_runtime", optional = true}
 num-traits.workspace = true
 serde.workspace = true
 tezos-smart-rollup.workspace = true
@@ -43,4 +44,4 @@ tokio.workspace = true
 
 [features]
 v2_runtime = ["jstz_proto/v2_runtime", "jstz_proto/kernel"]
-riscv_kernel = ["v2_runtime", "dep:tokio", "tezos-smart-rollup/experimental-host-in-memory-store"]
+riscv_kernel = ["v2_runtime", "dep:tokio", "dep:jstz_runtime", "tezos-smart-rollup/experimental-host-in-memory-store"]

--- a/crates/jstz_kernel/src/executable.rs
+++ b/crates/jstz_kernel/src/executable.rs
@@ -1,8 +1,9 @@
 #![cfg(feature = "riscv_kernel")]
-use tezos_smart_rollup::{entrypoint, host::Runtime};
+use tezos_smart_rollup::{entrypoint, host::Runtime, prelude::debug_msg};
 
 // kernel entry
 #[entrypoint::main]
 pub fn entry(rt: &mut impl Runtime) {
+    debug_msg!(rt, "Starting Jstz kernel\n");
     jstz_kernel::riscv_kernel::run(rt);
 }

--- a/crates/jstz_kernel/src/riscv_kernel.rs
+++ b/crates/jstz_kernel/src/riscv_kernel.rs
@@ -8,6 +8,7 @@ use jstz_crypto::{
     hash::Hash, public_key::PublicKey, smart_function_hash::SmartFunctionHash,
 };
 use jstz_proto::runtime::{ProtocolContext, PROTOCOL_CONTEXT};
+use jstz_runtime::JstzRuntime;
 use tezos_crypto_rs::hash::ContractKt1Hash;
 use tezos_smart_rollup::prelude::{debug_msg, Runtime};
 
@@ -42,6 +43,7 @@ pub fn run(rt: &mut impl Runtime) {
             return;
         }
     };
+    let _ = JstzRuntime::new(Default::default());
     let local_set = tokio::task::LocalSet::new();
     local_set.block_on(&tokio_runtime, run_event_loop(rt))
 }


### PR DESCRIPTION
# Context
V8 platform setup takes a few seconds to setup.

Launching a dummy runtime warms the v8 platform up such that future runtime creation will be much faster

# Manually testing the PR
`make riscv-kernel-pvm`
<!-- Describe how reviewers and approvers can test this PR. -->
