### PR TITLE
chore(release): 0.1.1-alpha.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_api"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_cli"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3092,7 +3092,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_client"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "anyhow",
  "jstz_crypto",
@@ -3105,7 +3105,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_core"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "anyhow",
  "bincode 2.0.0-rc.3",
@@ -3138,7 +3138,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_crypto"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "anyhow",
  "bincode 2.0.0-rc.3",
@@ -3155,7 +3155,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_kernel"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "anyhow",
  "bincode 2.0.0-rc.3",
@@ -3180,7 +3180,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_mock"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "derive_more",
  "jstz_core",
@@ -3193,7 +3193,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_node"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3246,7 +3246,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_oracle_node"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "anyhow",
  "bincode 2.0.0-rc.3",
@@ -3282,7 +3282,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_proto"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "boa_engine",
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_runtime"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "anyhow",
  "bincode 2.0.0-rc.3",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_sdk"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "jstz_crypto",
  "jstz_proto",
@@ -3363,7 +3363,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_tps_bench"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -3383,7 +3383,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_utils"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "anyhow",
  "futures",
@@ -3410,7 +3410,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_wpt"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -3428,7 +3428,7 @@ dependencies = [
 
 [[package]]
 name = "jstzd"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "octez"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "anyhow",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3358,6 +3358,7 @@ dependencies = [
  "jstz_crypto",
  "jstz_proto",
  "serde-wasm-bindgen",
+ "serde_json",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 authors = ["TriliTech <contact@trili.tech>"]
 repository = "https://github.com/jstz-dev/jstz"
 homepage = "https://github.com/jstz-dev/jstz"

--- a/crates/jstz_cli/src/sandbox/mod.rs
+++ b/crates/jstz_cli/src/sandbox/mod.rs
@@ -10,7 +10,7 @@ pub use consts::*;
 use container::*;
 
 const SANDBOX_CONTAINER_NAME: &str = "jstz-sandbox";
-const SANDBOX_IMAGE: &str = "ghcr.io/jstz-dev/jstz/jstzd:0.1.1-alpha.3";
+const SANDBOX_IMAGE: &str = "ghcr.io/jstz-dev/jstz/jstzd:0.1.1-alpha.4";
 
 pub async fn assert_sandbox_running(sandbox_base_url: &str) -> Result<()> {
     match jstzd::is_jstzd_running(sandbox_base_url).await {

--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -11,7 +11,7 @@
       "name": "MIT",
       "url": "https://github.com/jstz-dev/jstz/blob/main/LICENSE"
     },
-    "version": "0.1.1-alpha.3"
+    "version": "0.1.1-alpha.4"
   },
   "paths": {
     "/accounts/{address}": {

--- a/crates/jstz_node/openapi_v1.json
+++ b/crates/jstz_node/openapi_v1.json
@@ -11,7 +11,7 @@
       "name": "MIT",
       "url": "https://github.com/jstz-dev/jstz/blob/main/LICENSE"
     },
-    "version": "0.1.1-alpha.3"
+    "version": "0.1.1-alpha.4"
   },
   "paths": {
     "/accounts/{address}": {

--- a/crates/jstz_sdk/Cargo.toml
+++ b/crates/jstz_sdk/Cargo.toml
@@ -13,3 +13,4 @@ jstz_crypto = { path = "../jstz_crypto" }
 jstz_proto = { path = "../jstz_proto" }
 serde-wasm-bindgen.workspace = true
 wasm-bindgen.workspace = true
+serde_json.workspace = true

--- a/crates/jstz_sdk/src/lib.rs
+++ b/crates/jstz_sdk/src/lib.rs
@@ -4,7 +4,9 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 pub fn sign_operation(operation: JsValue, secret_key: &str) -> Result<String, JsValue> {
-    let operation: Operation = serde_wasm_bindgen::from_value(operation)?;
+    let json: serde_json::Value = serde_wasm_bindgen::from_value(operation)?;
+    let operation: Operation =
+        serde_json::from_value(json).map_err(|e| JsValue::from_str(&e.to_string()))?;
     let hash = operation.hash();
     let secret_key = SecretKey::from_base58(secret_key)
         .map_err(|e| JsValue::from_str(&e.to_string()))?;

--- a/crates/jstzd/src/config.rs
+++ b/crates/jstzd/src/config.rs
@@ -197,7 +197,10 @@ pub async fn build_config(mut config: Config) -> Result<(u16, JstzdConfig)> {
             octez_client_config,
             octez_rollup_config,
             #[cfg(feature = "oracle")]
-            build_oracle_config(Some(injector.clone()), &jstz_node_config),
+            build_oracle_config(
+                Some(jstz_node_config.injector.clone()),
+                &jstz_node_config,
+            ),
             jstz_node_config,
             protocol_params,
         ),
@@ -285,8 +288,10 @@ fn build_oracle_config(
         key_pair,
         jstz_node_endpoint: jstz_node_config.endpoint.clone(),
         log_path: match &jstz_node_config.mode {
-            RunMode::Default => jstz_node_config.kernel_log_file.clone(),
-            RunMode::Sequencer { debug_log_path, .. } => debug_log_path.clone(),
+            jstz_node::RunMode::Default => jstz_node_config.kernel_log_file.clone(),
+            jstz_node::RunMode::Sequencer { debug_log_path, .. } => {
+                debug_log_path.clone()
+            }
         },
     }
 }

--- a/examples/get-tez/README.md
+++ b/examples/get-tez/README.md
@@ -33,7 +33,7 @@ Follow these steps to use it:
 5. Ask the smart function for tez in an impolite way by running this command:
 
    ```sh
-   jstz run jstz://<GET_TEZ>/ --data '{"message":"Give me tez now."}' -n dev
+   jstz run jstz://<GET_TEZ>/ --data '{"message":"Give me tez now."}' --method POST -n dev
    ```
 
    The smart function returns the message "Sorry, I only fulfill polite requests."
@@ -41,7 +41,7 @@ Follow these steps to use it:
 6. Ask the smart function politely by running this command, which includes the word "please" in the message:
 
    ```sh
-   jstz run jstz://<GET_TEZ>/ --data '{"message":"Please, give me some tez."}' -n dev
+   jstz run jstz://<GET_TEZ>/ --data '{"message":"Please, give me some tez."}' --method POST -n dev
    ```
 
    The function returns the message "Thank you for your polite request. You received 1 tez!"

--- a/examples/show-tez/package-lock.json
+++ b/examples/show-tez/package-lock.json
@@ -5,8 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
-        "@jstz-dev/jstz-client": "0.1.1-alpha.1",
-        "jstz_sdk": "0.1.1-alpha.1",
+        "@jstz-dev/jstz-client": "0.1.1-alpha.4",
+        "jstz_sdk": "file:../../crates/jstz_sdk/pkg",
         "untildify": "^5.0.0"
       },
       "devDependencies": {
@@ -18,8 +18,7 @@
     },
     "../../crates/jstz_sdk/pkg": {
       "name": "jstz_sdk",
-      "version": "0.1.0-alpha.0",
-      "extraneous": true
+      "version": "0.1.0-alpha.0"
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -89,9 +88,10 @@
       }
     },
     "node_modules/@jstz-dev/jstz-client": {
-      "version": "0.1.1-alpha.1",
-      "resolved": "https://registry.npmjs.org/@jstz-dev/jstz-client/-/jstz-client-0.1.1-alpha.1.tgz",
-      "integrity": "sha512-ukTuUopIDM2jtvkMQY6gZXcdb9So+0WQ48BQ+wCcEsdOLwdyhoC2pZVMLWiqKiPHHk0GdODA0umnqmQiW15pUA==",
+      "version": "0.1.1-alpha.4",
+      "resolved": "https://registry.npmjs.org/@jstz-dev/jstz-client/-/jstz-client-0.1.1-alpha.4.tgz",
+      "integrity": "sha512-RMlQtYNudQGCJvuMo/HrJoFIkbMOLISD/M9XZb77mDrx22lftq1XZJzz28x4L5tVZqX/Fppc8uT/qx4MK+Vqdg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^20.11.7",
         "@types/node-fetch": "^2.6.4",
@@ -1026,9 +1026,8 @@
       "dev": true
     },
     "node_modules/jstz_sdk": {
-      "version": "0.1.1-alpha.1",
-      "resolved": "https://registry.npmjs.org/jstz_sdk/-/jstz_sdk-0.1.1-alpha.1.tgz",
-      "integrity": "sha512-WdXLhG9zfo6xa2bnHC1okK7ej38Er7BePpzjg4fr3z4SMYRVL8rwwWWfLazUuvZtfjPtgLLKa6Y+2a7nlQA21A=="
+      "resolved": "../../crates/jstz_sdk/pkg",
+      "link": true
     },
     "node_modules/kind-of": {
       "version": "6.0.3",

--- a/examples/show-tez/package.json
+++ b/examples/show-tez/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "jstz_sdk": "0.1.1-alpha.1",
-    "@jstz-dev/jstz-client": "0.1.1-alpha.1",
+    "jstz_sdk": "0.1.1-alpha.4",
+    "@jstz-dev/jstz-client": "0.1.1-alpha.4",
     "untildify": "^5.0.0"
   },
   "devDependencies": {

--- a/examples/show-tez/src/index.ts
+++ b/examples/show-tez/src/index.ts
@@ -7,9 +7,6 @@ import untildify from "untildify";
 
 import * as signer from "jstz_sdk";
 
-const encoder = new TextEncoder();
-const decoder = new TextDecoder("utf-8");
-
 // Accept a smart function address and message and put together a request
 function buildRequest(
   functionAddress: string,
@@ -17,13 +14,11 @@ function buildRequest(
 ): JstzType.Operation.RunFunction {
   return {
     _type: "RunFunction",
-    body: Array.from(
-      encoder.encode(
-        JSON.stringify({
-          message: message,
-        }),
-      ),
-    ),
+    body: Buffer.from(
+      JSON.stringify({
+        message: message,
+      }),
+    ).toString("base64"),
     gasLimit: 55000,
     headers: {},
     method: "POST",
@@ -122,7 +117,10 @@ async function main() {
         } = await response;
         waitingForReceipt = false;
         if (body) {
-          console.log("🤖:", JSON.parse(decoder.decode(new Uint8Array(body))));
+          console.log(
+            "🤖:",
+            JSON.parse(Buffer.from(body, "base64").toString()),
+          );
         }
       }
     } catch (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4998,6 +4998,30 @@
       "resolved": "packages/jstz",
       "link": true
     },
+    "node_modules/@jstz-dev/jstz-client": {
+      "version": "0.1.1-alpha.4",
+      "resolved": "https://registry.npmjs.org/@jstz-dev/jstz-client/-/jstz-client-0.1.1-alpha.4.tgz",
+      "integrity": "sha512-RMlQtYNudQGCJvuMo/HrJoFIkbMOLISD/M9XZb77mDrx22lftq1XZJzz28x4L5tVZqX/Fppc8uT/qx4MK+Vqdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^20.11.7",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/@jstz-dev/jstz-client/node_modules/@types/node": {
+      "version": "20.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
+      "integrity": "sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/@jstz-dev/sdk": {
       "resolved": "packages/sdk",
       "link": true
@@ -7192,20 +7216,6 @@
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "license": "Apache-2.0"
-    },
-    "node_modules/@zcabter/jstz-client": {
-      "version": "0.1.0-alpha",
-      "resolved": "https://registry.npmjs.org/@zcabter/jstz-client/-/jstz-client-0.1.0-alpha.tgz",
-      "integrity": "sha512-qnto9/wV9sZX/xHACJoQQHgVZA9syTBEkLMKYGQDGDACa++zZ+JWpRj7G69rs130uePhAxoNscNGLtUwQLJncw==",
-      "dependencies": {
-        "@types/node": "^22.10.6",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      }
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -22037,9 +22047,14 @@
       "name": "@jstz-dev/sdk",
       "version": "0.0.0",
       "dependencies": {
-        "@zcabter/jstz-client": "0.1.0-alpha",
-        "jstz_sdk": "0.1.0-alpha.0"
+        "@jstz-dev/jstz-client": "0.1.1-alpha.4",
+        "jstz_sdk": "0.1.1-alpha.4"
       }
+    },
+    "packages/sdk/node_modules/jstz_sdk": {
+      "version": "0.1.1-alpha.4",
+      "resolved": "https://registry.npmjs.org/jstz_sdk/-/jstz_sdk-0.1.1-alpha.4.tgz",
+      "integrity": "sha512-P+uFb4lRaMR34YFRRsh4Po2WtAmwzLrVjS0xbtyoFXR6xj4qQ2J0WwPHKraiXSUNDXy0m46WrKOOizhcTYyUfg=="
     },
     "packages/types": {
       "name": "@jstz-dev/types",
@@ -24895,11 +24910,42 @@
         "@jstz-dev/types": "^0.0.0"
       }
     },
+    "@jstz-dev/jstz-client": {
+      "version": "0.1.1-alpha.4",
+      "resolved": "https://registry.npmjs.org/@jstz-dev/jstz-client/-/jstz-client-0.1.1-alpha.4.tgz",
+      "integrity": "sha512-RMlQtYNudQGCJvuMo/HrJoFIkbMOLISD/M9XZb77mDrx22lftq1XZJzz28x4L5tVZqX/Fppc8uT/qx4MK+Vqdg==",
+      "requires": {
+        "@types/node": "^20.11.7",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "20.19.11",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
+          "integrity": "sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==",
+          "requires": {
+            "undici-types": "~6.21.0"
+          }
+        }
+      }
+    },
     "@jstz-dev/sdk": {
       "version": "file:packages/sdk",
       "requires": {
-        "@zcabter/jstz-client": "0.1.0-alpha",
-        "jstz_sdk": "0.1.0-alpha.0"
+        "@jstz-dev/jstz-client": "0.1.1-alpha.4",
+        "jstz_sdk": "0.1.1-alpha.4"
+      },
+      "dependencies": {
+        "jstz_sdk": {
+          "version": "0.1.1-alpha.4",
+          "resolved": "https://registry.npmjs.org/jstz_sdk/-/jstz_sdk-0.1.1-alpha.4.tgz",
+          "integrity": "sha512-P+uFb4lRaMR34YFRRsh4Po2WtAmwzLrVjS0xbtyoFXR6xj4qQ2J0WwPHKraiXSUNDXy0m46WrKOOizhcTYyUfg=="
+        }
       }
     },
     "@jstz-dev/types": {
@@ -26292,20 +26338,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
-    },
-    "@zcabter/jstz-client": {
-      "version": "0.1.0-alpha",
-      "resolved": "https://registry.npmjs.org/@zcabter/jstz-client/-/jstz-client-0.1.0-alpha.tgz",
-      "integrity": "sha512-qnto9/wV9sZX/xHACJoQQHgVZA9syTBEkLMKYGQDGDACa++zZ+JWpRj7G69rs130uePhAxoNscNGLtUwQLJncw==",
-      "requires": {
-        "@types/node": "^22.10.6",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      }
     },
     "abort-controller": {
       "version": "3.0.0",

--- a/packages/cli/main/package.json
+++ b/packages/cli/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jstz-dev/cli",
-  "version": "0.1.1-alpha.3",
+  "version": "0.1.1-alpha.4",
   "description": "A command-line interface for jstz.",
   "type": "module",
   "bin": {

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -1,9 +1,7 @@
 import * as jstz from "jstz_sdk";
 
-// FIXME: https://linear.app/tezos/issue/JSTZ-287/publish-client-lib-to-jstz-dev-scope
-// Change to import from "@jstz-dev/client" when published to scope
-import { Jstz as JstzClient } from "@zcabter/jstz-client";
-import JstzType from "@zcabter/jstz-client";
+import { Jstz as JstzClient } from "@jstz-dev/jstz-client";
+import JstzType from "@jstz-dev/jstz-client";
 
 export type Address = string;
 
@@ -61,19 +59,18 @@ export class Jstz {
     const nonce = await this.getNonce(user.address);
     const content: JstzType.Operation.DeployFunction = {
       _type: "DeployFunction",
-      function_code: functionCode,
-      account_credit: initialBalance,
+      functionCode: functionCode,
+      accountCredit: initialBalance,
     };
 
     const operation = {
-      source: user.address,
+      publicKey: user.publicKey,
       nonce,
       content,
     };
     const signature = signOperation(user, operation);
     const request = {
-      public_key: user.publicKey,
-      signature: signature,
+      signature,
       inner: operation,
     };
     const receipt = await this.client.operations.injectAndPoll(request);
@@ -87,15 +84,15 @@ export class Jstz {
     const nonce = await this.getNonce(user.address);
     const content: JstzType.Operation.RunFunction = {
       _type: "RunFunction",
-      body: request.body ? Array.from(request.body) : null,
-      gas_limit: request.gasLimit ?? 1000,
+      body: request.body ? Buffer.from(request.body).toString("base64") : null,
+      gasLimit: request.gasLimit ?? 1000,
       headers: request.headers ?? {},
       method: request.method ?? "GET",
       uri: request.uri,
     };
 
     const operation = {
-      source: user.address,
+      publicKey: user.publicKey,
       nonce,
       content,
     };
@@ -103,7 +100,6 @@ export class Jstz {
     const signature = signOperation(user, operation);
 
     const receipt = await this.client.operations.injectAndPoll({
-      public_key: user.publicKey,
       signature: signature,
       inner: operation,
     });

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -9,7 +9,7 @@
     "build": "tsc --outDir dist"
   },
   "dependencies": {
-    "@zcabter/jstz-client": "0.1.0-alpha",
-    "jstz_sdk": "0.1.0-alpha.0"
+    "@jstz-dev/jstz-client": "0.1.1-alpha.4",
+    "jstz_sdk": "0.1.1-alpha.4"
   }
 }


### PR DESCRIPTION
# Context
Release 0.1.1-alpha.4

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
* Rebuild jstz_sdk signer and hasher and published. Required because of backward incompatible change in RunFunction due to parsing body from base64 instead of Vec<u8>. jstz_sdk parses the javascript value into a valid operation before performing any actions on it, so I've had to parse it JS into JSON first then JSON into Operation. Tested by pointing to jstz_sdk and jstz_client to local relative path before publising. 
```
make build-sdk-wasm-pkg
```
* Bump version
* Regenerate openapi
* Fixed missing import in jstz_node section that is hidden behind oracle feature flag

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
`make`
```
cargo run --bin jstz-node --features v2_runtime -- spec -o crates/jstz_node/openapi.json
cargo run --bin jstz-node -- spec -o crates/jstz_node/openapi_v1.json
```

Tested `jstz_sdk` and `jstz_client` changes by using `show-tez`. First run `cargo run --bin jstzd -- run`, then after deploying `get-tez`, in examples/show-tez:
```
npm install
npm run build
npm run start <SF_ADDRESS>
```

Unfortuntely, test coverage is not happy

<!-- Describe how reviewers and approvers can test this PR. -->
