### PR TITLE
refactor(proto): improve fetch error

### DIFF
--- a/crates/jstz_proto/src/runtime/v2/fetch/error.rs
+++ b/crates/jstz_proto/src/runtime/v2/fetch/error.rs
@@ -25,25 +25,22 @@ pub enum FetchError {
     #[class(type)]
     #[error("Invalid Response type")]
     InvalidResponseType,
-    #[class("RuntimeError")]
+    #[class(generic)]
     #[error(transparent)]
     RuntimeError(#[from] RuntimeError),
-    #[class(not_supported)]
-    #[error("{0}")]
+    #[class(generic)]
+    #[error("NotSupportedError:{0}")]
     NotSupported(&'static str),
     #[class(generic)]
     #[error("Oracle calls are not allowed to be called from RunFunction")]
     TopLevelOracleCallNotSupported,
-    #[class("ProtocolError")]
-    #[error("Source address must be user address")]
-    InvalidSourceAddress,
     #[class(inherit)]
     #[error(transparent)]
     OracleError(#[from] OracleError),
     // TODO: Boa's JsClass errors are not Send safe. Once we remove boa, we
     // should be able to use crate::Error type directly
-    #[class("RuntimeError")]
-    #[error("{0}")]
+    #[class(generic)]
+    #[error("JstzError: {0}")]
     JstzError(String),
     #[class(syntax)]
     #[error("Smart function '{address}' has no code")]

--- a/crates/jstz_proto/src/runtime/v2/fetch/fetch_handler.rs
+++ b/crates/jstz_proto/src/runtime/v2/fetch/fetch_handler.rs
@@ -753,7 +753,9 @@ impl TryFrom<Address> for SourceAddress {
         if matches!(source, Address::User(_)) {
             Ok(SourceAddress(source))
         } else {
-            Err(FetchError::InvalidSourceAddress)
+            Err(FetchError::JstzError(
+                "Source address must be user address".to_string(),
+            ))
         }
     }
 }
@@ -917,7 +919,7 @@ mod test {
             assert_eq!(response.status, 500);
             assert_eq!(response.status_text, "InternalServerError");
             assert_eq!(
-                json!({"class":"RuntimeError","message":"InvalidAddress"}),
+                json!({"class":"Error","message":"JstzError: InvalidAddress"}),
                 serde_json::from_slice::<JsonValue>(response.body.to_vec().as_slice())
                     .unwrap()
             );
@@ -1498,7 +1500,7 @@ mod test {
 
             assert_eq!(500, response.status);
             assert_eq!(
-                json!({"class":"RuntimeError","message":"InsufficientFunds"}),
+                json!({"class":"Error","message":"JstzError: InsufficientFunds"}),
                 serde_json::from_slice::<JsonValue>(response.body.to_vec().as_slice())
                     .unwrap()
             )
@@ -1678,7 +1680,7 @@ mod test {
         assert_eq!("InternalServerError", response.status_text);
         assert_eq!(500, response.status);
         assert_eq!(
-            json!({"class":"RuntimeError","message":"Error: boom\n    at default (jstz://KT1WSFFotGccKa4WZ5PNQGT3EgsRutzLMD4z:2:19)"}),
+            json!({"class":"Error","message":"Error: boom\n    at default (jstz://KT1WSFFotGccKa4WZ5PNQGT3EgsRutzLMD4z:2:19)"}),
             serde_json::from_slice::<JsonValue>(response.body.to_vec().as_slice())
                 .unwrap()
         );

--- a/crates/jstz_proto/src/runtime/v2/parsed_code.rs
+++ b/crates/jstz_proto/src/runtime/v2/parsed_code.rs
@@ -253,7 +253,7 @@ pub enum ParseError {
     #[error(transparent)]
     Other(#[from] jstz_runtime::error::RuntimeError),
 
-    #[class(not_supported)]
+    #[class(generic)]
     #[error("Import specifiers are not supported")]
     ImportsNotSupported,
 
@@ -378,7 +378,7 @@ mod test {
         let error = ParsedCode::parse(code.to_string()).unwrap_err();
         println!("{:?}", error);
         assert!(matches!(error, ParseError::ImportsNotSupported));
-        assert_eq!(error.get_class(), "NotSupported");
+        assert_eq!(error.get_class(), "Error");
         assert_eq!(error.get_message(), "Import specifiers are not supported");
     }
 
@@ -395,7 +395,7 @@ mod test {
             error,
             ParseError::CompileModuleError(CompileModuleError(_))
         ));
-        assert_eq!(error.get_class(), "CompileModuleError");
-        assert_eq!(error.get_message(), "Uncaught undefined");
+        assert_eq!(error.get_class(), "Error");
+        assert_eq!(error.get_message(), "Uncaught Error: Kv is not supported");
     }
 }

--- a/crates/jstz_runtime/src/ext/jstz_console/mod.rs
+++ b/crates/jstz_runtime/src/ext/jstz_console/mod.rs
@@ -202,9 +202,7 @@ mod tests {
         let mut runtime = JstzRuntime::new(JstzRuntimeOptions::default());
         let code = r#"console.info("hello")"#;
         let err = runtime.execute(code).unwrap_err();
-        assert_eq!(
-            "Error: Uncaught undefined",
-            format!("{}: {}", err.get_class(), err.get_message())
-        );
+        assert_eq!("Error", err.get_class());
+        assert_eq!("Error: console is not supported\n    at Console.console.Console.noColorStdout (ext:jstz_console/console.js:4:44)\n    at console.info (ext:deno_console/01_console.js:3167:20)\n    at jstz://run:1:9", err.get_message());
     }
 }

--- a/crates/jstz_runtime/src/ext/jstz_fetch/mod.rs
+++ b/crates/jstz_runtime/src/ext/jstz_fetch/mod.rs
@@ -84,8 +84,11 @@ mod test {
             let id = runtime.execute_main_module(&specifier).await.unwrap();
             let err = runtime.call_default_handler(id, &[]).await.unwrap_err();
             assert_eq!(
-                "Error: Uncaught (in promise) undefined",
-                format!("{}: {}", err.get_class(), err.get_message())
+                "Error",
+                err.get_class()
+            );
+            assert!(
+                err.get_message().contains("fetch is not supported")
             );
         });
     }

--- a/crates/jstz_runtime/src/ext/jstz_kv/mod.rs
+++ b/crates/jstz_runtime/src/ext/jstz_kv/mod.rs
@@ -121,31 +121,23 @@ pub(crate) mod extension {
             let mut runtime = JstzRuntime::new(JstzRuntimeOptions::default());
             let code = r#"Kv.set("hello", "world")"#;
             let err = runtime.execute(code).unwrap_err();
-            assert_eq!(
-                "Error: Uncaught undefined",
-                format!("{}: {}", err.get_class(), err.get_message())
-            );
+            assert_eq!("Error", err.get_class());
+            assert!(err.get_message().contains("Kv is not supported"));
 
             let code = r#"Kv.get("hello")"#;
             let err = runtime.execute(code).unwrap_err();
-            assert_eq!(
-                "Error: Uncaught undefined",
-                format!("{}: {}", err.get_class(), err.get_message())
-            );
+            assert_eq!("Error", err.get_class());
+            assert!(err.get_message().contains("Kv is not supported"));
 
             let code = r#"Kv.contains("hello")"#;
             let err = runtime.execute(code).unwrap_err();
-            assert_eq!(
-                "Error: Uncaught undefined",
-                format!("{}: {}", err.get_class(), err.get_message())
-            );
+            assert_eq!("Error", err.get_class());
+            assert!(err.get_message().contains("Kv is not supported"));
 
             let code = r#"Kv.delete("hello")"#;
             let err = runtime.execute(code).unwrap_err();
-            assert_eq!(
-                "Error: Uncaught undefined",
-                format!("{}: {}", err.get_class(), err.get_message())
-            );
+            assert_eq!("Error", err.get_class());
+            assert!(err.get_message().contains("Kv is not supported"));
         }
     }
 }

