### PR TITLE
fix(cli): allow jstzd config in sandbox start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_api"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_cli"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3092,7 +3092,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_client"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "anyhow",
  "jstz_crypto",
@@ -3105,7 +3105,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_core"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "anyhow",
  "bincode 2.0.0-rc.3",
@@ -3138,7 +3138,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_crypto"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "anyhow",
  "bincode 2.0.0-rc.3",
@@ -3155,7 +3155,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_kernel"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "anyhow",
  "bincode 2.0.0-rc.3",
@@ -3180,7 +3180,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_mock"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "derive_more",
  "jstz_core",
@@ -3193,7 +3193,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_node"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3246,7 +3246,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_oracle_node"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "anyhow",
  "bincode 2.0.0-rc.3",
@@ -3282,7 +3282,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_proto"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "boa_engine",
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_runtime"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "anyhow",
  "bincode 2.0.0-rc.3",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_sdk"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "jstz_crypto",
  "jstz_proto",
@@ -3363,7 +3363,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_tps_bench"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -3383,7 +3383,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_utils"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "anyhow",
  "futures",
@@ -3410,7 +3410,7 @@ dependencies = [
 
 [[package]]
 name = "jstz_wpt"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -3428,7 +3428,7 @@ dependencies = [
 
 [[package]]
 name = "jstzd"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "octez"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 dependencies = [
  "anyhow",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.1.1-alpha.3"
+version = "0.1.1-alpha.4"
 authors = ["TriliTech <contact@trili.tech>"]
 repository = "https://github.com/jstz-dev/jstz"
 homepage = "https://github.com/jstz-dev/jstz"

--- a/crates/jstz_node/openapi.json
+++ b/crates/jstz_node/openapi.json
@@ -11,7 +11,7 @@
       "name": "MIT",
       "url": "https://github.com/jstz-dev/jstz/blob/main/LICENSE"
     },
-    "version": "0.1.1-alpha.3"
+    "version": "0.1.1-alpha.4"
   },
   "paths": {
     "/accounts/{address}": {

--- a/crates/jstz_node/openapi_v1.json
+++ b/crates/jstz_node/openapi_v1.json
@@ -11,7 +11,7 @@
       "name": "MIT",
       "url": "https://github.com/jstz-dev/jstz/blob/main/LICENSE"
     },
-    "version": "0.1.1-alpha.3"
+    "version": "0.1.1-alpha.4"
   },
   "paths": {
     "/accounts/{address}": {

--- a/crates/jstz_oracle_node/src/relay.rs
+++ b/crates/jstz_oracle_node/src/relay.rs
@@ -4,7 +4,6 @@ use anyhow::Result;
 use futures_util::StreamExt;
 use jstz_proto::runtime::v2::oracle::OracleRequest;
 use jstz_utils::event_stream::EventStream;
-use jstz_utils::test_util::append_async;
 use tokio::sync::broadcast;
 use tokio::task::AbortHandle;
 
@@ -72,6 +71,7 @@ impl Drop for Relay {
 mod tests {
     use super::*;
     use anyhow::Result;
+    use jstz_utils::test_util::append_async;
     use std::{io::Write, time::Duration};
     use tempfile::NamedTempFile;
     use tokio::{

--- a/crates/jstzd/src/config.rs
+++ b/crates/jstzd/src/config.rs
@@ -197,7 +197,10 @@ pub async fn build_config(mut config: Config) -> Result<(u16, JstzdConfig)> {
             octez_client_config,
             octez_rollup_config,
             #[cfg(feature = "oracle")]
-            build_oracle_config(Some(injector.clone()), &jstz_node_config),
+            build_oracle_config(
+                Some(jstz_node_config.injector.clone()),
+                &jstz_node_config,
+            ),
             jstz_node_config,
             protocol_params,
         ),
@@ -285,8 +288,10 @@ fn build_oracle_config(
         key_pair,
         jstz_node_endpoint: jstz_node_config.endpoint.clone(),
         log_path: match &jstz_node_config.mode {
-            RunMode::Default => jstz_node_config.kernel_log_file.clone(),
-            RunMode::Sequencer { debug_log_path, .. } => debug_log_path.clone(),
+            jstz_node::RunMode::Default => jstz_node_config.kernel_log_file.clone(),
+            jstz_node::RunMode::Sequencer { debug_log_path, .. } => {
+                debug_log_path.clone()
+            }
         },
     }
 }

--- a/examples/get-tez/README.md
+++ b/examples/get-tez/README.md
@@ -33,7 +33,7 @@ Follow these steps to use it:
 5. Ask the smart function for tez in an impolite way by running this command:
 
    ```sh
-   jstz run jstz://<GET_TEZ>/ --data '{"message":"Give me tez now."}' -n dev
+   jstz run jstz://<GET_TEZ>/ --data '{"message":"Give me tez now."}' --method POST -n dev
    ```
 
    The smart function returns the message "Sorry, I only fulfill polite requests."
@@ -41,7 +41,7 @@ Follow these steps to use it:
 6. Ask the smart function politely by running this command, which includes the word "please" in the message:
 
    ```sh
-   jstz run jstz://<GET_TEZ>/ --data '{"message":"Please, give me some tez."}' -n dev
+   jstz run jstz://<GET_TEZ>/ --data '{"message":"Please, give me some tez."}' --method POST -n dev
    ```
 
    The function returns the message "Thank you for your polite request. You received 1 tez!"

--- a/packages/cli/main/package.json
+++ b/packages/cli/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jstz-dev/cli",
-  "version": "0.1.1-alpha.3",
+  "version": "0.1.1-alpha.4",
   "description": "A command-line interface for jstz.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
# Context
Parity with jstzd configuration

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
* Make sandbox take jstzd config so that the sequencer can be activated. Without it, we cannot use the oracle as it depends on v2 runtime. Note that this doesn't affect container mode as the container activates the sequencer and oracle by default 

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
Run test
`make`

Manually test CLI
```jstz-config.json
{
    "jstz_node": {
        "mode": "sequencer",
        "capacity": 1024
    }
}
```

```
export PATH=target/release:$PATH
cargo run -- sandbox start --config jstzd-config.json

# in separate terminal
cargo run --bin jstz bridge deposit --from bootstrap1 --to KT1SXBizWUHDEYTpcRqfethonWSdESy1M9nD --amount 1000 -n dev
cargo run -- deploy examples/get-tez/dist/index.js  -n dev
cargo run -- run jstz://KT1SXBizWUHDEYTpcRqfethonWSdESy1M9nD/  --data '{"message":"Please, give me some tez."}' --method POST  --network dev

# oracle will not work without sequencer
cargo run -- deploy examples/oracle_basic.js  -n  dev
cargo run -- run jstz://KT1MBVeQ9jynmFARqH1Tu6eB1BFGv1UKUwaV/ --network dev -t
```



<!-- Describe how reviewers and approvers can test this PR. -->
