### PR TITLE
feat(kernel): record inbox id of parsed inbox messages

### DIFF
--- a/crates/jstz_kernel/src/wasm_kernel.rs
+++ b/crates/jstz_kernel/src/wasm_kernel.rs
@@ -13,7 +13,7 @@ pub fn run(rt: &mut impl Runtime) {
         tx.begin();
         if let Some(message) = read_message(rt, &ticketer) {
             let _ = rt.mark_for_reboot();
-            match message {
+            match message.content {
                 ParsedInboxMessage::JstzMessage(message) => {
                     handle_message(rt, message, &ticketer, &mut tx, &injector)
                         .await

--- a/crates/jstz_node/src/services/operations.rs
+++ b/crates/jstz_node/src/services/operations.rs
@@ -268,6 +268,7 @@ async fn handle_inbox_message(
     use crate::sequencer::queue::WrappedOperation;
     use jstz_kernel::inbox::{
         encode_signed_operation, parse_inbox_message_hex, Message, ParsedInboxMessage,
+        ParsedInboxMessageWrapper,
     };
     use jstz_proto::operation::internal::InboxId;
     use tezos_smart_rollup::types::SmartRollupAddress;
@@ -287,7 +288,7 @@ async fn handle_inbox_message(
         "failed to parse injected inbox message"
     )))?;
     // parse_inbox_messages does not deal with large payload and thus it needs to be handled here
-    Ok(match message {
+    Ok(match message.content {
         ParsedInboxMessage::JstzMessage(Message::External(m)) => {
             let (op, _) =
                 encode_operation(m, injector, store, rollup_preimages_dir).await?;
@@ -299,7 +300,10 @@ async fn handle_inbox_message(
             .map_err(|e| ServiceError::FromAnyhow(anyhow::anyhow!("{e}")))?;
 
             WrappedOperation::FromInbox {
-                message: ParsedInboxMessage::JstzMessage(Message::External(op)),
+                message: ParsedInboxMessageWrapper {
+                    content: ParsedInboxMessage::JstzMessage(Message::External(op)),
+                    inbox_id: message.inbox_id,
+                },
                 original_inbox_message: hex::encode(buf),
             }
         }

--- a/crates/jstz_riscv_wpt_test_kernel/src/lib.rs
+++ b/crates/jstz_riscv_wpt_test_kernel/src/lib.rs
@@ -15,7 +15,7 @@ const DEFAULT_TICKETER_ADDRESS: &str = "KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton";
 fn read_message(
     rt: &mut impl Runtime,
     ticketer: &ContractKt1Hash,
-) -> Option<ParsedInboxMessage> {
+) -> Option<ParsedInboxMessageWrapper> {
     let input = match rt.read_input() {
         Ok(input) => match input {
             Some(input) => input,
@@ -46,7 +46,7 @@ pub fn run(rt: &mut impl Runtime) {
 
     while let Some(message) = read_message(rt, &ticketer) {
         if let ParsedInboxMessage::JstzMessage(Message::External(signed_operation)) =
-            message
+            message.content
         {
             let operation: Operation = signed_operation.into();
             if let Content::DeployFunction(deploy_function) = operation.content {


### PR DESCRIPTION
# Context

Part of JSTZ-804.
[JSTZ-804](https://linear.app/tezos/issue/JSTZ-804/configure-riscv-pvm-in-sequencer)

Since inbox ID is used to derive operation hashes for deposit operations, inbox ID must be preserved with parsed inbox messages such that the RISCV PVM is aware of this information while loading messages.

# Description

Introduced one wrapper struct `ParsedInboxMessageWrapper` that packs the existing `ParsedInboxMessage` and an inbox message's inbox ID. To avoid unnecessary distracting changes, the awkward name `ParsedInboxMessageWrapper` is chosen instead of using `ParsedInboxMessage` and renaming the enum. Renaming can be carried out later on if necessary.

# Manually testing the PR

* Unit testing: updated existing tests to cover index IDs
