### PR TITLE
fix(docs): override bash formatting to highlight variables

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -240,3 +240,12 @@ article a[target="_blank"]:after {
   content: url("/img/external_link.svg");
   padding-left: 5px;
 }
+
+/* Override color for <VARIABLES> in bash codeblocks */
+/* See src/theme/languages/prism-bash.js */
+.language-bash .token.variable,
+.language-sh .token.variable,
+.language-shell .token.variable {
+  color: var(--ifm-color-primary) !important;
+  font-style: inherit !important;
+}

--- a/docs/src/theme/languages/prism-bash.js
+++ b/docs/src/theme/languages/prism-bash.js
@@ -1,0 +1,15 @@
+(function (Prism) {
+  // Highlight blocks like <PLACEHOLDER> or <ALIAS|ADDRESS>
+  // But not <A B>
+  const placeholderRegex = new RegExp("<[\\w\|]+>", "gm");
+
+  const languageBase = {
+    variable: {
+      pattern: placeholderRegex,
+    },
+  };
+
+  Prism.languages.bash = languageBase;
+  Prism.languages.sh = languageBase;
+  Prism.languages.shell = languageBase;
+})(Prism);

--- a/docs/src/theme/prism-include-languages.js
+++ b/docs/src/theme/prism-include-languages.js
@@ -1,0 +1,27 @@
+import siteConfig from "@generated/docusaurus.config";
+// Swizzled via:
+// npm run swizzle @docusaurus/theme-classic prism-include-languages
+export default function prismIncludeLanguages(PrismObject) {
+  const {
+    themeConfig: { prism },
+  } = siteConfig;
+  const { additionalLanguages } = prism;
+  // Prism components work on the Prism instance on the window, while prism-
+  // react-renderer uses its own Prism instance. We temporarily mount the
+  // instance onto window, import components to enhance it, then remove it to
+  // avoid polluting global namespace.
+  // You can mutate PrismObject: registering plugins, deleting languages... As
+  // long as you don't re-assign it
+  globalThis.Prism = PrismObject;
+  additionalLanguages.forEach((lang) => {
+    // if (lang === 'php') {
+    //   // eslint-disable-next-line global-require
+    //   require('prismjs/components/prism-markup-templating.js');
+    // }
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    require(`prismjs/components/prism-${lang}`);
+  });
+
+  require(`./languages/prism-bash`);
+  delete globalThis.Prism;
+}


### PR DESCRIPTION
As in https://gitlab.com/tezos/docs/-/merge_requests/52, let's highlight the <PLACEHOLDERS> that we use in the docs. This PR overrides the default bash formatter. This affects only fenced code blocks, not inline code blocks.

Before:
<img width="1010" height="208" alt="Screenshot 2025-08-20 at 9 41 09 AM" src="https://github.com/user-attachments/assets/764d56a6-e499-4bc2-b7d2-0c117812dab2" />

After:
<img width="1033" height="208" alt="Screenshot 2025-08-20 at 9 41 21 AM" src="https://github.com/user-attachments/assets/e8ff2864-5347-4b00-8feb-96669f176d3c" />
