### PR TITLE
fix(docs): install submodules in readme build steps

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -240,7 +240,7 @@ The Jstz dev wallet supports only the Chrome web browser.
 1. Go into the repository, install the dependencies, and build the wallet:
 
    ```bash
-   cd dev-wallet && pnpm i && pnpm build
+   cd dev-wallet && git submodule update --init && pnpm i && pnpm build
    ```
 
 1. In Chrome, open the extensions page at `chrome://extensions`.


### PR DESCRIPTION
To get the install steps to work I had to install git submodules, or else `pnpm i` threw errors.

See also https://github.com/jstz-dev/dev-wallet/pull/36.