### PR TITLE
feat(core): add storage update event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,6 +2824,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "serde_json",
+ "serde_with",
  "tezos-smart-rollup",
  "tezos-smart-rollup-host",
  "tezos-smart-rollup-mock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ serde = { version = "1.0.196", features = ["derive", "rc"] }
 serde-big-array = "0.5.1"
 serde-wasm-bindgen = "0.6.5"
 serde_json = "1.0.107"
-serde_with = { version = "3.6.1", features = ["macros"] }
+serde_with = { version = "3.6.1", features = ["macros", "base64"] }
 serde_bytes = "0.11.17"
 signal-hook = "0.3.17"
 syntect = "5.2.0"

--- a/crates/jstz_core/Cargo.toml
+++ b/crates/jstz_core/Cargo.toml
@@ -25,6 +25,7 @@ parking_lot.workspace = true
 serde.workspace = true
 serde-big-array.workspace = true
 serde_json.workspace = true
+serde_with.workspace = true
 tezos_crypto_rs.workspace = true
 tezos_data_encoding.workspace = true
 tezos-smart-rollup-host.workspace = true

--- a/crates/jstz_core/src/event.rs
+++ b/crates/jstz_core/src/event.rs
@@ -4,32 +4,47 @@ use serde::{de::DeserializeOwned, Serialize};
 use tezos_smart_rollup::prelude::debug_msg;
 
 /// Jstz Events
-pub trait Event: PartialEq + Serialize + DeserializeOwned {
+pub trait Event: PartialEq + StringEncodable {
     fn tag() -> &'static str;
 }
 
-/// Responsible for publishing events to the kernel debug log
-#[derive(Debug, Default)]
-pub struct EventPublisher;
+/// A trait to encode to string and decode from string symmetrically.
+pub trait StringEncodable: Sized {
+    fn to_string(&self) -> Result<String>;
+    fn from_str(s: &str) -> Result<Self>;
+}
 
-impl EventPublisher {
+impl<T: Serialize + DeserializeOwned> StringEncodable for T {
+    fn to_string(&self) -> Result<String> {
+        Ok(serde_json::to_string(self).map_err(EncodeError::from)?)
+    }
+
+    fn from_str(s: &str) -> Result<Self> {
+        Ok(serde_json::from_str(s).map_err(DecodeError::from)?)
+    }
+}
+
+/// Responsible for publishing events to the kernel debug log
+pub trait EventPublish: Event {
     /// Jstz events are published as single line in the kernel debug log with the
-    /// schema "[Event::tag()]<json payload>\n"
-    pub fn publish_event<R, E: Event>(rt: &R, event: &E) -> Result<()>
+    /// schema "[Event::tag()]<payload>\n"
+    fn publish_event<R>(self, rt: &R) -> Result<()>
     where
         R: HostRuntime,
     {
-        let json = serde_json::to_string(event).map_err(EncodeError::from)?;
-        let prefix = E::tag();
-        debug_msg!(rt, "[{prefix}]{json}\n");
+        let payload = self.to_string()?;
+        let prefix = <Self as Event>::tag();
+        debug_msg!(rt, "[{prefix}]{payload}\n");
         Ok(())
     }
 }
 
+impl<E: Event> EventPublish for E {}
+
 pub fn decode_line<E: Event>(input: &str) -> Result<E> {
     let input = input.trim();
     let str = parse_line::<E>(input)?;
-    Ok(serde_json::from_str(str).map_err(DecodeError::from)?)
+    E::from_str(str)
 }
 
 fn parse_line<E: Event>(input: &str) -> std::result::Result<&str, DecodeError> {
@@ -102,7 +117,7 @@ impl nom::error::ParseError<&str> for NomError {
 #[cfg(test)]
 mod test {
 
-    use crate::event::{decode_line, Event, EventPublisher, NomError};
+    use crate::event::{decode_line, Event, EventPublish, NomError};
     use bincode::{Decode, Encode};
     use jstz_crypto::{hash::Hash, public_key_hash::PublicKeyHash};
     use nom::error::ParseError;
@@ -164,7 +179,7 @@ mod test {
             )
         });
         let event = mock_event();
-        EventPublisher::publish_event(&host, &event).unwrap();
+        event.clone().publish_event(&host).unwrap();
         let head_line = sink.lines().first().unwrap().clone();
         assert_eq!(
             head_line,

--- a/crates/jstz_core/src/kv/mod.rs
+++ b/crates/jstz_core/src/kv/mod.rs
@@ -9,6 +9,7 @@ use tezos_smart_rollup_host::{path::Path, runtime::Runtime};
 use crate::error::Result;
 
 pub mod outbox;
+pub mod storage_update;
 pub mod transaction;
 pub mod value;
 

--- a/crates/jstz_proto/src/runtime/v2/oracle/oracle.rs
+++ b/crates/jstz_proto/src/runtime/v2/oracle/oracle.rs
@@ -4,7 +4,7 @@ use futures::{
     channel::oneshot::{channel, Receiver, Sender},
     future::UnwrapOrElse,
 };
-use jstz_core::event::{EventError, EventPublisher};
+use jstz_core::event::{EventError, EventPublish};
 use jstz_core::{
     host::HostRuntime,
     kv::{Storage, Transaction},
@@ -107,7 +107,7 @@ impl Oracle {
         OracleRequestStorage::insert(rt, &oracle_request);
         self.active_requests
             .insert(request_id, RequestMetadata { sender, timeout });
-        EventPublisher::publish_event(rt, &oracle_request)?;
+        oracle_request.publish_event(rt)?;
         Ok(rx)
     }
 


### PR DESCRIPTION
## Context

Part of: [JSTZ-813 – Leak StorageUpdateEvent from kernel](https://linear.app/tezos/issue/JSTZ-813/leak-storageupdateevent-from-kernel)

This PR introduces the`BatchStorageUpdate` event, which will be used to reconstruct storage state in `jstz-node`. The event is published from within transactions, as will be fully integrated in a follow-up PR (#1251).


## Description

- **Refactored `event.rs`:**
  - The `Event` trait now provides two symmetric methods: `to_string` and `from_str` (with JSON as the default implementation).  
    The purpose of `Event` is to leak data from the kernel, and since the only way to do so is via the kernel debug log (which requires string conversion), these methods are appropriate.  This also makes it easy to customize serialization for each event type (e.g, JSON for sf logs event vs HEX for storage update event etc)
  - Replaced the `EventPublisher` struct with trait, which is automatically implemented for all `Event` types. This trait consumes the event after publishing it.

- **Added `kv::storage_update.rs`:**
  - Introduced the `BatchStorageUpdate` event, which is a collection of `StorageUpdate` items.  
    Each `StorageUpdate` represents either an insertion (key-value pair) or a removal (key only). Check #1251 on how it's used. 
  - Used Hex for encoding the value as it's faster than Base64 although it requires more space.
---

## Manual Testing

Unit tests have been added. To run them:

```sh
cargo test --package jstz_core
```