### PR TITLE
chore: remove cli kernel build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,7 @@ node_modules/
 
 .env
 
-# Required by the CLI
-crates/jstz_cli/jstz_kernel.wasm
+# Required by jstzd
 crates/jstzd/resources/jstz_rollup/jstz_kernel.wasm
 
 **/*/.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -12,16 +12,15 @@ else
 endif
 
 JSTZD_KERNEL_PATH := crates/jstzd/resources/jstz_rollup/jstz_kernel.wasm
-CLI_KERNEL_PATH := crates/jstz_cli/jstz_kernel.wasm
 
 .PHONY: all
 all: build test build-v2 test-v2 check
 
 .PHONY: build
-build: build-cli-kernel build-jstzd-kernel
+build: build-jstzd-kernel
 	@cargo build $(PROFILE_OPT)
 
-build-v2: build-cli-kernel build-jstzd-kernel
+build-v2: build-jstzd-kernel
 	@cargo build $(PROFILE_OPT) --features v2_runtime
 
 .PHONY: build-bridge
@@ -41,14 +40,8 @@ build-kernel:
 build-jstzd-kernel: build-kernel
 	@cp target/wasm32-unknown-unknown/$(PROFILE_TARGET_DIR)/jstz_kernel.wasm $(JSTZD_KERNEL_PATH)
 
-# TODO: Remove once jstzd replaces the sandbox
-# https://linear.app/tezos/issue/JSTZ-205/remove-build-for-jstz-cli
-.PHONY: build-cli-kernel
-build-cli-kernel: build-kernel
-	@cp target/wasm32-unknown-unknown/$(PROFILE_TARGET_DIR)/jstz_kernel.wasm $(CLI_KERNEL_PATH)
-
 .PHONY: build-cli
-build-cli: build-cli-kernel
+build-cli:
 	@cargo build --package jstz_cli $(PROFILE_OPT)
 
 .PHONY: build-deps
@@ -140,8 +133,7 @@ fmt-check:
 
 .PHONY: lint
 lint:
-	@touch $(CLI_KERNEL_PATH) 
 #  Jstzd has to processes a non-empty kernel in its build script
 	@echo "ignore" > $(JSTZD_KERNEL_PATH)
 	@cargo clippy --all-targets -- --deny warnings
-	@rm -f $(CLI_KERNEL_PATH) $(JSTZD_KERNEL_PATH)
+	@rm -f $(JSTZD_KERNEL_PATH)

--- a/crates/jstz_cli/Dockerfile
+++ b/crates/jstz_cli/Dockerfile
@@ -6,8 +6,6 @@ RUN apk --no-cache add musl-dev libcrypto3 openssl-dev clang
 ENV OPENSSL_DIR=/usr
 WORKDIR /jstz_build
 COPY . .
-ARG KERNEL_PATH
-COPY $KERNEL_PATH crates/jstz_cli/jstz_kernel.wasm
 RUN RUSTFLAGS='-C target-feature=-crt-static' cargo build --package jstz_cli
 
 FROM alpine AS cli
@@ -21,5 +19,4 @@ COPY --from=octez /usr/local/bin/octez-client /usr/bin/octez-client
 COPY --from=octez /usr/share/zcash-params /root/.zcash-params
 # Copy the jstz binary & dependencies
 COPY --from=builder /jstz_build/target/debug/jstz /usr/bin/jstz
-COPY --from=builder /jstz_build/crates/jstz_cli/jstz_kernel.wasm /usr/share/jstz/jstz_kernel.wasm
 ENTRYPOINT [ "/usr/bin/jstz" ]

--- a/nix/crates.nix
+++ b/nix/crates.nix
@@ -89,7 +89,6 @@
       buildInputs = common.buildInputs ++ [pkgs.iana-etc octez pkgs.cacert pkgs.sqlite];
       preBuildPhases = ["cpJstzKernel"];
       cpJstzKernel = ''
-        cp ${jstz_kernel}/lib/jstz_kernel.wasm ./crates/jstz_cli/jstz_kernel.wasm
         cp ${jstz_kernel}/lib/jstz_kernel.wasm ./crates/jstzd/resources/jstz_rollup/jstz_kernel.wasm
       '';
     };
@@ -119,17 +118,7 @@ in let
     # When adding a new crate, add it to this list
     # in alphabetical order.
     jstz_api = crate "jstz_api";
-    jstz_cli = craneLib.buildPackage (commonWorkspace
-      // rec {
-        pname = "jstz_cli";
-        cargoExtraArgs = "-p ${pname}";
-        # The `jstz_cli` crate depends on the `jstz_kernel` crate
-        # to build the `jstz_kernel.wasm` file.
-        preBuildPhases = ["mkJstzKernelForCli"];
-        mkJstzKernelForCli = ''
-          cp ${jstz_kernel}/lib/jstz_kernel.wasm ./crates/jstz_cli/jstz_kernel.wasm
-        '';
-      });
+    jstz_cli = crate "jstz_cli";
     jstz_core = crate "jstz_core";
     jstz_crypto = crate "jstz_crypto";
     inherit jstz_kernel;


### PR DESCRIPTION
# Context

Completes JSTZ-205.
[JSTZ-205](https://linear.app/tezos/issue/JSTZ-205/remove-build-for-jstz-cli)

Some of the dependencies of `jstz_cli` are redundant after jstzd replaced the old sandbox.

# Description

Removed the wasm kernel build for CLI.

# Manually testing the PR

CI passes.
