### PR TITLE
feat(core): publish storage update event from transaction

### DIFF
--- a/crates/jstz_core/src/event.rs
+++ b/crates/jstz_core/src/event.rs
@@ -115,7 +115,7 @@ impl nom::error::ParseError<&str> for NomError {
 }
 
 #[cfg(test)]
-mod test {
+pub(crate) mod test {
 
     use crate::event::{decode_line, Event, EventPublish, NomError};
     use bincode::{Decode, Encode};

--- a/crates/jstz_core/src/kv/transaction.rs
+++ b/crates/jstz_core/src/kv/transaction.rs
@@ -9,7 +9,7 @@ use std::{
 use parking_lot::{ArcMutexGuard, Mutex, RawMutex};
 
 use derive_more::{Deref, DerefMut};
-
+use tezos_smart_rollup::prelude::debug_msg;
 use tezos_smart_rollup_host::{path::OwnedPath, runtime::Runtime};
 
 use super::{
@@ -19,7 +19,10 @@ use super::{
     value::{BoxedValue, Value},
     Storage,
 };
-use crate::error::{KvError, Result};
+use crate::{
+    error::{KvError, Result},
+    kv::storage_update::BatchStorageUpdate,
+};
 
 /// A transaction is a 'lazy' snapshot of the persistent key-value store from
 /// the point in time when the transaction began. Modifications to new or old
@@ -341,6 +344,9 @@ impl InnerTransaction {
     }
 
     /// Commit a transaction.
+    ///
+    /// Publishes storage update event for the final commit.
+    /// If the transaction has no changes, no event is published.
     fn commit(&mut self, rt: &mut impl Runtime) -> Result<()> {
         let curr_ctxt = self.stack.pop().ok_or(KvError::TransactionStackEmpty)?;
 
@@ -363,12 +369,23 @@ impl InnerTransaction {
 
             prev_ctxt.outbox_queue.extend(curr_ctxt.outbox_queue);
         } else {
+            let mut storage_updates = BatchStorageUpdate::new(
+                curr_ctxt.remove_edits.len() + curr_ctxt.insert_edits.len(),
+            );
+
             for key in &curr_ctxt.remove_edits {
-                Storage::remove(rt, key)?
+                Storage::remove(rt, key)?;
+                storage_updates.push_remove(key);
             }
 
             for (key, value) in curr_ctxt.insert_edits {
-                Storage::insert(rt, &key, value.0.as_ref())?
+                let value = value.0.as_ref();
+                Storage::insert(rt, &key, value)?;
+                storage_updates.push_insert(&key, value)?;
+            }
+
+            if let Err(e) = storage_updates.publish_event(rt) {
+                debug_msg!(rt, "Failed to publish storage update events: {e}");
             }
 
             flush(rt, &mut self.persistent_outbox, curr_ctxt.outbox_queue)?;
@@ -1147,6 +1164,7 @@ mod test {
 
 #[cfg(test)]
 mod tests {
+    use crate::event::test::Sink;
     use bincode::{Decode, Encode};
     use serde::{Deserialize, Serialize};
     use tezos_smart_rollup_mock::MockHost;
@@ -1225,5 +1243,51 @@ mod tests {
                 source: crate::error::KvError::LockPoisoned
             })
         ));
+    }
+
+    #[test]
+    fn storage_update_event_is_published_on_final_commit() {
+        let mut sink = Sink(Vec::new());
+        let mut hrt = MockHost::default();
+        let tx = Transaction::default();
+        hrt.set_debug_handler(unsafe {
+            std::mem::transmute::<&mut std::vec::Vec<u8>, &'static mut Vec<u8>>(
+                &mut sink.0,
+            )
+        });
+        // Begin tx1 and insert /key1
+        tx.begin();
+        tx.insert(OwnedPath::try_from("/key1".to_string()).unwrap(), 42)
+            .unwrap();
+        // Begin tx2 and remove /key2
+        tx.begin();
+        tx.remove(OwnedPath::try_from("/key2".to_string()).unwrap())
+            .unwrap();
+        // Committing tx2 does not publish any events
+        tx.commit(&mut hrt).unwrap();
+        assert!(sink.lines().first().unwrap().is_empty());
+        // Final commit should publish the event
+        tx.commit(&mut hrt).unwrap();
+        assert_eq!(
+            sink.lines().first().unwrap(),
+            r#"[BATCH_STORAGE_UPDATE][{"Remove":{"key":"/key2"}},{"Insert":{"key":"/key1","value":"KgAAAA=="}}]"#
+        );
+    }
+
+    #[test]
+    fn storage_update_event_is_not_published_when_there_are_no_kv_changes() {
+        let mut sink = Sink(Vec::new());
+        let mut hrt = MockHost::default();
+        let tx = Transaction::default();
+        hrt.set_debug_handler(unsafe {
+            std::mem::transmute::<&mut std::vec::Vec<u8>, &'static mut Vec<u8>>(
+                &mut sink.0,
+            )
+        });
+        // Begin tx1
+        tx.begin();
+        // Commit tx1 does not publish any events
+        tx.commit(&mut hrt).unwrap();
+        assert!(sink.lines().first().unwrap().is_empty());
     }
 }

--- a/crates/jstz_proto/src/runtime/v2/oracle/oracle.rs
+++ b/crates/jstz_proto/src/runtime/v2/oracle/oracle.rs
@@ -279,7 +279,7 @@ mod test {
     use crate::runtime::v2::oracle::UserAddress;
     use crate::runtime::v2::protocol_context::ProtocolContext;
     use crate::tests::DebugLogSink;
-    use jstz_core::event::decode_line;
+    use jstz_core::event::{decode_line, Event};
     use jstz_core::kv::Storage;
     use jstz_crypto::{hash::Hash, public_key::PublicKey};
     use serde_json::json;
@@ -408,8 +408,7 @@ mod test {
         // See calculate_gas_limi
         // let balance = Account::balance(&host, &mut tx, &caller).unwrap();
         // assert_eq!(1_000_000 - minimal_gas, balance);
-
-        let line = sink.lines().first().unwrap().clone();
+        let line = sink.lines().iter().nth(1).unwrap().clone();
         assert_eq!(stored, decode_line(&line).unwrap());
 
         // Second requst but this time with X_JSTZ_ORACLE_GAS_LIMIT header
@@ -439,7 +438,7 @@ mod test {
         // // Expected is initial - request 1 gas - request 2 gas
         // assert_eq!(1_000_000 - minimal_gas - 3500, balance);
 
-        let line = sink.lines().iter().nth(1).unwrap().clone();
+        let line = sink.lines().iter().nth(2).unwrap().clone();
         assert_eq!(stored2, decode_line(&line).unwrap());
 
         let response = Response {


### PR DESCRIPTION
# Context

Closes: [813](https://linear.app/tezos/issue/JSTZ-813/leak-storageupdateevent-from-kernel) 

In the next step, we will add the storage update event consumer in jstz node to sync the storage.

# Description

* Publishes storage update event from the final transaction commit. 
* The events are batched in memory and published in the final commit 
* Added `publish_event` method to `BatchStroageUpdate` that publishes itself only if non empty

# Manually testing the PR

Added unit test:
```
cargo test --package jstz_core
```
