### PR TITLE
fix(proto): inbox_id is not unique (only unique to the level)

### DIFF
--- a/crates/jstz_kernel/src/parsing.rs
+++ b/crates/jstz_kernel/src/parsing.rs
@@ -1,6 +1,6 @@
 use jstz_crypto::public_key_hash::PublicKeyHash;
 use jstz_crypto::smart_function_hash::SmartFunctionHash;
-use jstz_proto::operation::internal::FaDeposit;
+use jstz_proto::operation::internal::{FaDeposit, InboxId};
 use jstz_proto::{context::account::Address, Result};
 use num_traits::ToPrimitive;
 use tezos_smart_rollup::michelson::{ticket::FA2_1Ticket, MichelsonContract};
@@ -19,7 +19,7 @@ pub fn try_parse_contract(contract: &Contract) -> Result<Address> {
 }
 
 pub fn try_parse_fa_deposit(
-    inbox_id: u32,
+    inbox_id: InboxId,
     ticket: FA2_1Ticket,
     receiver: MichelsonContract,
     proxy_contract: Option<MichelsonContract>,
@@ -57,7 +57,7 @@ mod test {
     use jstz_crypto::smart_function_hash::SmartFunctionHash;
     use jstz_proto::{
         context::account::{Address, Addressable},
-        operation::internal::FaDeposit,
+        operation::internal::{FaDeposit, InboxId},
     };
     use tezos_smart_rollup::{
         michelson::{
@@ -94,7 +94,10 @@ mod test {
         .unwrap();
         let receiver = jstz_pkh_to_michelson(&jstz_mock::account1());
         let proxy_contract = Some(jstz_sfh_to_michelson(&jstz_mock::sf_account1()));
-        let inbox_id = 41717;
+        let inbox_id = InboxId {
+            l1_level: 1,
+            l1_message_id: 41717,
+        };
         let ticket_hash = ticket.hash().unwrap();
 
         let fa_deposit = try_parse_fa_deposit(inbox_id, ticket, receiver, proxy_contract)
@@ -123,7 +126,10 @@ mod test {
         .unwrap();
         let receiver = jstz_pkh_to_michelson(&jstz_mock::account2());
         let proxy_contract = Some(jstz_pkh_to_michelson(&jstz_mock::account1()));
-        let inbox_id = 41717;
+        let inbox_id = InboxId {
+            l1_level: 1,
+            l1_message_id: 41717,
+        };
 
         let fa_deposit = try_parse_fa_deposit(inbox_id, ticket, receiver, proxy_contract);
         assert!(fa_deposit

--- a/crates/jstz_kernel/src/riscv_kernel.rs
+++ b/crates/jstz_kernel/src/riscv_kernel.rs
@@ -14,7 +14,7 @@ use tezos_smart_rollup::prelude::{debug_msg, Runtime};
 
 use crate::{
     handle_message,
-    inbox::{self, LevelInfo, ParsedInboxMessage},
+    inbox::{read_message, LevelInfo, ParsedInboxMessage},
     read_injector, read_ticketer, INJECTOR, TICKETER,
 };
 
@@ -98,25 +98,6 @@ async fn run_event_loop(rt: &mut impl Runtime) {
         tokio::task::yield_now().await;
         tokio::task::yield_now().await;
     }
-}
-
-// We reach None in 3 cases
-// 1. No more inputs
-// 2. Input targetting the wrong rollup
-// 3. Parsing failures
-fn read_message(
-    rt: &mut impl Runtime,
-    ticketer: &ContractKt1Hash,
-) -> Option<ParsedInboxMessage> {
-    let input = rt.read_input().ok()??;
-    let jstz_rollup_address = rt.reveal_metadata().address();
-    inbox::parse_inbox_message(
-        rt,
-        input.id,
-        input.as_ref(),
-        ticketer,
-        &jstz_rollup_address,
-    )
 }
 
 #[cfg(test)]

--- a/crates/jstz_node/Cargo.toml
+++ b/crates/jstz_node/Cargo.toml
@@ -70,6 +70,6 @@ path = "src/main.rs"
 
 [features]
 persistent-logging = []
-v2_runtime = ["jstz_proto/v2_runtime"]
+v2_runtime = ["jstz_proto/v2_runtime", "jstz_kernel/v2_runtime"]
 oracle = ["v2_runtime"]
 inject_inbox = []

--- a/crates/jstz_node/tests/sequencer.rs
+++ b/crates/jstz_node/tests/sequencer.rs
@@ -11,7 +11,10 @@ use jstz_node::sequencer::{inbox::api::BlockResponse, runtime::JSTZ_ROLLUP_ADDRE
 use jstz_proto::{
     context::account::{Address, Nonce},
     executor::fa_deposit::FaDepositReceipt,
-    operation::{Content, DeployFunction, Operation, RunFunction, SignedOperation},
+    operation::{
+        internal::InboxId, Content, DeployFunction, Operation, RunFunction,
+        SignedOperation,
+    },
     receipt::{
         DeployFunctionReceipt, DepositReceipt, Receipt, ReceiptContent, ReceiptResult,
         RunFunctionReceipt,
@@ -340,15 +343,35 @@ fn mock_deploy_op() -> SignedOperation {
 /// mock deposit op to transfer 30000 mutez to tz1dbGzJfjYFSjX8umiRZ2fmsAQsk8XMH1E9
 fn mock_deposit_op() -> (&'static str, &'static str) {
     let op = "0000050507070a000000160000c4ecf33f52c7b89168cfef8f350818fee1ad08e807070a000000160146d83d8ef8bce4d8c60a96170739c0269384075a00070707070000030600b0d40354267463f8cf2844e4d8b20a76f0471bcb2137fd0002298c03ed7d454a101eb7022bc95f7e5f41ac78c3ea4c18195bcfac262dcb29e3d803ae74681739";
-    let op_hash = "d236fca2b92ca42da90327820d7fe73c8ad22ea13cd8d761adc6e98822195c77";
+    let op_hash = "09952d767f9ebf76b0edd3f837596b71f3b8193f13be4cbfb09e5eec691bbde3";
     (op_hash, op)
+}
+
+#[test]
+fn mock_deposit_op_hash_matches_actual_hash() {
+    let (op_hash, _) = mock_deposit_op();
+    let inbox_id = InboxId {
+        l1_level: 123,
+        l1_message_id: 3,
+    };
+    assert_eq!(inbox_id.hash().to_string(), op_hash);
 }
 
 /// mock fa deposit op to transfer 1000 FA token to `tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN`
 fn mock_deposit_fa_op() -> (&'static str, &'static str) {
     let op = "0000050807070a000000160000e7670f32038107a59a2b9cfefae36ea21f5aa63c070705090a0000001601238f371da359b757db57238e9f27f3c48234defa0007070a0000001601207905b1a5abdace0a6b5bff0d71a467d5b85cf500070707070001030600a80f9424c685d3f69801ff6e3f2cfb74b250f00988e100e7670f32038107a59a2b9cfefae36ea21f5aa63cc3ea4c18195bcfac262dcb29e3d803ae74681739";
-    let op_hash = "34461635d31fd734cee1f20839218ffef78785d536b348b04204510012a8cbd2";
+    let op_hash = "89873bc722b5a0744657ed0bd6251f30989bea2059a52d080308c1d21923b053";
     (op_hash, op)
+}
+
+#[test]
+fn mock_fa_deposit_op_hash_matches_actual_hash() {
+    let (op_hash, _) = mock_deposit_fa_op();
+    let inbox_id = InboxId {
+        l1_level: 123,
+        l1_message_id: 4,
+    };
+    assert_eq!(inbox_id.hash().to_string(), op_hash);
 }
 
 async fn check_worker_health(client: &Client, base_uri: &str) {

--- a/crates/jstz_proto/src/executor/fa_deposit.rs
+++ b/crates/jstz_proto/src/executor/fa_deposit.rs
@@ -178,6 +178,7 @@ mod test {
             fa_deposit::{FaDeposit, FaDepositReceipt},
             smart_function,
         },
+        operation::internal::InboxId,
         receipt::{Receipt, ReceiptContent, ReceiptResult},
     };
     use jstz_core::kv::Transaction;
@@ -186,7 +187,10 @@ mod test {
 
     fn mock_fa_deposit(proxy: Option<SmartFunctionHash>) -> FaDeposit {
         FaDeposit {
-            inbox_id: 34,
+            inbox_id: InboxId {
+                l1_level: 1,
+                l1_message_id: 34,
+            },
             amount: 42,
             receiver: Address::User(jstz_mock::account2()),
             proxy_smart_function: proxy.map(Address::SmartFunction),


### PR DESCRIPTION
# Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

Fixes [JSTZ-582](https://linear.app/tezos/issue/JSTZ-582/fix-inbox-id-in-deposit-and-fadeposit)

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

This PR replaces the `u32` `inbox_id` with a pair of `u32`s, consisting of the level and the original `inbox_id` (unique within a level). Together they define a globally unique ID for a given inbox message.

# Manually testing the PR

<!-- Describe how reviewers and approvers can test this PR. -->

```
make test
```