### PR TITLE
feat(nix): use v8 with caged heap aligned to page size

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -206,8 +206,8 @@
           # preserve the hash compatability among case (in/)sensitive file systems
           riscvV8 = with pkgs; let
             tarball = fetchurl {
-              url = "https://raw.githubusercontent.com/jstz-dev/rusty_v8/9730f78b1d3fb8320441e3e91926fa09c67b1332/librusty_v8.tar.gz";
-              sha256 = "sha256-+XDNEhBzsCdxyZ/NIvOPX/4Lyi9tacB203Dxga/msSw=";
+              url = "https://raw.githubusercontent.com/jstz-dev/rusty_v8/63dcedfc7ba101a4bbf4ce9fd94bba8ff71f8824/librusty_v8.tar.gz";
+              sha256 = "sha256-Wi4guXiewq9zmAme5Oos31Gq4YJ5Oh2/yOxdm+NUPhM=";
             };
           in
             runCommand "fetch-riscv-v8" {} ''


### PR DESCRIPTION
# Context
Aligns v8 caged heap to page size to reduce redundant memory request

Depends on https://github.com/jstz-dev/rusty_v8/pull/6
Closes https://linear.app/tezos/issue/JSTZ-839disable-pointer-compression-in-v8
<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
Updates nix to point to the v8 archive that aligns cage heap to page size. See the rusty_v8 related PR for implementation context and details
https://github.com/jstz-dev/rusty_v8/pull/6

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
To run test
```
make run-manual-test
```
To generate results (linux only). For mac, you can run manual test and open Activity Monitor.
```
./scripts/heaptrack.sh
```
# Heaptrack Summary
```
total runtime: 3.929000s.
calls to allocation functions: 3516312 (894963/s)
temporary memory allocations: 469705 (119548/s)
peak heap memory consumption: 1.23G
peak RSS (including heaptrack overhead): 5.99G
total memory leaked: 7.85M
```


<!-- Describe how reviewers and approvers can test this PR. -->
