### PR TITLE
feat(jstzd): skip jstz node on demand

### DIFF
--- a/crates/jstzd/tests/jstzd_test.rs
+++ b/crates/jstzd/tests/jstzd_test.rs
@@ -208,7 +208,7 @@ async fn create_jstzd_server(
             log_path: kernel_debug_file_path.clone(),
             jstz_node_endpoint: jstz_node_rpc_endpoint.to_owned(),
         },
-        jstz_node_config,
+        Some(jstz_node_config),
         protocol_params,
     );
     (JstzdServer::new(config.clone(), jstzd_port), config)


### PR DESCRIPTION
# Context

Part of JSTZ-893.
[JSTZ-893](https://linear.app/tezos/issue/JSTZ-893/build-images-for-nodes-for-private-net)

# Description

Made jstz node config in jstzd config optional and made jstzd skip launching jstz node when its jstz node config is missing. This means that when jstzd launches with config as follows, users cannot interact with the setup because there won't be a jstz node accepting requests:
```
{
  "jstz_node": { "skipped": true }
}
```

# Manually testing the PR

* Unit testing: added one test
* Manual testing: built jstzd locally and ran it with the sample config above and observed that jstz node was indeed not launched
