### PR TITLE
feat(cli): delete network

### DIFF
--- a/crates/jstz_cli/src/network.rs
+++ b/crates/jstz_cli/src/network.rs
@@ -44,6 +44,12 @@ pub enum Command {
         #[command(flatten)]
         args: UpdateArgs,
     },
+    /// Delete a network.
+    Delete {
+        /// Name of the network to be deleted.
+        #[arg(value_name = "NETWORK_NAME")]
+        name: String,
+    },
 }
 
 pub async fn exec(command: Command) -> Result<()> {
@@ -140,6 +146,16 @@ pub async fn exec(command: Command) -> Result<()> {
 
             cfg.save()?;
             info!("Updated network '{short_name}'.");
+            Ok(())
+        }
+        Command::Delete { name } => {
+            let short_name = trim_long_string(&name, 20);
+            if cfg.networks.networks.remove(&name).is_none() {
+                bail_user_error!("Network '{short_name}' does not exist.");
+            }
+
+            cfg.save()?;
+            info!("Deleted network '{short_name}'.");
             Ok(())
         }
     }


### PR DESCRIPTION
# Context

Part of JSTZ-783.
[JSTZ-783](https://linear.app/tezos/issue/JSTZ-783/support-jstz-network-addupdatedelete)

# Description

Added one command `network delete` to CLI to delete networks from the config file.

Example:
```sh
$ jstz network list
  +------+--------------------+--------------------+
  | Name | Octez RPC endpoint | Jstz node endpoint |
  +======+====================+====================+
  | foo  | http://a.com       | http://b.com       |
  +------+--------------------+--------------------+

$ jstz network delete foo
Deleted network 'foo'.
$ jstz network list      
  +------+--------------------+--------------------+
  | Name | Octez RPC endpoint | Jstz node endpoint |
  +======+====================+====================+
  +------+--------------------+--------------------+


```

# Manually testing the PR

* Integration test: added one test
