### PR TITLE
fix: revert alpine removal

### DIFF
--- a/.github/workflows/cli-npm-test.yaml
+++ b/.github/workflows/cli-npm-test.yaml
@@ -2,8 +2,6 @@ name: Build npm package for jstz CLI
 
 on:
   push:
-    tags:
-      - "*"
 
 jobs:
   macos-arm64:


### PR DESCRIPTION
Please go the the `Preview` tab and select the appropriate sub-template:

- [🚧 Web/runtime APIs template](?expand=1&template=api_dev.md)
- [📚 Web/runtime APIs documentation template](?expand=1&template=api_doc.md)
- [⬜️ Blank template](?expand=1&template=default.md)