--- a/crates/jstz_runtime/src/ext/mod.rs
+++ b/crates/jstz_runtime/src/ext/mod.rs
@@ -6,7 +6,7 @@ pub(crate) mod jstz_main;
 pub use jstz_fetch::FetchHandlerOptions;
 
 #[derive(Debug, ::thiserror::Error, deno_error::JsError)]
-#[class(not_supported)]
+#[class(generic)]
 #[error("{name} is not supported")]
 pub struct NotSupported {
     pub name: &'static str,

--- a/crates/jstz_runtime/src/runtime.rs
+++ b/crates/jstz_runtime/src/runtime.rs
@@ -252,10 +252,6 @@ impl JstzRuntime {
             let default_fn = v8::Local::<v8::Function>::try_from(default_value)?;
             v8::Global::new(scope, default_fn)
         };
-        // Note: [`call_with_args`] wraps the scope with TryCatch for us and converts
-        // any exception into an error
-        // FIXME(ryan): If user code throws an uncaught exception, the original
-        // exception is lost and replaced with Uncaught undefined
         let fut = self.call_with_args(&default_fn, args);
         let result = self.with_event_loop_future(fut, Default::default()).await;
         Ok(result?)


### PR DESCRIPTION
# Context

This PR refactors and improves error handling in the v2 runtime. Previously, when using non-standard or custom error types with the deno_error::JsError macro (such as a custom error or NotSupportedError), the Deno runtime failed to propagate the error message correctly outside of the promise, resulting in "undefined" being shown in JavaScript.
```rust
#[derive(Debug, thiserror::Error, deno_error::JsError)]
pub enum MyError {
    #[class("CustomError")]
    CustomError,
}
```

```js
try {
  await someOpThatReturnsCustomError();
} catch (e) {
  console.log(e); // undefined
}
```

This PR addresses these propagation issues and ensures error messages are handled more reliably. For reference, see [the list of standard built-in js error types](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#error_types) for the list of standard builtin error types.

# Description

* Removed the "ProtocolError" and merged it with "JstzError". The concept of protocol error can be communicated via the message, not via the class type. 
* Replaced the custom error type with the standard generic error type. 
* Replaced the NotSupported error type with the standard generic error type. 

# Manually testing the PR

Fixed unit tests
