### PR TITLE
chore(proto): increase test coverage

### DIFF
--- a/crates/jstz_proto/src/context/receipt.rs
+++ b/crates/jstz_proto/src/context/receipt.rs
@@ -11,3 +11,43 @@ impl Receipt {
         Ok(tx.insert(path::concat(&RECEIPTS_PATH, &receipt_path)?, self)?)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::receipt::{DeployFunctionReceipt, Receipt, ReceiptContent, ReceiptResult};
+    use jstz_core::kv::Transaction;
+    use jstz_crypto::{
+        hash::Blake2b,
+        smart_function_hash::{Kt1Hash, SmartFunctionHash},
+    };
+    use tezos_crypto_rs::hash::ContractKt1Hash;
+    use tezos_smart_rollup_mock::MockHost;
+
+    #[test]
+    fn test_write_receipt_inserts_into_transaction() {
+        let host = MockHost::default();
+        let mut tx = Transaction::default();
+        tx.begin();
+        let receipt = Receipt::new(
+            Blake2b::default(),
+            Ok(ReceiptContent::DeployFunction(DeployFunctionReceipt {
+                address: SmartFunctionHash(Kt1Hash(
+                    ContractKt1Hash::from_base58_check(
+                        "KT1F3MuqvT9Yz57TgCS3EkDcKNZe9HpiavUJ",
+                    )
+                    .unwrap(),
+                )),
+            })),
+        );
+        receipt.clone().write(&host, &mut tx).unwrap();
+        let hash = receipt.hash();
+        let path = path::concat(
+            &RECEIPTS_PATH,
+            &OwnedPath::try_from(format!("/{}", hash)).unwrap(),
+        )
+        .unwrap();
+        let stored = tx.get::<Receipt>(&host, path).unwrap();
+        assert!(matches!(stored.unwrap().result, ReceiptResult::Success(_)));
+    }
+}

--- a/crates/jstz_proto/src/error.rs
+++ b/crates/jstz_proto/src/error.rs
@@ -174,3 +174,35 @@ impl From<tezos_smart_rollup::storage::path::PathError> for Error {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use boa_engine::{JsError, JsNativeError};
+    use tezos_smart_rollup::storage::path::PathError;
+
+    #[test]
+    fn from_js_native_error_for_error() {
+        let js_native_error = JsNativeError::eval().with_message("dummy");
+        let error: Error = js_native_error.into();
+        assert!(matches!(error, Error::CoreError { .. }));
+    }
+
+    #[test]
+    fn from_js_error_for_error() {
+        let js_native_error = JsNativeError::eval().with_message("dummy");
+        let js_error: JsError = js_native_error.into();
+        let error: Error = js_error.into();
+        assert!(
+            matches!(error, Error::CoreError { source } if matches!(source, jstz_core::Error::JsError { .. }))
+        );
+    }
+
+    #[test]
+    fn from_path_error_for_error() {
+        let error: Error = PathError::PathEmpty.into();
+        assert!(
+            matches!(error, Error::CoreError { source } if matches!(source, jstz_core::Error::PathError { .. }))
+        );
+    }
+}

--- a/crates/jstz_proto/src/event.rs
+++ b/crates/jstz_proto/src/event.rs
@@ -106,11 +106,11 @@ impl nom::error::ParseError<&str> for NomError {
 #[cfg(test)]
 mod test {
 
-    use std::{fmt::Display, str::FromStr};
-
     use http::HeaderMap;
     use jstz_crypto::{hash::Hash, public_key_hash::PublicKeyHash};
+    use nom::error::ParseError;
     use serde_json::json;
+    use std::{fmt::Display, str::FromStr};
     use tezos_smart_rollup_mock::MockHost;
     use url::Url;
 
@@ -188,5 +188,15 @@ mod test {
             decoded.to_string(),
             "Error while decoding event: missing field `id` at line 1 column 19"
         )
+    }
+
+    #[test]
+    fn test_nomerror_append() {
+        use nom::error::ErrorKind;
+        let child = NomError::from_error_kind("childinput", ErrorKind::Alpha);
+        let appended = NomError::append("parentinput", ErrorKind::Alpha, child);
+        let msg = appended.to_string();
+        assert!(msg.contains("while decoding kind 'Alphabetic' for 'parentinpu[1..]'"));
+        assert!(msg.contains("kind 'Alphabetic' on input 'childinput'"));
     }
 }

