### PR TITLE
refactor(sequencer): extract retry logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2933,6 +2933,7 @@ dependencies = [
  "tezos_data_encoding",
  "thiserror 1.0.67",
  "tokio",
+ "tokio-retry2",
  "tokio-stream",
  "tokio-util",
  "tower",
@@ -5670,6 +5671,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-retry2"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1264d076dd34560544a2799e40e457bd07c43d30f4a845686b031bcd8455c84f"
+dependencies = [
+ "pin-project",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ tempfile = "3.10.0"
 thiserror = "1.0.56"
 tl = "0.7.7"
 tokio = { version = "1.36.0", features = ["full"] }
+tokio-retry2 = "0.5.7"
 tokio-stream = "0.1.14"
 tokio-util = "0.7.10"
 tower = "0.5.2"

--- a/crates/jstz_node/Cargo.toml
+++ b/crates/jstz_node/Cargo.toml
@@ -51,6 +51,7 @@ tezos-smart-rollup.workspace = true
 tezos_crypto_rs.workspace = true
 tezos_data_encoding.workspace = true
 thiserror.workspace = true
+tokio-retry2.workspace = true
 tokio-stream.workspace = true
 tokio-util.workspace = true
 tokio.workspace = true

--- a/crates/jstz_node/src/sequencer/inbox/mod.rs
+++ b/crates/jstz_node/src/sequencer/inbox/mod.rs
@@ -2,8 +2,6 @@
 #![allow(unreachable_code)]
 use std::sync::{Arc, RwLock};
 
-use std::time::Duration;
-
 use crate::sequencer::queue::OperationQueue;
 use crate::sequencer::runtime::{JSTZ_ROLLUP_ADDRESS, TICKETER};
 use anyhow::Result;
@@ -13,10 +11,12 @@ use async_trait::async_trait;
 use jstz_core::host::WriteDebug;
 use log::{debug, error};
 use parsing::{parse_inbox_message_hex, ParsedInboxMessage};
-#[cfg(test)]
 use std::future::Future;
+use std::time::Duration;
 use tezos_crypto_rs::hash::{ContractKt1Hash, SmartRollupHash};
 use tokio::{select, task::JoinHandle};
+use tokio_retry2::strategy::ExponentialFactorBackoff;
+use tokio_retry2::{Retry, RetryError};
 use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 
@@ -137,29 +137,42 @@ fn parse_inbox_messages(
         .collect()
 }
 
+/// Retry the given async function using exponential backoff until it succeeds.
+///
+/// - Starts at `initial_delay_ms` milliseconds
+/// - Backs off exponentially
+/// - Max delay is capped at 5 seconds
+pub(crate) async fn retry_expo<T, E, Fut>(
+    initial_delay_ms: u64,
+    f: impl FnMut() -> Fut,
+) -> T
+where
+    Fut: Future<Output = Result<T, RetryError<E>>>,
+{
+    let backoff = ExponentialFactorBackoff::from_millis(initial_delay_ms, 2.0)
+        .max_delay(Duration::from_secs(5));
+    match Retry::spawn(backoff, f).await {
+        Ok(val) => val,
+        _ => unreachable!("Exponential backoff is infinite; this should never fail"),
+    }
+}
+
 // Retry fetching the block indefinitely because:
 // 1. We cannot progress without successfully fetching the block data
 // 2. The block data must eventually become available (it's part of the chain)
 // 3. Temporary network issues or API unavailability should not stop the sequencer
 // 4. The exponential backoff ensures we don't overwhelm the API
 async fn retry_fetch_block(rollup_endpoint: &str, block_level: u32) -> BlockResponse {
-    let mut attempts = 0;
-    let mut backoff = Duration::from_millis(200);
-    const MAX_BACKOFF: Duration = Duration::from_secs(5);
-    loop {
+    retry_expo(200, || async {
         match api::fetch_block(rollup_endpoint, block_level).await {
-            Ok(block) => return block,
+            Ok(block) => Ok(block),
             Err(e) => {
-                attempts += 1;
-                error!(
-                    "Retry {}: Failed to fetch block {}: {:?}",
-                    attempts, block_level, e
-                );
-                tokio::time::sleep(backoff).await;
-                backoff = std::cmp::min(backoff * 2, MAX_BACKOFF);
+                error!("Failed to fetch block {}: {:?}", block_level, e);
+                Err(RetryError::transient(e))
             }
         }
-    }
+    })
+    .await
 }
 
 #[cfg(test)]
@@ -174,7 +187,8 @@ mod tests {
         sync::{Arc, Mutex, RwLock},
     };
     use tokio::task;
-    use tokio::time::sleep;
+    use tokio::time::{sleep, Instant};
+    use tokio_retry2::RetryError;
 
     fn mock_deploy_op() -> (&'static str, &'static str) {
         let op = "0100c3ea4c18195bcfac262dcb29e3d803ae746817390000000040000000000000002c33da9518a6fce4c22a7ba352580d9097cacc9123df767adb40871cef49cbc7efebffcb4a1021b514dca58450ac9c50e221deaeb0ed2034dd36f1ae2de11f0f00000000200000000000000073c58fbff04bb1bc965986ad626d2a233e630ea253d49e1714a0bc9610c1ef450000000000000000000000000901000000000000636f6e7374204b4559203d2022636f756e746572223b0a0a636f6e73742068616e646c6572203d202829203d3e207b0a20206c657420636f756e746572203d204b762e676574284b4559293b0a2020636f6e736f6c652e6c6f672860436f756e7465723a20247b636f756e7465727d60293b0a202069662028636f756e746572203d3d3d206e756c6c29207b0a20202020636f756e746572203d20303b0a20207d20656c7365207b0a20202020636f756e7465722b2b3b0a20207d0a20204b762e736574284b45592c20636f756e746572293b0a202072657475726e206e657720526573706f6e736528293b0a7d3b0a0a6578706f72742064656661756c742068616e646c65723b0a0000000000000000";
@@ -294,6 +308,34 @@ mod tests {
         assert_eq!(hash_of(&op), op_hash);
 
         handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_retry_expo_retries_and_succeeds() {
+        let attempts = Arc::new(Mutex::new(0));
+        let attempts_clone = attempts.clone();
+        let fail_times = 3;
+        let time_before = Instant::now();
+        let result = retry_expo(10, || {
+            let attempts_clone = attempts_clone.clone();
+            async move {
+                let mut lock = attempts_clone.lock().unwrap();
+                *lock += 1;
+                if *lock <= fail_times {
+                    Err(RetryError::transient("fail"))
+                } else {
+                    Ok("success")
+                }
+            }
+        })
+        .await;
+        let time_after = Instant::now();
+        let duration = time_after.duration_since(time_before);
+        // 10 + 20 + 40 = 70ms
+        assert!(duration > Duration::from_millis(70));
+        assert!(duration < Duration::from_millis(80));
+        assert_eq!(result, "success");
+        assert_eq!(*attempts.lock().unwrap(), fail_times + 1);
     }
 }
 


### PR DESCRIPTION
# Context

Refactor inbox monitor

# Description

Implement `retry_expo` that uses tokio-retry for exponential backoff retry. This function can be reused later for connecting to the block stream in #1193 

# Manually testing the PR

cargo test --package jstz_node --test sequencer -- run_sequencer --exact --show-output                          
