### PR TITLE
feat(sequencer): implement sequential stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,12 +141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arbitrary-int"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825297538d77367557b912770ca3083f778a196054b3ee63b22673c4a3cae0a5"
-
-[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,18 +344,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64ct"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
-
-[[package]]
-name = "binary-merge"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597bb81c80a54b6a4381b23faba8d7774b144c94cbd1d6fe3f1329bd776554ab"
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,7 +380,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -535,7 +517,7 @@ dependencies = [
  "icu_normalizer",
  "indexmap 2.6.0",
  "intrusive-collections",
- "itertools 0.13.0",
+ "itertools",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -723,9 +705,6 @@ name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
-dependencies = [
- "allocator-api2",
-]
 
 [[package]]
 name = "bytecheck"
@@ -1008,12 +987,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,176 +1022,6 @@ checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "cranelift"
-version = "0.120.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28bda640bdb33597583178887b25582520457258590a979344f3137a1e64a282"
-dependencies = [
- "cranelift-codegen",
- "cranelift-frontend",
- "cranelift-module",
-]
-
-[[package]]
-name = "cranelift-assembler-x64"
-version = "0.120.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5023e06632d8f351c2891793ccccfe4aef957954904392434038745fb6f1f68"
-dependencies = [
- "cranelift-assembler-x64-meta",
-]
-
-[[package]]
-name = "cranelift-assembler-x64-meta"
-version = "0.120.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c4012b4c8c1f6eb05c0a0a540e3e1ee992631af51aa2bbb3e712903ce4fd65"
-dependencies = [
- "cranelift-srcgen",
-]
-
-[[package]]
-name = "cranelift-bforest"
-version = "0.120.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6d883b4942ef3a7104096b8bc6f2d1a41393f159ac8de12aed27b25d67f895"
-dependencies = [
- "cranelift-entity",
-]
-
-[[package]]
-name = "cranelift-bitset"
-version = "0.120.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7b2ee9eec6ca8a716d900d5264d678fb2c290c58c46c8da7f94ee268175d17"
-
-[[package]]
-name = "cranelift-codegen"
-version = "0.120.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeda0892577afdce1ac2e9a983a55f8c5b87a59334e1f79d8f735a2d7ba4f4b4"
-dependencies = [
- "bumpalo",
- "cranelift-assembler-x64",
- "cranelift-bforest",
- "cranelift-bitset",
- "cranelift-codegen-meta",
- "cranelift-codegen-shared",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-isle",
- "gimli",
- "hashbrown 0.15.0",
- "log",
- "regalloc2",
- "rustc-hash 2.0.0",
- "serde",
- "smallvec",
- "target-lexicon",
-]
-
-[[package]]
-name = "cranelift-codegen-meta"
-version = "0.120.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e461480d87f920c2787422463313326f67664e68108c14788ba1676f5edfcd15"
-dependencies = [
- "cranelift-assembler-x64-meta",
- "cranelift-codegen-shared",
- "cranelift-srcgen",
-]
-
-[[package]]
-name = "cranelift-codegen-shared"
-version = "0.120.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976584d09f200c6c84c4b9ff7af64fc9ad0cb64dffa5780991edd3fe143a30a1"
-
-[[package]]
-name = "cranelift-control"
-version = "0.120.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46d43d70f4e17c545aa88dbf4c84d4200755d27c6e3272ebe4de65802fa6a955"
-dependencies = [
- "arbitrary",
-]
-
-[[package]]
-name = "cranelift-entity"
-version = "0.120.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75418674520cb400c8772bfd6e11a62736c78fc1b6e418195696841d1bf91f1"
-dependencies = [
- "cranelift-bitset",
-]
-
-[[package]]
-name = "cranelift-frontend"
-version = "0.120.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8b1a91c86687a344f3c52dd6dfb6e50db0dfa7f2e9c7711b060b3623e1fdeb"
-dependencies = [
- "cranelift-codegen",
- "log",
- "smallvec",
- "target-lexicon",
-]
-
-[[package]]
-name = "cranelift-isle"
-version = "0.120.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711baa4e3432d4129295b39ec2b4040cc1b558874ba0a37d08e832e857db7285"
-
-[[package]]
-name = "cranelift-jit"
-version = "0.120.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86eece6be06ba68ed88ea8acb59a528deffe9cee09f08f2a422bfec554e82995"
-dependencies = [
- "anyhow",
- "cranelift-codegen",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-module",
- "cranelift-native",
- "libc",
- "log",
- "region",
- "target-lexicon",
- "wasmtime-jit-icache-coherence",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "cranelift-module"
-version = "0.120.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0065b75e59fcd32cfb50f754d6daf56235a2914eecb29e61aa2b4250a095c4c"
-dependencies = [
- "anyhow",
- "cranelift-codegen",
- "cranelift-control",
-]
-
-[[package]]
-name = "cranelift-native"
-version = "0.120.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c83e8666e3bcc5ffeaf6f01f356f0e1f9dcd69ce5511a1efd7ca5722001a3f"
-dependencies = [
- "cranelift-codegen",
- "libc",
- "target-lexicon",
-]
-
-[[package]]
-name = "cranelift-srcgen"
-version = "0.120.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e3f4d783a55c64266d17dc67d2708852235732a100fc40dd9f1051adc64d7b"
 
 [[package]]
 name = "crc32fast"
@@ -1261,16 +1064,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
-dependencies = [
- "generic-array",
- "subtle",
 ]
 
 [[package]]
@@ -1333,7 +1126,6 @@ dependencies = [
  "fiat-crypto",
  "rustc_version 0.4.1",
  "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -1492,14 +1284,11 @@ dependencies = [
 [[package]]
 name = "deno_fetch_base"
 version = "0.202.0"
-source = "git+https://github.com/jstz-dev/deno?branch=leo%2Fextend-fetch-base#8d1d5522ee06190fcc68bd7e5ba65534520edac5"
+source = "git+https://github.com/jstz-dev/deno?branch=leo%2Fextend-fetch-base#26c62e089fe3f1ba624d017821d9c836106bf729"
 dependencies = [
  "bytes",
  "deno_core",
  "deno_error",
- "http 1.1.0",
- "http-body-util",
- "hyper 1.6.0",
  "serde",
 ]
 
@@ -1623,16 +1412,6 @@ name = "der"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79b71cca7d95d7681a4b3b9cdf63c8dbc3730d0584c2c74e31416d64a90493f4"
-
-[[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
- "zeroize",
-]
 
 [[package]]
 name = "deranged"
@@ -1814,9 +1593,9 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
 dependencies = [
- "der 0.4.5",
+ "der",
  "elliptic-curve",
- "hmac 0.11.0",
+ "hmac",
  "signature 1.3.2",
 ]
 
@@ -1826,7 +1605,6 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
  "signature 2.2.0",
 ]
 
@@ -1838,10 +1616,8 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "serde",
  "sha2 0.10.9",
  "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -1849,12 +1625,6 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
-
-[[package]]
-name = "elf"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4445909572dbd556c457c849c4ca58623d84b27c8fff1e74b0b4227d8b90d17b"
 
 [[package]]
 name = "elliptic-curve"
@@ -1897,26 +1667,6 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
-name = "enum-tag"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7696ca164c11153f0885c27f03654e874b052c9198f8964b015f4f675fabf390"
-dependencies = [
- "enum-tag-macro",
-]
-
-[[package]]
-name = "enum-tag-macro"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ccd72f8e71e242f71705868f5478fe7592a6e194c06330d8732421ffdbc554c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.87",
-]
 
 [[package]]
 name = "env_filter"
@@ -2013,12 +1763,6 @@ name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
-
-[[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fallible-streaming-iterator"
@@ -2269,11 +2013,6 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-dependencies = [
- "fallible-iterator 0.3.0",
- "indexmap 2.6.0",
- "stable_deref_trait",
-]
 
 [[package]]
 name = "glob"
@@ -2469,33 +2208,12 @@ checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
 
 [[package]]
 name = "hmac"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
-dependencies = [
- "crypto-mac 0.8.0",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
- "crypto-mac 0.11.0",
+ "crypto-mac",
  "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac-drbg"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
-dependencies = [
- "digest 0.9.0",
- "generic-array",
- "hmac 0.8.1",
 ]
 
 [[package]]
@@ -2666,13 +2384,12 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.14"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
+checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
 dependencies = [
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
@@ -2869,15 +2586,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ieee-apsqrt"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4328941c554aaeea28ca420cd1f10e932fa38874faf8c75e3ed184c64c5c6cec"
-dependencies = [
- "rustc_apfloat",
-]
-
-[[package]]
 name = "if_chain"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2931,15 +2639,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inplace-vec-builder"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf64c2edc8226891a71f127587a2861b132d2b942310843814d5001d99a1d307"
-dependencies = [
- "smallvec",
-]
-
-[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2979,15 +2678,6 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -3037,7 +2727,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tezos-smart-rollup",
- "tezos-smart-rollup-mock 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
+ "tezos-smart-rollup-mock",
  "tokio",
  "url",
  "urlpattern 0.2.0",
@@ -3088,8 +2778,8 @@ dependencies = [
  "syntect",
  "tempfile",
  "tezos-smart-rollup",
- "tezos-smart-rollup-mock 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos_crypto_rs 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
+ "tezos-smart-rollup-mock",
+ "tezos_crypto_rs",
  "tokio",
  "url",
 ]
@@ -3130,10 +2820,10 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tezos-smart-rollup",
- "tezos-smart-rollup-host 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos-smart-rollup-mock 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos_crypto_rs 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos_data_encoding 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
+ "tezos-smart-rollup-host",
+ "tezos-smart-rollup-mock",
+ "tezos_crypto_rs",
+ "tezos_data_encoding",
  "thiserror 1.0.69",
  "tokio",
  "url",
@@ -3154,7 +2844,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
- "tezos_crypto_rs 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
+ "tezos_crypto_rs",
  "utoipa",
 ]
 
@@ -3193,9 +2883,9 @@ dependencies = [
  "jstz_core",
  "jstz_crypto",
  "tezos-smart-rollup",
- "tezos-smart-rollup-mock 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos_crypto_rs 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos_data_encoding 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
+ "tezos-smart-rollup-mock",
+ "tezos_crypto_rs",
+ "tezos_data_encoding",
 ]
 
 [[package]]
@@ -3226,8 +2916,8 @@ dependencies = [
  "mockito",
  "num-traits",
  "octez",
- "octez-riscv",
  "parking_lot",
+ "pin-project",
  "pretty_assertions",
  "r2d2",
  "r2d2_sqlite",
@@ -3237,8 +2927,9 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tezos-smart-rollup",
- "tezos_crypto_rs 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos_data_encoding 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
+ "tezos_crypto_rs",
+ "tezos_data_encoding",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-retry2",
  "tokio-stream",
@@ -3317,9 +3008,9 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tezos-smart-rollup",
- "tezos-smart-rollup-mock 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos_crypto_rs 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos_data_encoding 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
+ "tezos-smart-rollup-mock",
+ "tezos_crypto_rs",
+ "tezos_data_encoding",
  "thiserror 1.0.69",
  "tokio",
  "url",
@@ -3374,8 +3065,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tezos-smart-rollup",
- "tezos-smart-rollup-host 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos-smart-rollup-mock 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
+ "tezos-smart-rollup-host",
+ "tezos-smart-rollup-mock",
  "thiserror 1.0.69",
  "tokio",
  "url",
@@ -3409,8 +3100,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tezos-smart-rollup",
- "tezos_crypto_rs 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos_data_encoding 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
+ "tezos_crypto_rs",
+ "tezos_data_encoding",
 ]
 
 [[package]]
@@ -3432,8 +3123,8 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tezos-smart-rollup",
- "tezos_crypto_rs 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos_data_encoding 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
+ "tezos_crypto_rs",
+ "tezos_data_encoding",
  "tokio",
  "tokio-retry2",
  "tokio-util",
@@ -3495,17 +3186,8 @@ dependencies = [
  "tezos-smart-rollup",
  "tezos-smart-rollup-installer",
  "tezos-smart-rollup-installer-config",
- "tezos_crypto_rs 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
+ "tezos_crypto_rs",
  "tokio",
-]
-
-[[package]]
-name = "keccak"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
-dependencies = [
- "cpufeatures",
 ]
 
 [[package]]
@@ -3561,14 +3243,11 @@ dependencies = [
  "arrayref",
  "base64 0.22.1",
  "digest 0.9.0",
- "hmac-drbg",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand 0.8.5",
  "serde",
- "sha2 0.9.9",
- "typenum",
 ]
 
 [[package]]
@@ -3645,15 +3324,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
-name = "mach2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3664,15 +3334,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "memmap2"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "483758ad303d734cec05e5c12b41d7e93e6a6390c5e9dae6bdeb7c1259012d28"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "memoffset"
@@ -3955,48 +3616,9 @@ dependencies = [
  "serde_with",
  "signal-hook",
  "tempfile",
- "tezos-smart-rollup-encoding 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos_crypto_rs 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
+ "tezos-smart-rollup-encoding",
+ "tezos_crypto_rs",
  "tokio",
-]
-
-[[package]]
-name = "octez-riscv"
-version = "0.0.0"
-source = "git+https://github.com/huancheng-trili/riscv-pvm?rev=6b530863daa11cb4e6ea0ae9202a73f44c0d2d48#6b530863daa11cb4e6ea0ae9202a73f44c0d2d48"
-dependencies = [
- "arbitrary-int",
- "bincode 1.3.3",
- "cranelift",
- "cranelift-jit",
- "cranelift-module",
- "cranelift-native",
- "derive_more",
- "ed25519-dalek",
- "elf",
- "enum-tag",
- "hex",
- "ieee-apsqrt",
- "itertools 0.12.1",
- "libsecp256k1",
- "memmap2",
- "num_enum",
- "paste",
- "range-collections",
- "rustc_apfloat",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "sha3",
- "strum 0.26.3",
- "tezos-smart-rollup-constants 0.2.2 (git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f)",
- "tezos-smart-rollup-utils 0.2.2 (git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f)",
- "tezos_crypto_rs 0.6.0 (git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f)",
- "thiserror 1.0.69",
- "trait-set",
- "try-blocks",
- "tuples",
- "vm-fdt",
 ]
 
 [[package]]
@@ -4245,16 +3867,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der 0.7.10",
- "spki",
-]
 
 [[package]]
 name = "pkg-config"
@@ -4682,18 +4294,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "range-collections"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "861706ea9c4aded7584c5cd1d241cec2ea7f5f50999f236c22b65409a1f1a0d0"
-dependencies = [
- "binary-merge",
- "inplace-vec-builder",
- "ref-cast",
- "smallvec",
-]
-
-[[package]]
 name = "raw-cpuid"
 version = "11.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4720,40 +4320,6 @@ dependencies = [
  "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "ref-cast"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.87",
-]
-
-[[package]]
-name = "regalloc2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5216b1837de2149f8bc8e6d5f88a9326b63b8c836ed58ce4a0a29ec736a59734"
-dependencies = [
- "allocator-api2",
- "bumpalo",
- "hashbrown 0.15.0",
- "log",
- "rustc-hash 2.0.0",
- "smallvec",
 ]
 
 [[package]]
@@ -4790,18 +4356,6 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
-
-[[package]]
-name = "region"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
- "mach2",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "regress"
@@ -4941,7 +4495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "549b9d036d571d42e6e85d1c1425e2ac83491075078ca9a15be021c56b1641f2"
 dependencies = [
  "bitflags 2.6.0",
- "fallible-iterator 0.2.0",
+ "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
@@ -5017,16 +4571,6 @@ name = "rustc-hash"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
-
-[[package]]
-name = "rustc_apfloat"
-version = "0.2.3+llvm-462a31f5a5ab"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486c2179b4796f65bfe2ee33679acf0927ac83ecf583ad6c91c3b4570911b9ad"
-dependencies = [
- "bitflags 2.6.0",
- "smallvec",
-]
 
 [[package]]
 name = "rustc_version"
@@ -5397,16 +4941,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha3"
-version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
-dependencies = [
- "digest 0.10.7",
- "keccak",
-]
-
-[[package]]
 name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5461,9 +4995,6 @@ name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "rand_core 0.6.4",
-]
 
 [[package]]
 name = "simd-abstraction"
@@ -5543,16 +5074,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der 0.7.10",
-]
-
-[[package]]
 name = "sptr"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5604,15 +5125,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
 name = "strum_macros"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5631,19 +5143,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.87",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -5782,12 +5281,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
-name = "target-lexicon"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
-
-[[package]]
 name = "tempfile"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5838,18 +5331,18 @@ version = "0.2.2"
 source = "git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c#0e21f47f1be4564f95c61a6cf32d02a03e87180c"
 dependencies = [
  "hex",
- "tezos-smart-rollup-build-utils 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos-smart-rollup-core 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
+ "tezos-smart-rollup-build-utils",
+ "tezos-smart-rollup-core",
  "tezos-smart-rollup-debug",
- "tezos-smart-rollup-encoding 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
+ "tezos-smart-rollup-encoding",
  "tezos-smart-rollup-entrypoint",
- "tezos-smart-rollup-host 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
+ "tezos-smart-rollup-host",
  "tezos-smart-rollup-macros",
- "tezos-smart-rollup-mock 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
+ "tezos-smart-rollup-mock",
  "tezos-smart-rollup-storage",
- "tezos-smart-rollup-utils 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos_crypto_rs 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos_data_encoding 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
+ "tezos-smart-rollup-utils",
+ "tezos_crypto_rs",
+ "tezos_data_encoding",
 ]
 
 [[package]]
@@ -5863,39 +5356,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "tezos-smart-rollup-build-utils"
-version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f#8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f"
-dependencies = [
- "rustc_version 0.4.1",
-]
-
-[[package]]
 name = "tezos-smart-rollup-constants"
 version = "0.2.2"
 source = "git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c#0e21f47f1be4564f95c61a6cf32d02a03e87180c"
-
-[[package]]
-name = "tezos-smart-rollup-constants"
-version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f#8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f"
 
 [[package]]
 name = "tezos-smart-rollup-core"
 version = "0.2.2"
 source = "git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c#0e21f47f1be4564f95c61a6cf32d02a03e87180c"
 dependencies = [
- "tezos-smart-rollup-build-utils 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos-smart-rollup-constants 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
-]
-
-[[package]]
-name = "tezos-smart-rollup-core"
-version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f#8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f"
-dependencies = [
- "tezos-smart-rollup-build-utils 0.2.2 (git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f)",
- "tezos-smart-rollup-constants 0.2.2 (git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f)",
+ "tezos-smart-rollup-build-utils",
+ "tezos-smart-rollup-constants",
 ]
 
 [[package]]
@@ -5903,8 +5374,8 @@ name = "tezos-smart-rollup-debug"
 version = "0.2.2"
 source = "git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c#0e21f47f1be4564f95c61a6cf32d02a03e87180c"
 dependencies = [
- "tezos-smart-rollup-core 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos-smart-rollup-host 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
+ "tezos-smart-rollup-core",
+ "tezos-smart-rollup-host",
 ]
 
 [[package]]
@@ -5918,29 +5389,10 @@ dependencies = [
  "num-traits",
  "paste",
  "regex",
- "tezos-smart-rollup-core 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos-smart-rollup-host 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos_crypto_rs 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos_data_encoding 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "thiserror 1.0.69",
- "time",
-]
-
-[[package]]
-name = "tezos-smart-rollup-encoding"
-version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f#8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f"
-dependencies = [
- "hex",
- "nom",
- "num-bigint",
- "num-traits",
- "paste",
- "regex",
- "tezos-smart-rollup-core 0.2.2 (git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f)",
- "tezos-smart-rollup-host 0.2.2 (git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f)",
- "tezos_crypto_rs 0.6.0 (git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f)",
- "tezos_data_encoding 0.6.0 (git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f)",
+ "tezos-smart-rollup-core",
+ "tezos-smart-rollup-host",
+ "tezos_crypto_rs",
+ "tezos_data_encoding",
  "thiserror 1.0.69",
  "time",
 ]
@@ -5952,11 +5404,11 @@ source = "git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d
 dependencies = [
  "cfg-if",
  "dlmalloc",
- "tezos-smart-rollup-build-utils 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos-smart-rollup-core 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
+ "tezos-smart-rollup-build-utils",
+ "tezos-smart-rollup-core",
  "tezos-smart-rollup-debug",
- "tezos-smart-rollup-host 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos-smart-rollup-mock 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
+ "tezos-smart-rollup-host",
+ "tezos-smart-rollup-mock",
  "tezos-smart-rollup-panic-hook",
 ]
 
@@ -5965,22 +5417,10 @@ name = "tezos-smart-rollup-host"
 version = "0.2.2"
 source = "git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c#0e21f47f1be4564f95c61a6cf32d02a03e87180c"
 dependencies = [
- "tezos-smart-rollup-build-utils 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos-smart-rollup-core 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos_crypto_rs 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos_data_encoding 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "tezos-smart-rollup-host"
-version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f#8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f"
-dependencies = [
- "tezos-smart-rollup-build-utils 0.2.2 (git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f)",
- "tezos-smart-rollup-core 0.2.2 (git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f)",
- "tezos_crypto_rs 0.6.0 (git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f)",
- "tezos_data_encoding 0.6.0 (git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f)",
+ "tezos-smart-rollup-build-utils",
+ "tezos-smart-rollup-core",
+ "tezos_crypto_rs",
+ "tezos_data_encoding",
  "thiserror 1.0.69",
 ]
 
@@ -5992,10 +5432,10 @@ dependencies = [
  "clap 4.5.20",
  "hex",
  "serde_yaml",
- "tezos-smart-rollup-encoding 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos-smart-rollup-host 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
+ "tezos-smart-rollup-encoding",
+ "tezos-smart-rollup-host",
  "tezos-smart-rollup-installer-config",
- "tezos_data_encoding 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
+ "tezos_data_encoding",
  "thiserror 1.0.69",
  "wasm-gen",
 ]
@@ -6009,11 +5449,11 @@ dependencies = [
  "nom",
  "serde",
  "serde_yaml",
- "tezos-smart-rollup-core 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos-smart-rollup-encoding 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos-smart-rollup-host 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos_crypto_rs 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos_data_encoding 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
+ "tezos-smart-rollup-core",
+ "tezos-smart-rollup-encoding",
+ "tezos-smart-rollup-host",
+ "tezos_crypto_rs",
+ "tezos_data_encoding",
  "thiserror 1.0.69",
 ]
 
@@ -6026,7 +5466,7 @@ dependencies = [
  "quote",
  "shellexpand",
  "syn 2.0.87",
- "tezos-smart-rollup-build-utils 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
+ "tezos-smart-rollup-build-utils",
 ]
 
 [[package]]
@@ -6035,24 +5475,11 @@ version = "0.2.2"
 source = "git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c#0e21f47f1be4564f95c61a6cf32d02a03e87180c"
 dependencies = [
  "hex",
- "tezos-smart-rollup-core 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos-smart-rollup-encoding 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos-smart-rollup-host 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos_crypto_rs 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos_data_encoding 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
-]
-
-[[package]]
-name = "tezos-smart-rollup-mock"
-version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f#8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f"
-dependencies = [
- "hex",
- "tezos-smart-rollup-core 0.2.2 (git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f)",
- "tezos-smart-rollup-encoding 0.2.2 (git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f)",
- "tezos-smart-rollup-host 0.2.2 (git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f)",
- "tezos_crypto_rs 0.6.0 (git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f)",
- "tezos_data_encoding 0.6.0 (git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f)",
+ "tezos-smart-rollup-core",
+ "tezos-smart-rollup-encoding",
+ "tezos-smart-rollup-host",
+ "tezos_crypto_rs",
+ "tezos_data_encoding",
 ]
 
 [[package]]
@@ -6061,8 +5488,8 @@ version = "0.2.2"
 source = "git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c#0e21f47f1be4564f95c61a6cf32d02a03e87180c"
 dependencies = [
  "rustversion",
- "tezos-smart-rollup-build-utils 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos-smart-rollup-core 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
+ "tezos-smart-rollup-build-utils",
+ "tezos-smart-rollup-core",
 ]
 
 [[package]]
@@ -6070,10 +5497,10 @@ name = "tezos-smart-rollup-storage"
 version = "0.2.2"
 source = "git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c#0e21f47f1be4564f95c61a6cf32d02a03e87180c"
 dependencies = [
- "tezos-smart-rollup-core 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
+ "tezos-smart-rollup-core",
  "tezos-smart-rollup-debug",
- "tezos-smart-rollup-encoding 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos-smart-rollup-host 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
+ "tezos-smart-rollup-encoding",
+ "tezos-smart-rollup-host",
  "thiserror 1.0.69",
 ]
 
@@ -6087,28 +5514,11 @@ dependencies = [
  "quanta",
  "serde",
  "serde_json",
- "tezos-smart-rollup-build-utils 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos-smart-rollup-encoding 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos-smart-rollup-mock 0.2.2 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos_crypto_rs 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "tezos_data_encoding 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
-]
-
-[[package]]
-name = "tezos-smart-rollup-utils"
-version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f#8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f"
-dependencies = [
- "clap 4.5.20",
- "hex",
- "quanta",
- "serde",
- "serde_json",
- "tezos-smart-rollup-build-utils 0.2.2 (git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f)",
- "tezos-smart-rollup-encoding 0.2.2 (git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f)",
- "tezos-smart-rollup-mock 0.2.2 (git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f)",
- "tezos_crypto_rs 0.6.0 (git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f)",
- "tezos_data_encoding 0.6.0 (git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f)",
+ "tezos-smart-rollup-build-utils",
+ "tezos-smart-rollup-encoding",
+ "tezos-smart-rollup-mock",
+ "tezos_crypto_rs",
+ "tezos_data_encoding",
 ]
 
 [[package]]
@@ -6131,32 +5541,7 @@ dependencies = [
  "serde",
  "strum 0.20.0",
  "strum_macros 0.20.1",
- "tezos_data_encoding 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "thiserror 1.0.69",
- "zeroize",
-]
-
-[[package]]
-name = "tezos_crypto_rs"
-version = "0.6.0"
-source = "git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f#8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f"
-dependencies = [
- "anyhow",
- "bs58",
- "byteorder 1.5.0",
- "cryptoxide",
- "ed25519-dalek",
- "hex",
- "libsecp256k1",
- "nom",
- "num-bigint",
- "num-traits",
- "p256",
- "rand 0.7.3",
- "serde",
- "strum 0.20.0",
- "strum_macros 0.20.1",
- "tezos_data_encoding 0.6.0 (git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f)",
+ "tezos_data_encoding",
  "thiserror 1.0.69",
  "zeroize",
 ]
@@ -6174,24 +5559,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "serde",
- "tezos_data_encoding_derive 0.6.0 (git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c)",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "tezos_data_encoding"
-version = "0.6.0"
-source = "git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f#8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f"
-dependencies = [
- "bit-vec",
- "bitvec",
- "hex",
- "lazy_static",
- "nom",
- "num-bigint",
- "num-traits",
- "serde",
- "tezos_data_encoding_derive 0.6.0 (git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f)",
+ "tezos_data_encoding_derive",
  "thiserror 1.0.69",
 ]
 
@@ -6199,19 +5567,6 @@ dependencies = [
 name = "tezos_data_encoding_derive"
 version = "0.6.0"
 source = "git+https://github.com/jstz-dev/tezos?rev=0e21f47f1be4564f95c61a6cf32d02a03e87180c#0e21f47f1be4564f95c61a6cf32d02a03e87180c"
-dependencies = [
- "lazy_static",
- "once_cell",
- "parse-display",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "tezos_data_encoding_derive"
-version = "0.6.0"
-source = "git+https://gitlab.com/tezos/tezos.git?rev=8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f#8a0a8d363b085e8d0b5fd89736158dc6d0c0c04f"
 dependencies = [
  "lazy_static",
  "once_cell",
@@ -6451,9 +5806,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "8437150ab6bbc8c5f0f519e3d5ed4aa883a83dd4cdd3d1b21f9482936046cb97"
 dependencies = [
  "bitflags 2.6.0",
  "bytes",
@@ -6496,23 +5851,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trait-set"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79e2e9c9ab44c6d7c20d5976961b47e8f49ac199154daa514b77cd1ab536625"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "try-blocks"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "296cc7892cc05ae83e113b20c113d3fd9020eac7abbbaaeaf69c424ef872be7a"
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6536,12 +5874,6 @@ dependencies = [
  "url",
  "utf-8",
 ]
-
-[[package]]
-name = "tuples"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5dcfa8dec45d3bff92d209a183499f95bf6298c5fea5852a210f15e066e7ca7"
 
 [[package]]
 name = "typeid"
@@ -6811,12 +6143,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dcc60c0624df774c82a0ef104151231d37da4962957d691c011c852b2473314"
 
 [[package]]
-name = "vm-fdt"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e21282841a059bb62627ce8441c491f09603622cd5a21c43bfedc85a2952f23"
-
-[[package]]
 name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6995,18 +6321,6 @@ checksum = "2eeee3bdea6257cc36d756fa745a70f9d393571e47d69e0ed97581676a5369ca"
 dependencies = [
  "deno_error",
  "thiserror 2.0.12",
-]
-
-[[package]]
-name = "wasmtime-jit-icache-coherence"
-version = "33.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7af0e940cb062a45c0b3f01a926f77da5947149e99beb4e3dd9846d5b8f11619"
-dependencies = [
- "anyhow",
- "cfg-if",
- "libc",
- "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/jstz_node/Cargo.toml
+++ b/crates/jstz_node/Cargo.toml
@@ -38,6 +38,7 @@ num-traits.workspace = true
 octez = { path = "../octez" }
 octez-riscv.workspace = true
 parking_lot.workspace = true
+pin-project.workspace = true
 r2d2.workspace = true
 r2d2_sqlite.workspace = true
 reqwest.workspace = true
@@ -48,6 +49,7 @@ tempfile.workspace = true
 tezos-smart-rollup.workspace = true
 tezos_crypto_rs.workspace = true
 tezos_data_encoding.workspace = true
+thiserror.workspace = true
 tokio-retry2.workspace = true
 tokio-stream.workspace = true
 tokio-util.workspace = true

--- a/crates/jstz_node/src/sequencer/inbox/api.rs
+++ b/crates/jstz_node/src/sequencer/inbox/api.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 use anyhow::Result;
 use futures_util::{Stream, StreamExt, TryStreamExt};
+use jstz_proto::BlockLevel;
 use serde::{Deserialize, Serialize};
 use std::io;
 use std::time::Duration;
@@ -17,7 +18,7 @@ pub struct BlockResponse {
 /// Fetches block data from the rollup node for a specific block level.
 pub async fn fetch_block(
     rollup_endpoint: &str,
-    block_level: u32,
+    block_level: BlockLevel,
 ) -> Result<BlockResponse> {
     let url = format!("{rollup_endpoint}/global/block/{block_level}");
     let response = reqwest::get(url).await?;
@@ -28,7 +29,7 @@ pub async fn fetch_block(
 /// Response structure for block monitoring, containing the block level information.
 #[derive(Debug, Deserialize)]
 pub struct MonitorBlocksResponse {
-    pub level: u32,
+    pub level: BlockLevel,
 }
 
 /// Establishes a streaming connection to monitor new blocks from the rollup node.

--- a/crates/jstz_node/src/sequencer/inbox/store.rs
+++ b/crates/jstz_node/src/sequencer/inbox/store.rs
@@ -1,0 +1,136 @@
+use futures_util::future::BoxFuture;
+use jstz_proto::BlockLevel;
+use serde::{Deserialize, Serialize};
+use std::io::{self, Result};
+use std::{path::PathBuf, sync::Arc};
+use tokio::{fs, io::AsyncWriteExt};
+
+/// Boxed future for loading a checkpoint.
+pub type CheckpointLoadFuture = BoxFuture<'static, io::Result<Option<BlockLevel>>>;
+
+/// A trait for storing and loading inbox checkpoint.
+#[async_trait::async_trait]
+pub trait CheckpointStore: Clone + Send + 'static {
+    /// Load the checkpoint block level.
+    async fn load(&self) -> Result<Option<BlockLevel>>;
+    /// Save the checkpoint block level.
+    async fn save(&mut self, level: BlockLevel) -> Result<()>;
+    /// Returns a boxed future for loading the checkpoint.
+    fn load_fut(&self) -> CheckpointLoadFuture {
+        let s = self.clone();
+        Box::pin(async move { s.load().await })
+    }
+}
+
+/// JSON structure written to disk
+#[derive(Serialize, Deserialize)]
+struct CheckpointFile {
+    block_level: BlockLevel,
+}
+
+/// Persists the last processed block level to a JSON file.
+#[derive(Clone)]
+pub struct FileCheckpointStore {
+    path: Arc<PathBuf>,
+}
+
+impl FileCheckpointStore {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self {
+            path: Arc::new(path.into()),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl CheckpointStore for FileCheckpointStore {
+    /// Load the checkpoint from disk.
+    ///
+    /// If the file does not exist or is empty, returns `None`.
+    async fn load(&self) -> Result<Option<BlockLevel>> {
+        match fs::read(&*self.path).await {
+            Ok(bytes) => {
+                if bytes.is_empty() {
+                    println!("checkpoint file is empty");
+                    return Ok(None);
+                }
+
+                let chk: CheckpointFile = serde_json::from_slice(&bytes)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                println!("checkpoint file value: {}", chk.block_level);
+                Ok(Some(chk.block_level))
+            }
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Save the checkpoint to disk safely.
+    async fn save(&mut self, level: BlockLevel) -> Result<()> {
+        let tmp = self.path.with_extension("tmp");
+        let json = serde_json::to_vec(&CheckpointFile { block_level: level })
+            .map_err(io::Error::other)?;
+        // Write to temp file first and then atomically rename it over the old file.
+        // This ensures that file is never left half-written
+        {
+            let mut f = fs::File::create(&tmp).await?;
+            f.write_all(&json).await?;
+            f.flush().await?;
+            let _ = f.sync_all().await;
+        }
+        if fs::metadata(&*self.path).await.is_ok() {
+            let _ = fs::remove_file(&*self.path).await;
+        }
+        fs::rename(&tmp, &*self.path).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+    use tokio::io::AsyncWriteExt;
+
+    #[tokio::test]
+    async fn load_returns_none_when_file_missing() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("checkpoint.json");
+        let store = FileCheckpointStore::new(&path);
+
+        let got = store.load().await.unwrap();
+        assert_eq!(got, None);
+    }
+
+    #[tokio::test]
+    async fn save_then_load_roundtrip() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("checkpoint.json");
+        let mut store = FileCheckpointStore::new(&path);
+
+        store.save(42).await.unwrap();
+        let got = store.load().await.unwrap();
+        assert_eq!(got, Some(42));
+
+        // overwrite with a new value
+        store.save(100).await.unwrap();
+        let got = store.load().await.unwrap();
+        assert_eq!(got, Some(100));
+    }
+
+    #[tokio::test]
+    async fn corrupted_json_yields_error() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("checkpoint.json");
+        let store = FileCheckpointStore::new(&path);
+
+        // Write invalid JSON directly
+        {
+            let mut f = fs::File::create(&path).await.unwrap();
+            f.write_all(b"{not json").await.unwrap();
+            f.flush().await.unwrap();
+        }
+
+        let err = store.load().await.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+}

--- a/crates/jstz_node/src/sequencer/inbox/stream.rs
+++ b/crates/jstz_node/src/sequencer/inbox/stream.rs
@@ -1,0 +1,524 @@
+#![allow(dead_code)]
+use crate::sequencer::inbox::store::{CheckpointLoadFuture, CheckpointStore};
+use futures_util::{stream::BoxStream, FutureExt, Stream, StreamExt};
+use jstz_proto::BlockLevel;
+use log::error;
+use pin_project::pin_project;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::{io, time::Duration};
+use tokio::time::{sleep, Sleep};
+
+/// A stream of live block levels.
+type SourceStream = BoxStream<'static, anyhow::Result<BlockLevel>>;
+
+/// Trait that produces a new source stream when called.
+/// Used to (re)connect to the live block stream as needed.
+pub trait StreamFactory: Fn() -> SourceStream + Send + 'static {}
+impl<T: Fn() -> SourceStream + Send + 'static> StreamFactory for T {}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Error occurred during checkpoint I/O.
+    #[error("Checkpoint I/O error: {0}")]
+    CheckpointIo(#[from] io::Error),
+}
+
+/// Represents a block level that must be committed once processed.
+pub struct PendingBlock<S> {
+    level: BlockLevel,
+    store: S,
+}
+
+impl<S: CheckpointStore> PendingBlock<S> {
+    pub fn new(store: S, level: BlockLevel) -> Self {
+        Self { level, store }
+    }
+
+    /// Mark this block as processed by saving its checkpoint.
+    pub async fn commit(&mut self) -> Result<()> {
+        self.store.save(self.level).await?;
+        Ok(())
+    }
+
+    /// Get the block level.
+    pub fn level(&self) -> BlockLevel {
+        self.level
+    }
+}
+
+#[cfg(test)]
+const RETRY_MS: u64 = 150;
+
+#[cfg(not(test))]
+const RETRY_MS: u64 = 2000;
+
+#[derive(Clone, Copy)]
+enum State {
+    /// Waiting a fixed delay due to io error from the source stream.
+    Backoff,
+    /// Actively polling the live source stream.
+    Streaming,
+    /// Emitting a backlog of block levels in the range [left, right).
+    Backlog((BlockLevel, BlockLevel)),
+    /// Loading the checkpoint from the store to compare with the live block to determine the next block to yield.
+    LoadingCheckpoint { live: BlockLevel },
+}
+
+/// # SequentialBlockStream
+///
+/// This stream provides gap-filling, resumable block level streaming for the inbox monitor,
+/// yielding block levels in order while handling gaps, source stream reconnection, and block progress persistence.
+///
+/// ## Example
+/// ```rust
+/// let stream = SequentialBlockStream::new(store, factory);
+/// pin_mut!(stream);
+/// while let Some(pending_block) = stream.next().await {
+///     if let Ok(pending_block) = pending_block {
+///         // Process the block
+///         pending_block.commit().await?; // Persist progress
+///     }
+/// }
+/// ```
+///
+/// ## State transitions
+///
+///     Streaming (follow live source)
+///         |
+///         | source error / end
+///         |--> Backoff
+///         |
+///         | new block
+///         v
+///     LoadingCheckpoint { live }
+///         |
+///         | Err(e) from store
+///         |--> return error, stay in LoadingCheckpoint
+///         |
+///         | Ok(None) or Ok(chk+1 == live)
+///         |--> yield(live), go to Streaming
+///         |
+///         | Ok(chk+1 < live)
+///         |--> Backlog(chk+1 .. live+1)
+///         |
+///         | Ok(chk >= live)
+///         |--> Backoff
+///         |
+///         |
+///         v
+///         Ok(chk + 1 = live) / None: yield and go back to Streaming
+///
+///     Backlog(L..R)
+///         | if L < R: yield(L), L++, stay in Backlog
+///         | if L == R: go to Streaming
+///
+///     Backoff
+///         | wait(delay) -> Streaming
+///
+/// ## Error Handling
+/// - If the checkpoint store returns an error, the stream will retry indefinitely in LoadingCheckpoint.
+/// - The client is responsible for handling checkpoint store errors.
+/// - If the source stream ends or errors, the stream will automatically reconnect with backoff.
+#[pin_project(project = SequentialBlockStreamProj)]
+pub struct SequentialBlockStream<S, F> {
+    /// Store for block checkpoints.
+    store: S,
+    /// Current state of the stream state machine.
+    state: State,
+    /// The current live source stream, or None if dropped for reconnect/backoff.
+    source_stream: Option<SourceStream>,
+    /// Factory to create a new source stream on demand.
+    stream_factory: F,
+    /// Future for loading the checkpoint.
+    fut: Option<CheckpointLoadFuture>,
+    /// The current delay for backoff, or None if dropped for reconnect/backoff.
+    #[pin]
+    delay: Option<Sleep>,
+}
+
+impl<S, F> SequentialBlockStream<S, F>
+where
+    F: StreamFactory,
+{
+    /// Create a new sequential block stream with the given store and stream factory.
+    pub fn new(store: S, stream_factory: F) -> Self {
+        Self {
+            state: State::Streaming,
+            store,
+            source_stream: None,
+            stream_factory,
+            delay: None,
+            fut: None,
+        }
+    }
+}
+
+impl<S, F> Stream for SequentialBlockStream<S, F>
+where
+    S: CheckpointStore,
+    F: StreamFactory,
+{
+    type Item = Result<PendingBlock<S>>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+        loop {
+            println!("[poll_next] starting loop");
+            let store = this.store.clone();
+            let (next_state, ret) = match *this.state {
+                // Waiting for a delay to pass before trying to reconnect to the source stream
+                State::Backoff => this.handle_backoff(cx),
+                // We know about a gap [left, right) and emit it sequentially.
+                State::Backlog((left, right)) => this.handle_backlog(cx, left, right),
+                // Poll the current block from the source stream and transition to checkpoint loading
+                State::Streaming => this.handle_streaming(cx),
+                // Awaiting a checkpoint store read to compare with `live` and determine the next block to yield.
+                State::LoadingCheckpoint { live } => {
+                    this.handle_loading_checkpoint(cx, live)
+                }
+            };
+            *this.state = next_state;
+            if let Some(ret) = ret {
+                return ret;
+            }
+        }
+    }
+}
+
+type PollResult<S, F> = Poll<Option<<SequentialBlockStream<S, F> as Stream>::Item>>;
+
+impl<'a, S, F> SequentialBlockStreamProj<'a, S, F>
+where
+    S: CheckpointStore,
+    F: StreamFactory,
+{
+    fn handle_backoff(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> (State, Option<PollResult<S, F>>) {
+        println!("[handle_backoff] Entered Backoff");
+        if self.delay.is_none() {
+            self.delay.set(Some(sleep(Duration::from_millis(RETRY_MS))));
+        }
+        match self.delay.as_mut().as_pin_mut().unwrap().poll_unpin(cx) {
+            Poll::Pending => (State::Backoff, Some(Poll::Pending)),
+            Poll::Ready(()) => {
+                self.delay.set(None);
+                (State::Streaming, None)
+            }
+        }
+    }
+
+    fn handle_backlog(
+        &mut self,
+        cx: &mut Context<'_>,
+        left: BlockLevel,
+        right: BlockLevel,
+    ) -> (State, Option<PollResult<S, F>>) {
+        println!("[poll_next] Entered Backlog: left={left}, right={right}");
+        // If there are more blocks in the backlog, yield the next one
+        if left < right {
+            let next = left;
+            println!("[poll_next] Returning PendingBlock for backlog: {next}");
+            (
+                State::Backlog((next + 1, right)),
+                Some(Poll::Ready(Some(Ok(PendingBlock::new(
+                    self.store.clone(),
+                    next,
+                ))))),
+            )
+        } else {
+            // Backlog exhausted, switch to the connected state to stream live blocks
+            println!("[poll_next] Backlog exhausted, switching to Connected");
+            (State::Streaming, None)
+        }
+    }
+
+    fn handle_streaming(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> (State, Option<PollResult<S, F>>) {
+        // Ensure we have a live stream, reconnect if needed
+        let source_stream = self.source_stream.get_or_insert((self.stream_factory)());
+        match source_stream.poll_next_unpin(cx) {
+            // We have a new live block, compare with the local checkpoint
+            Poll::Ready(Some(Ok(live))) => (State::LoadingCheckpoint { live }, None),
+            // An error occurred, reconnect to the source stream
+            Poll::Ready(err) => {
+                let msg = match err {
+                    Some(Err(e)) => format!("Block stream error: {e:?}"),
+                    None => "Block stream ended unexpectedly".to_string(),
+                    _ => unreachable!(),
+                };
+                error!("[handle_streaming] {msg}");
+                // Drop the stream so we reconnect next time
+                self.source_stream.take();
+                (State::Backoff, None)
+            }
+            Poll::Pending => (State::Streaming, Some(Poll::Pending)),
+        }
+    }
+
+    fn handle_loading_checkpoint(
+        &mut self,
+        cx: &mut Context<'_>,
+        live: BlockLevel,
+    ) -> (State, Option<PollResult<S, F>>) {
+        println!("[handle_loading_checkpoint] Entered LoadCheckpoint for block {live}");
+        let fut = self.fut.get_or_insert(self.store.load_fut());
+        match fut.poll_unpin(cx) {
+            Poll::Pending => {
+                println!("[handle_loading_checkpoint] Checkpoint future pending");
+                (State::LoadingCheckpoint { live }, Some(Poll::Pending))
+            }
+            Poll::Ready(Err(e)) => {
+                println!("[handle_loading_checkpoint] Checkpoint future error: {e:?}");
+                // Error loading checkpoint, return error
+                // NOTE: unlikely to happen as checkpoint is saved in the file
+                self.fut.take();
+                (
+                    State::LoadingCheckpoint { live },
+                    Some(Poll::Ready(Some(Err(e.into())))),
+                )
+            }
+            Poll::Ready(Ok(checkpoint)) => {
+                println!("[handle_loading_checkpoint] Checkpoint ready: {checkpoint:?}");
+                let (next_state, next_level) = match checkpoint {
+                    None => (State::Streaming, Some(live)), // Cold start: follow live
+                    Some(chk) if chk + 1 == live => (State::Streaming, Some(live)), // In sync
+                    Some(chk) if chk + 1 < live => {
+                        // Behind: queue the remaining gap into the backlog
+                        (State::Backlog((chk + 1, live + 1)), None)
+                    }
+                    _ /* checkpoint >= live */ => {
+                        // Duplicate/rewind: simplest policy—wait and reconnect.
+                        // TODO: handle block reorg
+                        // lhttps://linear.app/tezos/issue/JSTZ-902/handle-inbox-monitors-block-reorgs
+                        error!("[handle_loading_checkpoint] Checkpoint duplicate/rewind, entering wait");
+                        (State::Backoff, None)
+                    }
+                };
+                self.fut.take();
+                match next_level {
+                    Some(level) => (
+                        next_state,
+                        Some(Poll::Ready(Some(Ok(PendingBlock::new(
+                            self.store.clone(),
+                            level,
+                        ))))),
+                    ),
+                    None => (next_state, None),
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use anyhow::anyhow;
+    use futures_util::future::BoxFuture;
+    use futures_util::{pin_mut, stream};
+    use std::io;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::time::{Duration, Instant};
+
+    #[derive(Clone)]
+    pub(crate) struct MockStore {
+        buffer: Arc<Mutex<Vec<BlockLevel>>>,
+        store_error_count: Arc<AtomicUsize>,
+    }
+
+    impl MockStore {
+        pub(crate) fn new() -> Self {
+            Self {
+                buffer: Arc::new(Mutex::new(vec![])),
+                store_error_count: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+
+        fn buffer(&self) -> Vec<BlockLevel> {
+            self.buffer.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl CheckpointStore for MockStore {
+        // Returns the last block after 10 blocks, then returns 3 errors before returning the last block.
+        async fn load(&self) -> io::Result<Option<BlockLevel>> {
+            let val = self.buffer.lock().unwrap().last().copied();
+            if self.buffer.lock().unwrap().len() == 10 {
+                if self.store_error_count.load(Ordering::SeqCst) == 3 {
+                    return Ok(val);
+                }
+                self.store_error_count.fetch_add(1, Ordering::SeqCst);
+                return Err(io::Error::other("storage error"));
+            }
+            Ok(val)
+        }
+        async fn save(&mut self, level: BlockLevel) -> io::Result<()> {
+            self.buffer.lock().unwrap().push(level);
+            Ok(())
+        }
+    }
+
+    fn mock_stream(block_levels: Vec<anyhow::Result<BlockLevel>>) -> SourceStream {
+        stream::iter(block_levels).boxed()
+    }
+
+    fn mock_store() -> MockStore {
+        MockStore::new()
+    }
+
+    // Process the block stream and save the checkpoints to the store.
+    fn process_stream<'a>(
+        store: &'a mut MockStore,
+        stream: SequentialBlockStream<MockStore, impl StreamFactory>,
+    ) -> BoxFuture<'a, ()> {
+        async {
+            pin_mut!(stream);
+            while let Some(pending_block) = stream.next().await {
+                if let Ok(pending_block) = pending_block {
+                    let _ = store.save(pending_block.level()).await;
+                }
+            }
+        }
+        .boxed()
+    }
+
+    #[tokio::test]
+    async fn stream_follows_source_stream() {
+        // Cold start: follows the source stream
+        let mut store = mock_store();
+        let factory = move || mock_stream(vec![1, 2, 3].into_iter().map(Ok).collect());
+        let stream = SequentialBlockStream::new(store.clone(), factory);
+        let future = process_stream(&mut store, stream);
+        let result = tokio::time::timeout(Duration::from_secs(1), future).await;
+        assert!(
+            result.is_err(),
+            "should timeout as the stream never ends and keeps retrying"
+        );
+        assert_eq!(store.buffer(), (1..=3).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    async fn stream_handles_checkpoint_error() {
+        let mut store = mock_store();
+        // The store returns an error after 10 blocks, then returns the last block after 3 errors.
+        let factory = move || {
+            mock_stream(
+                vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+                    .into_iter()
+                    .map(Ok)
+                    .collect(),
+            )
+        };
+        let stream = SequentialBlockStream::new(store.clone(), factory);
+        let handle = process_stream(&mut store, stream);
+        let result = tokio::time::timeout(Duration::from_secs(3), handle).await;
+        assert!(
+            result.is_err(),
+            "should timeout as the stream never ends and keeps retrying"
+        );
+        assert_eq!(store.buffer(), (1..=12).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    async fn stream_fills_gap_if_source_stream_disconnects_and_reconnects() {
+        let mut store = mock_store();
+        let increment = |c: &AtomicUsize| c.fetch_add(1, Ordering::SeqCst);
+        let count = AtomicUsize::new(0);
+        let factory = move || match count.load(Ordering::SeqCst) {
+            // First try, the source stream yields 1 and errors -> backoff
+            0 => {
+                increment(&count);
+                mock_stream(
+                    vec![Ok(1), Err(anyhow!("stream disconnected"))]
+                        .into_iter()
+                        .collect(),
+                )
+            }
+            // Second try, consecutive errors from the source stream -> backoff
+            1 => {
+                increment(&count);
+                mock_stream(
+                    vec![Err(anyhow!("stream disconnected"))]
+                        .into_iter()
+                        .collect(),
+                )
+            }
+            // Third try, the source stream yields 5 and fails -> ensures backlog is exhausted to fill the gap and backoff
+            2 => {
+                increment(&count);
+                mock_stream(
+                    vec![Ok(5), Err(anyhow!("stream disconnected"))]
+                        .into_iter()
+                        .collect(),
+                )
+            }
+            // Fourth try, the source stream is reconnected quickly and still yields 5 -> backoff
+            3 => {
+                increment(&count);
+                mock_stream(vec![Ok(5)].into_iter().collect())
+            }
+            // Fifth try, the source stream continues to yield blocks
+            4 => mock_stream(vec![Ok(6), Ok(7)].into_iter().collect()),
+            _ => unreachable!(),
+        };
+        let stream = SequentialBlockStream::new(store.clone(), factory);
+        let handle = process_stream(&mut store, stream);
+        let result = tokio::time::timeout(Duration::from_secs(2), handle).await;
+        assert!(
+            result.is_err(),
+            "should timeout as the stream never ends and keeps retrying"
+        );
+        assert_eq!(store.buffer(), (1..=7).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    async fn stream_respects_backoff_delay() {
+        let mut store = mock_store();
+        let factory =
+            move || mock_stream(vec![Err(anyhow!("stream error"))].into_iter().collect());
+
+        let increment = |c: &AtomicUsize| c.fetch_add(1, Ordering::SeqCst);
+        let count = Arc::new(AtomicUsize::new(0));
+        let timestamps = Arc::new(Mutex::new(Vec::new()));
+        let t = timestamps.clone();
+        let count2 = count.clone();
+        let factory = move || {
+            let n = increment(&count2);
+            if n > 0 {
+                t.lock().unwrap().push(Instant::now());
+            }
+            match n {
+                0..=2 => mock_stream(
+                    vec![Err(anyhow!("stream disconnected"))]
+                        .into_iter()
+                        .collect(),
+                ),
+                3 => mock_stream(vec![Ok(1)].into_iter().collect()),
+                _ => mock_stream(vec![]),
+            }
+        };
+        let stream = SequentialBlockStream::new(store.clone(), factory);
+        let handle = process_stream(&mut store, stream);
+        let result = tokio::time::timeout(Duration::from_secs(2), handle).await;
+        assert!(
+            result.is_err(),
+            "should timeout as the stream never ends and keeps retrying"
+        );
+        assert_eq!(store.buffer(), vec![1]);
+        let timestamps = timestamps.lock().unwrap();
+        let first = *timestamps.first().unwrap();
+        let second = *timestamps.get(1).unwrap();
+        let third = *timestamps.get(2).unwrap();
+        assert!(second.duration_since(first) >= Duration::from_millis(RETRY_MS));
+        assert!(third.duration_since(second) >= Duration::from_millis(RETRY_MS));
+    }
+}


### PR DESCRIPTION
# Context

Part of: [696](https://linear.app/tezos/issue/JSTZ-696/implement-sequentialblockstream)

The sequencer monitors the L1 block to process the inbox messages. Currently this monitor isn't resumable as it doesn't keep track of the last processed block level. This PR introduces `SequentialBlockStream`, an abstraction for the sequencer’s inbox monitor. This stream yields block levels in order, automatically handling:
* Gaps in block levels (by filling backlogs)
* Source stream errors and reconnections
* Backoff and retry logic for robustness


In the next PR, we integrate `SequentialBlockStream` into the inbox monitor.
# Description

1. **Introduce `SequentialBlockStream`**  
   The stream can resume from a checkpoint loaded from persistent storage and provides an API to save checkpoints as progress is made. The stream must hold a *load-checkpoint future* so it can be woken and polled by the executor. We store this future on the heap as a boxed trait object (`Box<dyn Future<…>>`), which keeps the implementation straightforward. Technically, we could store it on the stack, but that would require complex type gymnastics with concrete future types. The extra heap allocation is negligible compared to the network I/O anyway. Please refer to the docs [here](https://github.com/jstz-dev/jstz/pull/1312/files#diff-6d8e66e195c9fec73e9fc6b72272708821830aa8321ec451cbb228d534e445b5).  

2. **Introduce `FileCheckpointStore` and `CheckpointStore`**  
   `FileCheckpointStore` implements persistence of the last processed block level via the `CheckpointStore` trait. It opens/closes the checkpoint file on each access.  
   This design prioritizes safety and simplicity:  
   - The OS page cache makes repeated opens cheap.  
   - The “write-to-temp + rename” pattern ensures atomic, crash-safe updates.  
   - Concurrency is not a concern, since only one sequencer process accesses the file.  

3. **Type hygiene**  
   Replaced some APIs that accepted `u32` block levels with the `BlockLevel` newtype from the protocol layer, for stronger type safety.


NOTE: I'm keeping the println! for debugging purpose, in the next step this will be deleted when it is integrated to the sequencer 

 
# Manually testing the PR

Added unit tests 
```
cargo nextest run -p jstz_node
```