### PR TITLE
fix(tps_bench): bench run uses dirname for path resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ crates/jstzd/resources/jstz_rollup/jstz_kernel.wasm
 # Heaptrack raw data
 *.zst
 
+*.log
+inbox.json

--- a/crates/jstz_tps_bench/run.sh
+++ b/crates/jstz_tps_bench/run.sh
@@ -6,14 +6,29 @@ inbox_file_path=./inbox.json
 n_transfer=10
 log_file_path=./output.log
 result_path=./result.log
+dir="$(realpath $(dirname "$0"))"
+
+case "${DISABLE_BUILD}" in
+1 | true | yes) ;;
+*)
+  unset NIX_LDFLAGS && RUSTY_V8_ARCHIVE=$RISCV_V8_ARCHIVE_DIR/librusty_v8.a \
+    RUSTY_V8_SRC_BINDING_PATH=$RISCV_V8_ARCHIVE_DIR/src_binding.rs \
+    cargo build \
+    -p jstz_kernel \
+    --no-default-features \
+    --features riscv_kernel \
+    --release \
+    --target riscv64gc-unknown-linux-musl
+  ;;
+esac
 
 cargo build --bin bench --features v2_runtime
 
 # Generate inbox file
-../../target/debug/bench generate --transfers $n_transfer --inbox-file $inbox_file_path --address $rollup_address
+$dir/../../target/debug/bench generate --transfers $n_transfer --inbox-file $inbox_file_path --address $rollup_address
 
 # Run riscv kernel with inbox file
-riscv-sandbox run --timings --address $rollup_address --inbox-file $inbox_file_path --input ../../target/riscv64gc-unknown-linux-musl/release/kernel-executable >$log_file_path
+riscv-sandbox run --timings --address $rollup_address --inbox-file $inbox_file_path --input $dir/../../target/riscv64gc-unknown-linux-musl/release/kernel-executable >$log_file_path
 
 # Process results and calculate TPS
-../../target/debug/bench results --expected-transfers $n_transfer --inbox-file $inbox_file_path --log-file $log_file_path >$result_path
+$dir/../../target/debug/bench results --expected-transfers $n_transfer --inbox-file $inbox_file_path --log-file $log_file_path >$result_path


### PR DESCRIPTION
# Context
Allows internal paths to resolve correctly when `jstz_tps_bench/run.sh` from any root path
<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
Sets base directory of relative paths to the directory of the script. Also add kernel compilation as the first step.
<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
```
./crates/jstz_tps_bench/run.sh
```
```
cd crates && ./jstz_tps_bench/run.sh
```
```
cd crates/jstz_tps_bench && ./run.sh
```

<!-- Describe how reviewers and approvers can test this PR. -->
