### PR TITLE
chore: upload runtime api coverage report

### DIFF
--- a/.github/workflows/deploy-runtime-api-coverage-report.yml
+++ b/.github/workflows/deploy-runtime-api-coverage-report.yml
@@ -1,0 +1,21 @@
+name: Deploy runtime API coverage report
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_ref:
+        description: Ref that the build runs against. If not provided, HEAD will be used.
+        type: string
+
+
+jobs:
+  runtime_api_coverage:
+    name: Runtime API coverage
+    uses: jstz-dev/jstz/.github/workflows/runtime-api-coverage.yml@main
+    secrets:
+      repo_token: ${{ secrets.RUNTIME_API_REPORT_REPO }}
+    with:
+      dest_repo: jstz-dev/nodejs-compat-matrix
+      dest_branch: deploy
+      build_ref: ${{ inputs.build_ref }}
+      deploy_report: true

--- a/.github/workflows/runtime-api-coverage.yml
+++ b/.github/workflows/runtime-api-coverage.yml
@@ -3,21 +3,21 @@ name: Runtime API coverage
 on:
   workflow_call:
     inputs:
-      target_repo:
-        description: Target repository (owner/repo_name) where the report will be deployed.
-        required: true
+      dest_repo:
+        description: Destination repository (owner/repo_name) where the report will be deployed.
         type: string
-      target_branch:
-        description: Name of the branch in the target repository where the report will be deployed.
-        required: true
+      dest_branch:
+        description: Name of the branch in the destination repository where the report will be deployed.
         type: string
       build_ref:
-        description: Ref that triggered the build. If not provided, the commit that triggers the build will be used.
+        description: Ref that triggered the build. If not provided, the SHA of the commit that triggered the build will be used.
         type: string
+      deploy_report:
+        description: Flag indicating if the report should be deployed.
+        type: boolean
     secrets:
       repo_token:
-        description: API token that gives access to manage the target repo.
-        required: true
+        description: API token that gives access to manage the destination repository.
 
 jobs:
   runtime_api_coverage:
@@ -46,9 +46,20 @@ jobs:
 
   push_api_coverage_report:
     name: Push runtime API coverage report
+    if: ${{ inputs.deploy_report }}
     needs: runtime_api_coverage
     runs-on: ubuntu-latest
     steps:
+      - name: Check input values
+        run: |
+          if [ -z "${{ inputs.dest_repo }}" ]; then
+              echo "dest_repo is unset or set to the empty string"
+              exit 1
+          fi
+          if [ -z "${{ inputs.dest_branch }}" ]; then
+              echo "dest_branch is unset or set to the empty string"
+              exit 1
+          fi
       - name: Download report
         uses: actions/download-artifact@v4
         with:
@@ -57,16 +68,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          repository: ${{ inputs.target_repo }}
-          # This is the branch that the report will be pushed to in the target repo
-          ref: ${{ inputs.target_branch }}
-          # This token should have write access to the target repo content
+          repository: ${{ inputs.dest_repo }}
+          # This is the branch that the report will be pushed to in the destination repo
+          ref: ${{ inputs.dest_branch }}
+          # This token should have write access to the content of the destination repository
           token: ${{ secrets.repo_token }}
           path: dest_repo
       - uses: pnpm/action-setup@v4
         with:
           package_json_file: dest_repo/package.json
-      - name: push to destination repo
+      - name: Push to destination repo
         run: |
           mv $GITHUB_WORKSPACE/report/output.json $GITHUB_WORKSPACE/dest_repo/data/jstz.json
           cd $GITHUB_WORKSPACE/dest_repo
@@ -85,4 +96,4 @@ jobs:
           git config user.email "<>"
           git add .
           git commit -m "Report built from ${{ github.sha }}"
-          git push origin ${{ inputs.target_branch }}
+          git push origin ${{ inputs.dest_branch }}

--- a/.github/workflows/runtime-api-coverage.yml
+++ b/.github/workflows/runtime-api-coverage.yml
@@ -3,9 +3,21 @@ name: Runtime API coverage
 on:
   workflow_call:
     inputs:
+      target_repo:
+        description: Target repository (owner/repo_name) where the report will be deployed.
+        required: true
+        type: string
+      target_branch:
+        description: Name of the branch in the target repository where the report will be deployed.
+        required: true
+        type: string
       build_ref:
         description: Ref that triggered the build. If not provided, the commit that triggers the build will be used.
         type: string
+    secrets:
+      repo_token:
+        description: API token that gives access to manage the target repo.
+        required: true
 
 jobs:
   runtime_api_coverage:
@@ -31,3 +43,46 @@ jobs:
           name: report
           path: crates/jstz_runtime/output.json
           retention-days: 1
+
+  push_api_coverage_report:
+    name: Push runtime API coverage report
+    needs: runtime_api_coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download report
+        uses: actions/download-artifact@v4
+        with:
+          name: report
+          path: report
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          repository: ${{ inputs.target_repo }}
+          # This is the branch that the report will be pushed to in the target repo
+          ref: ${{ inputs.target_branch }}
+          # This token should have write access to the target repo content
+          token: ${{ secrets.repo_token }}
+          path: dest_repo
+      - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: dest_repo/package.json
+      - name: push to destination repo
+        run: |
+          mv $GITHUB_WORKSPACE/report/output.json $GITHUB_WORKSPACE/dest_repo/data/jstz.json
+          cd $GITHUB_WORKSPACE/dest_repo
+          build_ref=${{ inputs.build_ref }}
+          short_sha=$(echo ${GITHUB_SHA} | cut -c1-7)
+          cat report/src/data/versionMap.json |  jq ". | with_entries(if .key == \"jstz\" then .value = \"${build_ref:-$short_sha}\" else . end)" > /tmp/tmp.json && mv /tmp/tmp.json report/src/data/versionMap.json
+
+          if [[ ! `git status --porcelain` ]]; then
+            echo "No change in coverage"
+            exit 0
+          fi
+
+          pnpm install --frozen-lockfile && pnpm generate:timestamp && pnpm run generate:table
+
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+          git add .
+          git commit -m "Report built from ${{ github.sha }}"
+          git push origin ${{ inputs.target_branch }}

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -46,8 +46,3 @@ jobs:
   runtime_api_coverage:
     name: Runtime API coverage
     uses: jstz-dev/jstz/.github/workflows/runtime-api-coverage.yml@main
-    secrets:
-      repo_token: ${{ secrets.RUNTIME_API_REPORT_REPO }}
-    with:
-      target_repo: jstz-dev/nodejs-compat-matrix
-      branch: deploy

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -46,3 +46,8 @@ jobs:
   runtime_api_coverage:
     name: Runtime API coverage
     uses: jstz-dev/jstz/.github/workflows/runtime-api-coverage.yml@main
+    secrets:
+      repo_token: ${{ secrets.RUNTIME_API_REPORT_REPO }}
+    with:
+      target_repo: jstz-dev/nodejs-compat-matrix
+      branch: deploy


### PR DESCRIPTION
# Context

Completes JSTZ-771.
[JSTZ-771](https://linear.app/tezos/issue/JSTZ-771/comparison-doc-generated-from-wpt)

# Description

Updated workflows such that runtime API coverage reports can be uploaded and deployed as a webpage.

# Manually testing the PR

[Test run](https://github.com/jstz-dev/jstz/actions/runs/16340885022)
[Test deployment](https://github.com/huancheng-trili/test-matrix/actions/runs/16341016086)
