### PR TITLE
feat(cli): update network

### DIFF
--- a/crates/jstz_cli/tests/network.rs
+++ b/crates/jstz_cli/tests/network.rs
@@ -161,3 +161,161 @@ fn add_network() {
         )
         .success();
 }
+
+#[test]
+fn update_network() {
+    let network_name = "foo";
+    let tmp_dir = TempDir::new().unwrap();
+    let home_path = tmp_dir.path().to_string_lossy().to_string();
+    let path = tmp_dir.path().join(".config/jstz/config.json");
+    create_dir_all(path.parent().expect("should find parent dir"))
+        .expect("should create dir");
+    let file = File::create(&path).expect("should create file");
+    serde_json::to_writer(
+        file,
+        &serde_json::json!({
+            "networks": {
+                network_name: {
+                    "octez_node_rpc_endpoint": "http://octez.test",
+                    "jstz_node_endpoint": "http://jstz.test"
+                },
+            }
+        }),
+    )
+    .expect("should write config file");
+
+    // network should be listed
+    Command::cargo_bin("jstz")
+        .unwrap()
+        .env("HOME", &home_path)
+        .args(["network", "list"])
+        .assert()
+        .stderr(
+            predicates::str::contains(network_name)
+                .and(predicates::str::contains("http://octez.test"))
+                .and(predicates::str::contains("http://jstz.test")),
+        )
+        .success();
+
+    // update octez endpoint
+    Command::cargo_bin("jstz")
+        .unwrap()
+        .env("HOME", &home_path)
+        .args([
+            "network",
+            "update",
+            network_name,
+            "--octez-node-rpc-endpoint",
+            "http://v2.octez.test",
+        ])
+        .assert()
+        .stderr(predicates::str::contains(format!(
+            "Updated network '{network_name}'.",
+        )))
+        .success();
+
+    // network should be listed with new octez endpoint
+    Command::cargo_bin("jstz")
+        .unwrap()
+        .env("HOME", &home_path)
+        .args(["network", "list"])
+        .assert()
+        .stderr(
+            predicates::str::contains(network_name)
+                .and(predicates::str::contains("http://v2.octez.test"))
+                .and(predicates::str::contains("http://jstz.test")),
+        )
+        .success();
+
+    // update jstz endpoint
+    Command::cargo_bin("jstz")
+        .unwrap()
+        .env("HOME", &home_path)
+        .args([
+            "network",
+            "update",
+            network_name,
+            "--jstz-node-endpoint",
+            "http://v2.jstz.test",
+        ])
+        .assert()
+        .stderr(predicates::str::contains(format!(
+            "Updated network '{network_name}'.",
+        )))
+        .success();
+
+    // network should be listed with new jstz endpoint
+    Command::cargo_bin("jstz")
+        .unwrap()
+        .env("HOME", &home_path)
+        .args(["network", "list"])
+        .assert()
+        .stderr(
+            predicates::str::contains(network_name)
+                .and(predicates::str::contains("http://v2.octez.test"))
+                .and(predicates::str::contains("http://v2.jstz.test")),
+        )
+        .success();
+
+    // update both
+    Command::cargo_bin("jstz")
+        .unwrap()
+        .env("HOME", &home_path)
+        .args([
+            "network",
+            "update",
+            network_name,
+            "--jstz-node-endpoint",
+            "http://v3.jstz.test",
+            "--octez-node-rpc-endpoint",
+            "http://v3.octez.test",
+        ])
+        .assert()
+        .stderr(predicates::str::contains(format!(
+            "Updated network '{network_name}'.",
+        )))
+        .success();
+
+    // network should be listed with new jstz endpoint
+    Command::cargo_bin("jstz")
+        .unwrap()
+        .env("HOME", &home_path)
+        .args(["network", "list"])
+        .assert()
+        .stderr(
+            predicates::str::contains(network_name)
+                .and(predicates::str::contains("http://v3.octez.test"))
+                .and(predicates::str::contains("http://v3.jstz.test")),
+        )
+        .success();
+
+    // missing options
+    Command::cargo_bin("jstz")
+        .unwrap()
+        .env("HOME", &home_path)
+        .args(["network", "update", network_name])
+        .assert()
+        .stderr(predicates::str::contains(
+            "the following required arguments were not provided",
+        ))
+        .failure();
+
+    // option used multiple times
+    Command::cargo_bin("jstz")
+        .unwrap()
+        .env("HOME", &home_path)
+        .args([
+            "network",
+            "update",
+            network_name,
+            "--octez-node-rpc-endpoint",
+            "http://v4.octez.test",
+            "--octez-node-rpc-endpoint",
+            "http://v5.octez.test",
+        ])
+        .assert()
+        .stderr(predicates::str::contains(
+            "the argument '--octez-node-rpc-endpoint <OCTEZ_NODE_RPC_ENDPOINT>' cannot be used multiple times",
+        ))
+        .failure();
+}


### PR DESCRIPTION
# Context

Part of JSTZ-783.
[JSTZ-783](https://linear.app/tezos/issue/JSTZ-783/support-jstz-network-addupdatedelete)

# Description

Added one command `network update` to CLI to update networks in the config file.

Example:
```sh
$ jstz network list
  +------+--------------------+--------------------+
  | Name | Octez RPC endpoint | Jstz node endpoint |
  +======+====================+====================+
  | foo  | http://a.com       | http://b.com       |
  +------+--------------------+--------------------+

$ jstz network update foo --octez-node-rpc-endpoint http://c.com --jstz-node-endpoint http://d.com
Updated network 'foo'.
$ jstz network list
  +------+--------------------+--------------------+
  | Name | Octez RPC endpoint | Jstz node endpoint |
  +======+====================+====================+
  | foo  | http://c.com       | http://d.com       |
  +------+--------------------+--------------------+

```

# Manually testing the PR

* Integration test: added one test
