### PR TITLE
fix(proto): handle noop transfer for sf in v2 fetch handler

### DIFF
--- a/crates/jstz_proto/src/executor/smart_function/run.rs
+++ b/crates/jstz_proto/src/executor/smart_function/run.rs
@@ -172,9 +172,6 @@ mod test {
         assert_eq!(balance_after, balance_before);
     }
 
-    // TODO: https://linear.app/tezos/issue/JSTZ-657/v2-fetch-should-support-transfer-with-noop
-    // v2 fetch does not support noop path
-    #[cfg(not(feature = "v2_runtime"))]
     #[tokio::test]
     async fn transfer_xtz_to_smart_function_succeeds_with_noop_path() {
         let source = Address::User(jstz_mock::account1());
@@ -654,10 +651,6 @@ mod test {
         );
         assert_eq!(source_after - source_before, transfer_amount);
     }
-
-    // TODO: https://linear.app/tezos/issue/JSTZ-657/v2-fetch-should-support-transfer-with-noop
-    // v2 fetch does not support noop path
-    #[cfg(not(feature = "v2_runtime"))]
     #[tokio::test]
     async fn transfer_xtz_from_smart_function_succeeds_with_noop() {
         let source = Address::User(jstz_mock::account2());

--- a/crates/jstz_proto/src/runtime/v2/fetch/http.rs
+++ b/crates/jstz_proto/src/runtime/v2/fetch/http.rs
@@ -28,6 +28,17 @@ pub struct Response {
     pub body: Body,
 }
 
+impl Response {
+    pub fn ok(body: Body, headers: Vec<(ByteString, ByteString)>) -> Response {
+        Response {
+            status: 200,
+            status_text: "OK".into(),
+            headers,
+            body,
+        }
+    }
+}
+
 impl PartialEq for Response {
     fn eq(&self, other: &Self) -> bool {
         self.status == other.status
@@ -378,6 +389,7 @@ mod test {
     use std::str::FromStr as _;
 
     use bytes::Bytes;
+    use deno_core::ByteString;
     use deno_fetch_base::BytesStream;
     use futures::StreamExt;
     use http::{HeaderMap, HeaderName, HeaderValue};
@@ -624,5 +636,19 @@ mod test {
             decode_from_slice(&wire, standard()).unwrap();
 
         assert_eq!(roundtrip, Body::Vector(payload));
+    }
+
+    #[test]
+    fn response_ok() {
+        let header = (ByteString::from("key1"), ByteString::from("value1"));
+        let body = Body::Vector(b"12345".into()).clone();
+        let resp = Response::ok(body.clone(), vec![header.clone()]);
+        let expected = Response {
+            status: 200,
+            status_text: "OK".into(),
+            headers: vec![header],
+            body,
+        };
+        assert_eq!(expected, resp)
     }
 }

--- a/docs/functions/tokens.md
+++ b/docs/functions/tokens.md
@@ -31,7 +31,6 @@ if (Ledger.balance(Ledger.selfAddress) >= ONE_TEZ) {
 }
 ```
 
-<!-- Blocked by JSTZ-657
 To send tez to a smart function without calling the smart function and running its handler function, send the tez in a request to `jstz://<ADDRESS>/-/noop`, as in this example:
 
 ```typescript
@@ -42,7 +41,6 @@ const call_request = new Request(`jstz://${smart_function}/-/noop`, {
   },
 });
 ```
--->
 
 As described in [Errors](/functions/errors), any transfers are reverted if a smart function throws an uncaught error.
 


### PR DESCRIPTION
# Context
Closes https://linear.app/tezos/issue/JSTZ-657/v2-fetch-should-support-transfer-with-noop
Reverts https://github.com/jstz-dev/jstz/pull/1179
 
Supports transfers to smart function accounts without executing its code. Parity with user account transfers.

# Description
Checks for `NOOP_PATH` in smart function flow. 

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
`cargo nextest run -p jstz_proto --features v2_runtime`

Previous ignored noop tests have been enabled
<!-- Describe how reviewers and approvers can test this PR. -->
