### PR TITLE
fix(jstzd): fix clippy with oracle feature flag

### DIFF
--- a/crates/jstzd/src/config.rs
+++ b/crates/jstzd/src/config.rs
@@ -197,7 +197,10 @@ pub async fn build_config(mut config: Config) -> Result<(u16, JstzdConfig)> {
             octez_client_config,
             octez_rollup_config,
             #[cfg(feature = "oracle")]
-            build_oracle_config(Some(injector.clone()), &jstz_node_config),
+            build_oracle_config(
+                Some(jstz_node_config.injector.clone()),
+                &jstz_node_config,
+            ),
             jstz_node_config,
             protocol_params,
         ),
@@ -285,8 +288,10 @@ fn build_oracle_config(
         key_pair,
         jstz_node_endpoint: jstz_node_config.endpoint.clone(),
         log_path: match &jstz_node_config.mode {
-            RunMode::Default => jstz_node_config.kernel_log_file.clone(),
-            RunMode::Sequencer { debug_log_path, .. } => debug_log_path.clone(),
+            jstz_node::RunMode::Default => jstz_node_config.kernel_log_file.clone(),
+            jstz_node::RunMode::Sequencer { debug_log_path, .. } => {
+                debug_log_path.clone()
+            }
         },
     }
 }
@@ -1250,6 +1255,7 @@ mod tests {
                 &PathBuf::from("/kernel/debug"),
                 keys.clone(),
                 jstz_node::RunMode::Default,
+                true,
             ),
         );
         assert_eq!(config.log_path.to_str().unwrap(), "/kernel/debug");
@@ -1265,7 +1271,9 @@ mod tests {
                 jstz_node::RunMode::Sequencer {
                     capacity: 0,
                     debug_log_path: PathBuf::from("/jstz_node/debug"),
+                    runtime_env: RuntimeEnv::Native,
                 },
+                true,
             ),
         );
         assert_eq!(config.log_path.to_str().unwrap(), "/jstz_node/debug");

--- a/crates/jstzd/src/task/oracle_node.rs
+++ b/crates/jstzd/src/task/oracle_node.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "oracle")]
 use anyhow::Result;
 use async_trait::async_trait;
 use jstz_oracle_node::{node::OracleNode as InnerOracleNode, OracleNodeConfig};

--- a/crates/jstzd/tests/jstzd_test.rs
+++ b/crates/jstzd/tests/jstzd_test.rs
@@ -434,7 +434,7 @@ async fn jstzd_with_oracle_key_pair_test() {
     tokio::spawn(async move {
         sleep(Duration::from_secs(3)).await;
         reqwest::Client::new()
-            .put(format!("http://localhost:{}/shutdown", jstzd_port))
+            .put(format!("http://localhost:{jstzd_port}/shutdown"))
             .send()
             .await
             .unwrap();

--- a/crates/jstzd/tests/main_test.rs
+++ b/crates/jstzd/tests/main_test.rs
@@ -124,7 +124,7 @@ fn test_oracle_config_from_file() {
     // Create a config file with oracle key pair
     let config_json = format!(
         r#"{{
-            "server_port": {},
+            "server_port": {port},
             "jstz_node": {{
                 "endpoint": "http://localhost:8932",
                 "rollup_endpoint": "http://localhost:8933",
@@ -135,8 +135,7 @@ fn test_oracle_config_from_file() {
                 "debug_log_file": "/tmp/debug.log",
                 "oracle_key_pair": ["edpkukK9ecWxib28zi52nvbXTdsYt8rYcvmt5bdH8KjipWXm8sH3Qi", "edsk3AbxMYLgdY71xPEjWjXi5JCx6tSS8jhQ2mc1KczZ1JfPrTqSgM"]
             }}
-        }}"#,
-        port
+        }}"#
     );
 
     tmp_file.write_all(config_json.as_bytes()).unwrap();


### PR DESCRIPTION
# Context

Issues missed out in previous commits.

# Description

Fixed building oracle config in jstzd.

# Manually testing the PR

```
cd $(git rev-parse --show-toplevel)/crates/jstzd && cargo clippy --features v2_runtime,oracle
```
