### PR TITLE
refactor(jstz_utils): move async_retry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3403,6 +3403,7 @@ dependencies = [
  "tezos_crypto_rs 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
  "tezos_data_encoding 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
  "tokio",
+ "tokio-retry2",
  "tokio-util",
  "url",
 ]

--- a/crates/jstz_oracle_node/src/relay.rs
+++ b/crates/jstz_oracle_node/src/relay.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use futures_util::StreamExt;
 use jstz_proto::runtime::v2::oracle::OracleRequest;
 use jstz_utils::event_stream::EventStream;
+use jstz_utils::test_util::append_async;
 use tokio::sync::broadcast;
 use tokio::task::AbortHandle;
 
@@ -78,15 +79,6 @@ mod tests {
         io::AsyncWriteExt,
         time::{sleep, timeout},
     };
-
-    async fn append_async(path: PathBuf, line: String, delay_ms: u64) -> Result<()> {
-        sleep(Duration::from_millis(delay_ms)).await;
-        let mut file = OpenOptions::new().append(true).open(&path).await?;
-        file.write_all(line.as_bytes()).await?;
-        file.write_all(b"\n").await?;
-        file.sync_all().await?;
-        Ok(())
-    }
 
     async fn next_event(
         rx: &mut broadcast::Receiver<OracleRequest>,

--- a/crates/jstz_utils/Cargo.toml
+++ b/crates/jstz_utils/Cargo.toml
@@ -27,6 +27,7 @@ tezos-smart-rollup = { workspace = true, features =  ["utils"], optional = true 
 tezos_crypto_rs.workspace = true
 tezos_data_encoding = { workspace = true, optional = true }
 tokio.workspace = true
+tokio-retry2.workspace = true
 tokio-util.workspace = true
 
 [dev-dependencies]

--- a/crates/jstz_utils/src/event_stream.rs
+++ b/crates/jstz_utils/src/event_stream.rs
@@ -65,12 +65,12 @@ impl<'a, E: Event + Unpin> Stream for EventStream<'a, E> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_util::append_async;
     use futures_util::StreamExt;
-
     use serde::{Deserialize, Serialize};
     use std::{str::FromStr, time::Duration};
     use tempfile::NamedTempFile;
-    use tokio::{fs::OpenOptions, io::AsyncWriteExt, time::timeout};
+    use tokio::time::timeout;
     use url::Url;
 
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -90,19 +90,6 @@ mod tests {
             id,
             url: Url::from_str("http://example.com/foo").unwrap(),
         }
-    }
-
-    async fn append_async(
-        path: PathBuf,
-        line: String,
-        delay_ms: u64,
-    ) -> anyhow::Result<()> {
-        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
-        let mut file = OpenOptions::new().append(true).open(&path).await?;
-        file.write_all(line.as_bytes()).await?;
-        file.write_all(b"\n").await?;
-        file.sync_all().await?;
-        Ok(())
     }
 
     fn make_line(req: &MockEvent) -> String {

--- a/crates/jstz_utils/src/filtered_log_stream.rs
+++ b/crates/jstz_utils/src/filtered_log_stream.rs
@@ -77,30 +77,19 @@ impl futures_core::Stream for FilteredLogStream {
 
 #[cfg(test)]
 mod tests {
+    use crate::test_util::append_async;
+
     use super::*;
     use futures_util::StreamExt;
     use std::{io::Write, time::Duration};
     use tempfile::NamedTempFile;
-    use tokio::{fs::OpenOptions, io::AsyncWriteExt, time::timeout};
+    use tokio::time::timeout;
 
     const PATTERN: &str = r#"^\[ORACLE\]\s+\d+\s+.*"#;
 
     fn append_sync(file: &mut NamedTempFile, line: &str) -> anyhow::Result<()> {
         writeln!(file.as_file_mut(), "{line}")?;
         file.as_file_mut().sync_all()?;
-        Ok(())
-    }
-
-    async fn append_async(
-        path: PathBuf,
-        line: String,
-        delay_ms: u64,
-    ) -> anyhow::Result<()> {
-        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
-        let mut file = OpenOptions::new().append(true).open(&path).await?;
-        file.write_all(line.as_bytes()).await?;
-        file.write_all(b"\n").await?;
-        file.sync_all().await?;
         Ok(())
     }
 

--- a/crates/jstz_utils/src/retry.rs
+++ b/crates/jstz_utils/src/retry.rs
@@ -1,0 +1,115 @@
+use std::{future::Future, time::Duration};
+
+use tokio_retry2::{strategy::ExponentialBackoff, Retry, RetryError};
+
+pub fn exponential_backoff(
+    base: u64,
+    max_attempts: usize,
+    max_delay: Duration,
+) -> impl Iterator<Item = Duration> {
+    ExponentialBackoff::from_millis(base)
+        .factor(2)
+        .max_delay(max_delay)
+        .take(max_attempts)
+}
+
+pub async fn retry_async<F, Fut, T, E, C>(
+    backoff: impl IntoIterator<Item = Duration>,
+    mut op: F,
+    should_retry: C,
+) -> Result<T, E>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+    C: Fn(&E) -> bool + Copy,
+{
+    let action = || {
+        let fut = op();
+
+        async move {
+            match fut.await {
+                Ok(v) => Ok(v),
+                Err(e) => {
+                    if should_retry(&e) {
+                        Err(RetryError::transient(e))
+                    } else {
+                        Err(RetryError::permanent(e))
+                    }
+                }
+            }
+        }
+    };
+
+    Retry::spawn(backoff, action).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    #[test]
+    fn test_exponential_backoff() {
+        let base = 50;
+        let max_attempts = 5;
+        let max_delay = Duration::from_secs(8); // allow more growth before capping
+        let intervals: Vec<_> =
+            exponential_backoff(base, max_attempts, max_delay).collect();
+        let expected = vec![
+            Duration::from_millis(100),  // 100*2
+            Duration::from_millis(5000), // capped from 20_000
+            Duration::from_millis(8000), // capped
+            Duration::from_millis(8000), // capped
+            Duration::from_millis(8000), // capped
+        ];
+        assert_eq!(intervals, expected);
+    }
+
+    #[tokio::test]
+    async fn test_retry_async_success() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let op = {
+            let attempts = attempts.clone();
+            move || {
+                let attempts = attempts.clone();
+                async move {
+                    let n = attempts.fetch_add(1, Ordering::SeqCst);
+                    if n < 2 {
+                        Err("fail")
+                    } else {
+                        Ok("success")
+                    }
+                }
+            }
+        };
+        let should_retry = |_e: &&str| true;
+        let backoff = exponential_backoff(1, 5, Duration::from_millis(10));
+        let result = retry_async(backoff, op, should_retry).await;
+        assert_eq!(result, Ok("success"));
+    }
+
+    #[tokio::test]
+    async fn test_retry_async_permanent_error() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let op = {
+            let attempts = attempts.clone();
+            move || {
+                let attempts = attempts.clone();
+                async move {
+                    let n = attempts.fetch_add(1, Ordering::SeqCst);
+                    if n == 0 {
+                        Err("permanent")
+                    } else {
+                        Ok("should not reach here")
+                    }
+                }
+            }
+        };
+        let should_retry = |e: &&str| *e != "permanent";
+        let backoff = exponential_backoff(1, 5, Duration::from_millis(10));
+        let result = retry_async(backoff, op, should_retry).await;
+        assert_eq!(result, Err("permanent"));
+    }
+}


### PR DESCRIPTION
# Context

Refactoring PR to prepare for #1264 

# Description

* Moved `exponential_back_off` & `retry_async` to `jstz_utils`
* Moved `append_async` test utils to `jstz_utils`

# Manually testing the PR

* Add test for `retry_async` and `exponential_back_off`