--- a/crates/jstz_proto/src/executor/smart_function/run.rs
+++ b/crates/jstz_proto/src/executor/smart_function/run.rs
@@ -29,17 +29,20 @@ mod test {
     use jstz_core::kv::Transaction;
     use jstz_crypto::{hash::Blake2b, smart_function_hash::SmartFunctionHash};
     use jstz_mock::host::JstzMockHost;
-    use serde_json::json;
+
     use tezos_smart_rollup_mock::MockHost;
 
     use crate::{
-        context::{
-            account::{Account, Address},
-            ticket_table::TicketTable,
-        },
-        executor::smart_function::{self, deploy::deploy_smart_function},
+        context::account::{Account, Address},
+        executor::smart_function,
         operation::RunFunction,
         runtime::ParsedCode,
+    };
+
+    #[cfg(not(feature = "v2_runtime"))]
+    use {
+        crate::context::ticket_table::TicketTable,
+        crate::executor::smart_function::deploy::deploy_smart_function, serde_json::json,
     };
 
     #[tokio::test]
@@ -168,9 +171,10 @@ mod test {
         assert_eq!(balance_after, balance_before);
     }
 
-    #[tokio::test]
-    #[cfg_attr(feature = "v2_runtime", ignore = "v2 fetch does not support noop path")]
     // TODO: https://linear.app/tezos/issue/JSTZ-657/v2-fetch-should-support-transfer-with-noop
+    // v2 fetch does not support noop path
+    #[cfg(not(feature = "v2_runtime"))]
+    #[tokio::test]
     async fn transfer_xtz_to_smart_function_succeeds_with_noop_path() {
         let source = Address::User(jstz_mock::account1());
         // 1. Deploy the smart function
@@ -288,12 +292,10 @@ mod test {
         assert!(result.status_code.is_server_error());
     }
 
-    #[tokio::test]
-    #[cfg_attr(
-        feature = "v2_runtime",
-        ignore = "v2 runtime fetch ignores invalid headers instead of failing. It should fail"
-    )]
     // TODO: https://linear.app/tezos/issue/JSTZ-656/v2-fetch-should-fail-no-invalid-headers
+    // v2 runtime fetch ignores invalid headers instead of failing. It should fail
+    #[cfg(not(feature = "v2_runtime"))]
+    #[tokio::test]
     async fn invalid_request_should_fail() {
         let source = Address::User(jstz_mock::account1());
         // 1. Deploy the smart function
@@ -358,12 +360,9 @@ mod test {
         assert!(call_failed);
     }
 
-    #[tokio::test]
-    #[cfg_attr(
-        feature = "v2_runtime",
-        ignore = "v2 runtime fetch ignores invalid headers instead of failing. It should fail"
-    )]
     // TODO: https://linear.app/tezos/issue/JSTZ-656/v2-fetch-should-fail-no-invalid-headers
+    #[cfg(not(feature = "v2_runtime"))]
+    #[tokio::test]
     async fn invalid_response_should_fail() {
         let source = Address::User(jstz_mock::account1());
         // 1. Deploy the smart function
@@ -519,12 +518,10 @@ mod test {
         assert_eq!(balance_after, 0);
     }
 
-    #[tokio::test]
-    #[cfg_attr(
-        feature = "v2_runtime",
-        ignore = "v2 runtime does not support HostScript withdrawals yet"
-    )]
     // TODO: https://linear.app/tezos/issue/JSTZ-655/support-hostscript-fa-withdraw-in-v2
+    // v2 runtime does not support HostScript withdrawals yet
+    #[cfg(not(feature = "v2_runtime"))]
+    #[tokio::test]
     async fn host_script_withdraw_from_smart_function_succeeds() {
         let mut mock_host = JstzMockHost::default();
         let host = mock_host.rt();
@@ -657,9 +654,10 @@ mod test {
         assert_eq!(source_after - source_before, transfer_amount);
     }
 
-    #[tokio::test]
-    #[cfg_attr(feature = "v2_runtime", ignore = "v2 fetch does not support noop path")]
     // TODO: https://linear.app/tezos/issue/JSTZ-657/v2-fetch-should-support-transfer-with-noop
+    // v2 fetch does not support noop path
+    #[cfg(not(feature = "v2_runtime"))]
+    #[tokio::test]
     async fn transfer_xtz_from_smart_function_succeeds_with_noop() {
         let source = Address::User(jstz_mock::account2());
         let mut jstz_mock_host = JstzMockHost::default();
@@ -937,12 +935,10 @@ mod test {
         assert_eq!(balance_before_source + refund_amount, balance_after_source);
     }
 
-    #[tokio::test]
-    #[cfg_attr(
-        feature = "v2_runtime",
-        ignore = "v2 runtime fetch ignores invalid headers instead of failing. It should fail"
-    )]
     // TODO: https://linear.app/tezos/issue/JSTZ-656/v2-fetch-should-fail-no-invalid-headers
