### PR TITLE
feat(crypto): handle Secp256k1 secret keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3150,6 +3150,7 @@ dependencies = [
  "boa_gc",
  "derive_more",
  "hex",
+ "libsecp256k1",
  "proptest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,11 @@ http = "1.0.0"
 http-serde = "2.0.0"
 in-container = "^1"
 indicatif = "0.17.0"
+libsecp256k1 = { version = "0.7", default-features = false, features = [
+  "static-context",
+  "hmac",
+  "std",
+] }
 log = "0.4.20"
 mockito = "1.7.0"
 nix = { version = "^0.27.1", features = ["process", "signal"] }

--- a/crates/jstz_crypto/Cargo.toml
+++ b/crates/jstz_crypto/Cargo.toml
@@ -17,6 +17,7 @@ bip39.workspace = true
 boa_gc.workspace = true
 derive_more.workspace = true
 hex.workspace = true
+libsecp256k1.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tezos_crypto_rs.workspace = true

--- a/crates/jstz_crypto/src/error.rs
+++ b/crates/jstz_crypto/src/error.rs
@@ -22,6 +22,11 @@ pub enum Error {
     InvalidSignature,
     InvalidPublicKeyHash,
     InvalidPublicKey,
+    InvalidSecretKey,
+    #[display(fmt = "libsecp256k1 error: {source}")]
+    Libsecp256k1Error {
+        source: libsecp256k1::Error,
+    },
 
     #[display(fmt = "invalid smart function hash")]
     InvalidSmartFunctionHash,
@@ -67,6 +72,13 @@ mod tests {
             (
                 Error::InvalidSmartFunctionHash,
                 "invalid smart function hash",
+            ),
+            (Error::InvalidSecretKey, "InvalidSecretKey"),
+            (
+                Error::Libsecp256k1Error {
+                    source: libsecp256k1::Error::InvalidSecretKey,
+                },
+                "libsecp256k1 error: Invalid secret key",
             ),
         ];
         for (e, expected) in tests {


### PR DESCRIPTION
# Context

Completes JSTZ-903.
[JSTZ-903](https://linear.app/tezos/issue/JSTZ-903/jstz-sdk-does-not-accept-spsk-tz2)

# Description

Updated `jstz_crypto` such that Secp256k1 secret keys become supported.

Note:
* `libsecp256k1==0.7` matches the version used by the upstream crate `tezos_crypto_rs`.
* Signing messages with Secp256k1 secret keys is implemented in this crate because `tezos_crypto_rs` does not implement that.

# Manually testing the PR

* Unit testing: added tests.
  Signatures in the unit test `sign` are verified with taquito. Sample code snippet:
  ```js
  import { InMemorySigner } from "@taquito/signer";

  const edsk = "edsk3caELE9Pmo6Zyy3rNrE1THwYGQc97FUnGz5Si5NC78d6khpW6A";
  const spsk = "spsk1ppL4ohtyZeighKZehzfGr2p6dL51kwQqEV2N1sNT7rx9cg5jG";

  const v = new TextEncoder().encode("foobar");
  // taquito signer expects input values to be hex-encoded messages.
  const bytes = Buffer.from(v).toString("hex");

  const signer = new InMemorySigner(spsk);
  const signature = await signer.sign(bytes);
  console.log(signature);
  ```
