### PR TITLE
chore(jstz_node): update docker file

### DIFF
--- a/crates/jstz_node/Dockerfile
+++ b/crates/jstz_node/Dockerfile
@@ -1,11 +1,23 @@
-FROM rust:1.73.0 AS builder
+FROM rust:1.88.0-slim-bookworm AS builder
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    curl=7.88.1-10+deb12u12 pkg-config=1.8.1-1 \
+    libssl-dev=3.0.17-1~deb12u2 libsqlite3-dev=3.40.1-2+deb12u1
+
 WORKDIR /jstz_build
 COPY . .
-RUN cargo build --package jstz_node --release
+RUN cargo build --bin jstz-node --release --features oracle,v2_runtime
 
-FROM debian:bookworm-slim AS node
-RUN apt-get update && apt-get install -y openssl sqlite3
+FROM debian:bookworm-20250520-slim AS jstz_node
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    curl=7.88.1-10+deb12u12 pkg-config=1.8.1-1 \
+    libssl-dev=3.0.17-1~deb12u2 libsqlite3-dev=3.40.1-2+deb12u1 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /jstz_build/target/release/jstz-node /usr/bin/jstz-node
+
 ENV RUST_BACKTRACE=1
 ENV RUST_LOG=debug
-COPY --from=builder /jstz_build/target/release/jstz-node /usr/bin/jstz-node
-ENTRYPOINT [ "/usr/bin/jstz-node" ]
+
+ENTRYPOINT ["/usr/bin/jstz-node"]


### PR DESCRIPTION
# Context

Part of JSTZ-893.
[JSTZ-893](https://linear.app/tezos/issue/JSTZ-893/build-images-for-nodes-for-private-net)

# Description

Updated the docker file for jstz node such that it builds with v2 runtime and oracle.

# Manually testing the PR

Built the image locally and ran jstz node from the image without any issue.