+    // v2 runtime fetch ignores invalid headers instead of failing. It should fail
+    #[cfg(not(feature = "v2_runtime"))]
+    #[tokio::test]
     async fn propagating_smart_function_refund_fails() {
         let source = Address::User(jstz_mock::account2());
         let mut jstz_mock_host = JstzMockHost::default();
@@ -1119,12 +1115,10 @@ mod test {
         assert_eq!(balance_before_source, balance_after_source);
     }
 
-    #[tokio::test]
-    #[cfg_attr(
-        feature = "v2_runtime",
-        ignore = "v2 runtime fetch ignores invalid headers instead of failing. It should fail"
-    )]
     // TODO: https://linear.app/tezos/issue/JSTZ-656/v2-fetch-should-fail-no-invalid-headers
+    // v2 runtime fetch ignores invalid headers instead of failing. It should fail
+    #[cfg(not(feature = "v2_runtime"))]
+    #[tokio::test]
     async fn returning_invalid_request_amount_fails() {
         let source = Address::User(jstz_mock::account2());
         let mut jstz_mock_host = JstzMockHost::default();
@@ -1351,12 +1345,10 @@ mod test {
         assert_eq!(balance_before, balance_after);
     }
 
-    #[tokio::test]
-    #[cfg_attr(
-        feature = "v2_runtime",
-        ignore = "v2 runtime does not support HostScript withdrawals yet"
-    )]
     // TODO: https://linear.app/tezos/issue/JSTZ-655/support-hostscript-fa-withdraw-in-v2
+    // v2 runtime does not support HostScript withdrawals yet
+    #[cfg(not(feature = "v2_runtime"))]
+    #[tokio::test]
     async fn host_script_fa_withdraw_from_smart_function_succeeds() {
         let receiver = Address::User(jstz_mock::account1());
         let source = Address::User(jstz_mock::account2());

--- a/crates/jstz_proto/src/logger.rs
+++ b/crates/jstz_proto/src/logger.rs
@@ -12,7 +12,7 @@ pub const REQUEST_START_PREFIX: &str = "[JSTZ:SMART_FUNCTION:REQUEST_START] ";
 pub const REQUEST_END_PREFIX: &str = "[JSTZ:SMART_FUNCTION:REQUEST_END] ";
 const RESPONSE_PREFIX: &str = "[JSTZ:RESPONSE]";
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(tag = "type")]
 pub enum RequestEvent {
     Start {
@@ -207,5 +207,21 @@ mod tests {
             503,
         );
         assert_eq!(String::from_utf8(buf.lock().unwrap().to_vec()).unwrap(), "[JSTZ:RESPONSE] {\"url\":\"foo://bar\",\"request_id\":\"foobar\",\"status_code\":503}\n");
+    }
+
+    #[test]
+    fn log_request_try_from_string() {
+        let json = r#"{"type":"Start","address":"KT1D5U6oBmtvYmjBtjzR5yPbrzxw8fa2kCn9","request_id":"start_request"}"#;
+        let event = super::RequestEvent::try_from_string(json).unwrap();
+        assert_eq!(
+            event,
+            super::RequestEvent::Start {
+                address: SmartFunctionHash::from_base58(
+                    "KT1D5U6oBmtvYmjBtjzR5yPbrzxw8fa2kCn9"
+                )
+                .unwrap(),
+                request_id: "start_request".to_string(),
+            }
+        );
     }
 }

--- a/crates/jstz_proto/src/runtime/v2/fetch/resources.rs
+++ b/crates/jstz_proto/src/runtime/v2/fetch/resources.rs
@@ -32,3 +32,19 @@ impl Resource for FetchResponseResource {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::rc::Rc;
+
+    #[tokio::test]
+    async fn test_read_vector() {
+        let data = vec![1, 2, 3, 4, 5];
+        let resource = Rc::new(FetchResponseResource {
+            body: RefCell::new(Some(Body::Vector(data.clone()))),
+        });
+        let buf_view = resource.read(1024).await.unwrap();
+        assert_eq!(buf_view.as_ref(), data.as_slice());
+    }
+}


### PR DESCRIPTION
# Context
Part of: [774](https://linear.app/tezos/issue/JSTZ-774/increase-jstz-proto-test-coverage-to-90percent)
Closes: [JSTZ-795: Add tests for `jstz_proto` except error.rs](https://linear.app/tezos/issue/JSTZ-795/add-tests-for-jstz-proto-except-errorrs)
# Description

Increased the `jstz_proto`'s test coverage from 76% to 83%
The remaining part that needs testing is [error.rs](https://app.codecov.io/gh/jstz-dev/jstz/blob/main/crates%2Fjstz_proto%2Fsrc%2Ferror.rs) ([task link](https://linear.app/tezos/issue/JSTZ-794/add-test-for-jstz-protoerrorrs))

# Manually testing the PR

codecov link

[Before](https://app.codecov.io/gh/jstz-dev/jstz/tree/main/crates%2Fjstz_proto)

[After](https://app.codecov.io/gh/jstz-dev/jstz/tree/leounoki%2Fjstz-774/crates%2Fjstz_proto)

