### PR TITLE
fix(sequencer): clean up feature flag

### DIFF
--- a/crates/jstz_node/src/sequencer/worker.rs
+++ b/crates/jstz_node/src/sequencer/worker.rs
@@ -16,7 +16,7 @@ use log::warn;
 
 use super::{db::Db, inbox::parsing::ParsedInboxMessage, queue::OperationQueue};
 
-#[cfg(feature = "v2_runtime")]
+#[cfg(feature = "oracle")]
 use super::inbox::parsing::LevelInfo;
 
 pub struct Worker {
@@ -114,7 +114,7 @@ pub fn spawn(
     })
 }
 
-#[cfg(feature = "v2_runtime")]
+#[cfg(feature = "oracle")]
 // See [jstz_kernel::riscv_kernel::run_event_loop]
 fn run_event_loop(
     tokio_rt: tokio::runtime::Runtime,


### PR DESCRIPTION
# Context

Cleaning up feature flags in the sequencer in preparation for the riscv pvm setup.

# Description

Replaced two references to the feature flag `v2_runtime` with `oracle`. This should be fine as the only reference to the guarded function `run_event_loop` is also guarded by that `oracle` feature flag.

# Manually testing the PR

Before the change was made, there was this warning:
```
$ cd $(git rev-parse --show-toplevel)/crates/jstz_node && cargo clippy --fix --allow-dirty --allow-staged --features v2_runtime
warning: function `run_event_loop` is never used
   --> crates/jstz_node/src/sequencer/worker.rs:119:4
    |
119 | fn run_event_loop(
    |    ^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default
```

Now it is cleared.