### PR TITLE
feat(jstzd): skip oracle node on demand

### DIFF
--- a/crates/jstzd/src/user_config.rs
+++ b/crates/jstzd/src/user_config.rs
@@ -19,12 +19,22 @@ pub(crate) struct UserJstzNodeConfig {
     pub storage_sync: bool,
 }
 
+/// Oracle node config for jstzd.
+#[derive(Deserialize, Default, Clone)]
+pub(crate) struct UserOracleNodeConfig {
+    #[serde(default)]
+    /// Flag indicating if oracle node should not be launched.
+    pub skipped: bool,
+}
+
 #[cfg(test)]
 mod tests {
     use std::{path::PathBuf, str::FromStr};
 
     use jstz_node::config::RunModeType;
     use tezos_crypto_rs::hash::SmartRollupHash;
+
+    use crate::user_config::UserOracleNodeConfig;
 
     use super::UserJstzNodeConfig;
 
@@ -81,5 +91,16 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(config, expected);
+    }
+
+    #[test]
+    fn deserialise_user_octez_node_config() {
+        let s = r#"{"skipped": true}"#;
+        let config = serde_json::from_str::<UserOracleNodeConfig>(s).unwrap();
+        assert!(config.skipped);
+
+        let s = r#"{}"#;
+        let config = serde_json::from_str::<UserOracleNodeConfig>(s).unwrap();
+        assert!(!config.skipped);
     }
 }

--- a/crates/jstzd/tests/jstzd_test.rs
+++ b/crates/jstzd/tests/jstzd_test.rs
@@ -203,11 +203,11 @@ async fn create_jstzd_server(
         octez_client_config.clone(),
         rollup_config.clone(),
         #[cfg(feature = "oracle")]
-        OracleNodeConfig {
+        Some(OracleNodeConfig {
             key_pair: oracle_key_pair,
             log_path: kernel_debug_file_path.clone(),
             jstz_node_endpoint: jstz_node_rpc_endpoint.to_owned(),
-        },
+        }),
         Some(jstz_node_config),
         protocol_params,
     );
@@ -418,6 +418,7 @@ async fn jstzd_with_oracle_key_pair_test() {
 
     let KeyPair(cfg_pk, cfg_sk) = config
         .oracle_node_config()
+        .unwrap()
         .key_pair
         .as_ref()
         .expect("oracle key pair missing");


### PR DESCRIPTION
# Context

Completes JSTZ-893.
[JSTZ-893](https://linear.app/tezos/issue/JSTZ-893/build-images-for-nodes-for-private-net)

# Description

Similar to #1297.

Added user config for oracle node. For now the only thing configurable is whether or not the oracle node should be skipped because this is the main thing that needs to be done for JSTZ-893. 

Made oracle node config in jstzd config optional and made jstzd skip launching oracle node when its oracle node config is missing. This means that when jstzd launches with config as follows, calling smart functions that trigger the oracle will not work because the oracle node will not be present:
```
{
  "oracle_node": { "skipped": true }
}
```

# Manually testing the PR

* Unit testing: added one test
* Manual testing: built jstzd locally and ran it with the sample config above and observed that calling a smart function that triggered the oracle always timed out without any receipt
