### PR TITLE
feat(kernel): unify ParsedInboxMessage and LevelInfo with sequencer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2946,6 +2946,7 @@ dependencies = [
  "jstz_api",
  "jstz_core",
  "jstz_crypto",
+ "jstz_kernel",
  "jstz_mock",
  "jstz_oracle_node",
  "jstz_proto",

--- a/crates/jstz_kernel/src/inbox.rs
+++ b/crates/jstz_kernel/src/inbox.rs
@@ -20,7 +20,7 @@ use crate::parsing::try_parse_fa_deposit;
 pub type ExternalMessage = SignedOperation;
 pub type InternalMessage = InternalOperation;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Message {
     External(ExternalMessage),
     Internal(InternalMessage),
@@ -203,12 +203,13 @@ fn read_external_message(
     Some(msg)
 }
 
-#[derive(derive_more::From)]
+#[derive(Debug, Clone, derive_more::From)]
 pub enum ParsedInboxMessage {
     JstzMessage(Message),
     LevelInfo(LevelInfo),
 }
 
+#[derive(Debug, Clone)]
 pub enum LevelInfo {
     // Start of level
     Start,

--- a/crates/jstz_kernel/src/lib.rs
+++ b/crates/jstz_kernel/src/lib.rs
@@ -1,4 +1,3 @@
-use inbox::Message;
 use jstz_core::kv::{Storage, Transaction};
 use jstz_crypto::{public_key::PublicKey, smart_function_hash::SmartFunctionHash};
 use jstz_proto::executor;
@@ -12,6 +11,9 @@ use tezos_smart_rollup::{
 
 pub mod inbox;
 pub mod parsing;
+
+pub use inbox::{LevelInfo, Message, ParsedInboxMessage};
+pub use parsing::try_parse_fa_deposit;
 
 #[cfg(feature = "riscv_kernel")]
 pub mod riscv_kernel;

--- a/crates/jstz_node/Cargo.toml
+++ b/crates/jstz_node/Cargo.toml
@@ -31,6 +31,7 @@ hex.workspace = true
 jstz_api = { path = "../jstz_api" }
 jstz_core = { path = "../jstz_core" }
 jstz_crypto = { path = "../jstz_crypto" }
+jstz_kernel = { path = "../jstz_kernel" }
 jstz_proto = { path = "../jstz_proto", features = ["kernel"] }
 jstz_oracle_node = { path = "../jstz_oracle_node", features = ["v2_runtime"], optional = true}
 jstz_utils = { path = "../jstz_utils" }

--- a/crates/jstz_node/src/sequencer/inbox/mod.rs
+++ b/crates/jstz_node/src/sequencer/inbox/mod.rs
@@ -11,8 +11,9 @@ use api::BlockResponse;
 use async_dropper_simple::AsyncDrop;
 use async_trait::async_trait;
 use jstz_core::host::WriteDebug;
+use jstz_kernel::ParsedInboxMessage;
 use log::{debug, error};
-use parsing::{parse_inbox_message_hex, ParsedInboxMessage};
+use parsing::parse_inbox_message_hex;
 #[cfg(test)]
 use std::future::Future;
 use tezos_crypto_rs::hash::{ContractKt1Hash, SmartRollupHash};
@@ -165,8 +166,8 @@ async fn retry_fetch_block(rollup_endpoint: &str, block_level: u32) -> BlockResp
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sequencer::inbox::parsing::{LevelInfo, Message};
     use crate::sequencer::inbox::test_utils::{hash_of, make_mock_monitor_blocks_filter};
+    use jstz_kernel::{LevelInfo, Message};
     use std::time::Duration;
     use std::{
         future::Future,
@@ -299,9 +300,10 @@ mod tests {
 
 #[cfg(test)]
 pub(crate) mod test_utils {
-    use super::{api::BlockResponse, parsing::Message, *};
+    use super::{api::BlockResponse, *};
     use bytes::Bytes;
     use futures_util::stream;
+    use jstz_kernel::Message;
     use std::{convert::Infallible, time::Duration};
     use tokio::time::sleep;
     use warp::{hyper::Body, Filter};

--- a/crates/jstz_node/src/sequencer/mod.rs
+++ b/crates/jstz_node/src/sequencer/mod.rs
@@ -15,9 +15,7 @@ pub mod tests {
     };
     use tezos_crypto_rs::hash::{Ed25519Signature, PublicKeyEd25519};
 
-    use crate::sequencer::inbox::parsing::Message;
-
-    use super::inbox::parsing::ParsedInboxMessage;
+    use jstz_kernel::{Message, ParsedInboxMessage};
 
     pub fn dummy_op() -> ParsedInboxMessage {
         let inner = SignedOperation::new(

--- a/crates/jstz_node/src/sequencer/queue.rs
+++ b/crates/jstz_node/src/sequencer/queue.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use super::inbox::parsing::ParsedInboxMessage;
+use jstz_kernel::ParsedInboxMessage;
 
 pub struct OperationQueue {
     capacity: usize,

--- a/crates/jstz_node/src/sequencer/runtime.rs
+++ b/crates/jstz_node/src/sequencer/runtime.rs
@@ -11,7 +11,8 @@ use tezos_smart_rollup::{
     storage::path::RefPath,
 };
 
-use crate::{config::KeyPair, sequencer::inbox::parsing::Message};
+use crate::config::KeyPair;
+use jstz_kernel::Message;
 
 use super::{db::Db, host::Host};
 

--- a/crates/jstz_node/src/sequencer/worker.rs
+++ b/crates/jstz_node/src/sequencer/worker.rs
@@ -16,10 +16,11 @@ use std::{
 use anyhow::Context;
 use log::warn;
 
-use super::{db::Db, inbox::parsing::ParsedInboxMessage, queue::OperationQueue};
+use super::{db::Db, queue::OperationQueue};
+use jstz_kernel::ParsedInboxMessage;
 
 #[cfg(feature = "v2_runtime")]
-use super::inbox::parsing::LevelInfo;
+use jstz_kernel::LevelInfo;
 
 pub struct Worker {
     thread_kill_sig: Sender<()>,

--- a/crates/jstz_node/src/services/operations.rs
+++ b/crates/jstz_node/src/services/operations.rs
@@ -4,11 +4,10 @@ use std::sync::Arc;
 use std::sync::RwLock;
 
 use crate::config::KeyPair;
-use crate::sequencer::inbox::parsing::Message;
-use crate::sequencer::inbox::parsing::ParsedInboxMessage;
 use crate::sequencer::queue::OperationQueue;
 use crate::services::accounts::get_account_nonce;
 use crate::RunMode;
+use jstz_kernel::{Message, ParsedInboxMessage};
 
 use super::error::{ServiceError, ServiceResult};
 use super::utils::StoreWrapper;
@@ -293,7 +292,6 @@ mod tests {
     use tezos_crypto_rs::hash::ContractKt1Hash;
     use tower::ServiceExt;
 
-    use crate::sequencer::inbox::parsing::{Message, ParsedInboxMessage};
     use crate::services::utils::StoreWrapper;
     use crate::{
         config::KeyPair,
@@ -305,6 +303,7 @@ mod tests {
         utils::tests::{dummy_receipt, mock_app_state},
         RunMode,
     };
+    use jstz_kernel::{Message, ParsedInboxMessage};
 
     use super::MAX_DIRECT_OPERATION_SIZE;
 


### PR DESCRIPTION
# Context
[JSTZ-760](https://linear.app/tezos/issue/JSTZ-760/unify-parsedinboxmessage-and-levelinfo-with-sequencer)
# Description
This PR unifies enums ParsedInboxMessage, LevelInfo and Message and try_parse_fa_deposit function that had identical definitions in both kernel and sequencer.
# Manual testing
```make```
