### PR TITLE
fix: include git install hooks as part of nix 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ fmt-check:
 lint:
 #  Jstzd has to processes a non-empty kernel in its build script
 	@echo "ignore" > $(JSTZD_KERNEL_PATH)
-	@cargo clippy --all-targets -- --deny warnings
+	@cargo clippy --all-targets --features skip-wpt -- --deny warnings
 	@rm -f $(JSTZD_KERNEL_PATH)
 
 .PHONY: run-manual-test

--- a/crates/jstz_runtime/tests/api_coverage/main.rs
+++ b/crates/jstz_runtime/tests/api_coverage/main.rs
@@ -1,3 +1,4 @@
+#![cfg(not(feature = "skip-wpt"))]
 use std::path::Path;
 
 use deno_core::StaticModuleLoader;
@@ -14,7 +15,6 @@ deno_core::extension!(
     esm = [dir "tests/api_coverage", "entrypoint.js", "baseline.js", "utils.js"]
 );
 
-#[cfg_attr(feature = "skip-wpt", ignore)]
 #[tokio::test]
 async fn test() {
     let mut tx = Transaction::default();

--- a/flake.nix
+++ b/flake.nix
@@ -322,6 +322,11 @@
                     npm install --lockfile-version 2
                     export PATH="$PWD/node_modules/.bin/:$PATH"
                   ''
+                  ''
+                    if [ ! -f ".git/hooks/pre-commit" ]; then
+                      ./scripts/install-hooks.sh
+                    fi
+                  ''
                 ]
                 ++ lib.optionals stdenv.isLinux [
                   ''


### PR DESCRIPTION
# Context

Ensure code is formatted/linted and dev env builds for everyone

# Description

* Install git pre-commit hook as part of provisioning nix dev shel
* Ignore the entire `crates/jstz_runtime/tests/api_coverage/main.rs` file when `skip-wpt` is defined. Since the test depends on files pulled on an ad-hoc, `cargo clippy` (via `make lint`) fails to compile

# Manually testing the PR
```
make build
make fmt
make lint
```
<!-- Describe how reviewers and approvers can test this PR. -->
