### PR TITLE
fix(proto): prevent valid operation receipts from being overwritten

### DIFF
--- a/crates/jstz_proto/src/error.rs
+++ b/crates/jstz_proto/src/error.rs
@@ -19,6 +19,7 @@ pub enum Error {
     BalanceOverflow,
     InsufficientFunds,
     InvalidNonce,
+    NoncePassed,
     InvalidAddress,
     InvalidScheme,
     RefererShouldNotBeSet,
@@ -146,6 +147,9 @@ impl From<Error> for JsError {
             #[cfg(feature = "v2_runtime")]
             Error::V2Error(_) => {
                 unimplemented!("V2 runtime errors are not supported in boa")
+            }
+            Error::NoncePassed => {
+                JsNativeError::eval().with_message("NoncePassed").into()
             }
         }
     }

--- a/crates/jstz_proto/src/operation.rs
+++ b/crates/jstz_proto/src/operation.rs
@@ -55,11 +55,11 @@ impl Operation {
     /// Returns the operation's
     pub fn verify_nonce(&self, rt: &mut impl HostRuntime) -> Result<()> {
         let expected_nonce = Account::storage_get_nonce(rt, &self.source())?;
-
         if self.nonce == expected_nonce {
             Account::storage_set_nonce(rt, &self.source(), expected_nonce.next())?;
-
             Ok(())
+        } else if self.nonce.0 < expected_nonce.0 {
+            Err(Error::NoncePassed)
         } else {
             Err(Error::InvalidNonce)
         }


### PR DESCRIPTION
# Context
Closes https://linear.app/tezos/issue/JSTZ-565/operation-receipts-should-not-be-updated

Valid operation receipts should not be overwritten

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
* Allow verify nonce to return Error::NoncePassed to indicate that a nonce being validated has already passed on the account
* Receipt::write skips writing if Error::NoncePassed and the receipt has already exists
<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
`cargo nextest run -p jstz_proto executor --features v2_runtime`
<!-- Describe how reviewers and approvers can test this PR. -->
