### PR TITLE
feat(runtime): register custom errors

### DIFF
--- a/crates/jstz_proto/src/runtime/v2/fetch/error.rs
+++ b/crates/jstz_proto/src/runtime/v2/fetch/error.rs
@@ -11,6 +11,8 @@ use super::http::*;
 
 pub type Result<T> = std::result::Result<T, FetchError>;
 
+// Note: When adding a custom error class (e.g. `class("CustomError")`),
+// make sure to register on the js side in `jstz_runtime/src/ext/jstz_main/98_global_scope.js`.
 #[derive(Debug, thiserror::Error, deno_error::JsError)]
 pub enum FetchError {
     #[class(type)]
@@ -34,7 +36,7 @@ pub enum FetchError {
     #[class(generic)]
     #[error("Oracle calls are not allowed to be called from RunFunction")]
     TopLevelOracleCallNotSupported,
-    #[class("ProtocolError")]
+    #[class("RuntimeError")]
     #[error("Source address must be user address")]
     InvalidSourceAddress,
     #[class(inherit)]

--- a/crates/jstz_runtime/src/ext/jstz_console/mod.rs
+++ b/crates/jstz_runtime/src/ext/jstz_console/mod.rs
@@ -202,9 +202,10 @@ mod tests {
         let mut runtime = JstzRuntime::new(JstzRuntimeOptions::default());
         let code = r#"console.info("hello")"#;
         let err = runtime.execute(code).unwrap_err();
+        assert_eq!("NotSupported", err.get_class());
         assert_eq!(
-            "Error: Uncaught undefined",
-            format!("{}: {}", err.get_class(), err.get_message())
+            "NotSupported: console is not supported\n    at Console.console.Console.noColorStdout (ext:jstz_console/console.js:4:44)\n    at console.info (ext:deno_console/01_console.js:3167:20)\n    at jstz://run:1:9",
+             err.get_message()
         );
     }
 }

--- a/crates/jstz_runtime/src/ext/jstz_fetch/mod.rs
+++ b/crates/jstz_runtime/src/ext/jstz_fetch/mod.rs
@@ -83,10 +83,8 @@ mod test {
             });
             let id = runtime.execute_main_module(&specifier).await.unwrap();
             let err = runtime.call_default_handler(id, &[]).await.unwrap_err();
-            assert_eq!(
-                "Error: Uncaught (in promise) undefined",
-                format!("{}: {}", err.get_class(), err.get_message())
-            );
+            assert_eq!(err.get_class(), "NotSupported");
+            assert!(err.get_message().contains("fetch is not supported"));
         });
     }
 }

--- a/crates/jstz_runtime/src/ext/jstz_kv/mod.rs
+++ b/crates/jstz_runtime/src/ext/jstz_kv/mod.rs
@@ -121,31 +121,23 @@ pub(crate) mod extension {
             let mut runtime = JstzRuntime::new(JstzRuntimeOptions::default());
             let code = r#"Kv.set("hello", "world")"#;
             let err = runtime.execute(code).unwrap_err();
-            assert_eq!(
-                "Error: Uncaught undefined",
-                format!("{}: {}", err.get_class(), err.get_message())
-            );
+            assert_eq!(err.get_class(), "NotSupported");
+            assert!(err.get_message().contains("Kv is not supported"));
 
             let code = r#"Kv.get("hello")"#;
             let err = runtime.execute(code).unwrap_err();
-            assert_eq!(
-                "Error: Uncaught undefined",
-                format!("{}: {}", err.get_class(), err.get_message())
-            );
+            assert_eq!(err.get_class(), "NotSupported");
+            assert!(err.get_message().contains("Kv is not supported"));
 
             let code = r#"Kv.contains("hello")"#;
             let err = runtime.execute(code).unwrap_err();
-            assert_eq!(
-                "Error: Uncaught undefined",
-                format!("{}: {}", err.get_class(), err.get_message())
-            );
+            assert_eq!(err.get_class(), "NotSupported");
+            assert!(err.get_message().contains("Kv is not supported"));
 
             let code = r#"Kv.delete("hello")"#;
             let err = runtime.execute(code).unwrap_err();
-            assert_eq!(
-                "Error: Uncaught undefined",
-                format!("{}: {}", err.get_class(), err.get_message())
-            );
+            assert_eq!(err.get_class(), "NotSupported");
+            assert!(err.get_message().contains("Kv is not supported"));
         }
     }
 }

--- a/crates/jstz_runtime/src/ext/jstz_main/01_errors.js
+++ b/crates/jstz_runtime/src/ext/jstz_main/01_errors.js
@@ -1,6 +1,43 @@
-export class NotSupported extends Error {
-  constructor(msg) {
-    super(msg);
-    this.name = "NotSupported";
-  }
-}
+import { core } from "ext:core/mod.js";
+
+// Builtin v8 / JS errors
+// https://github.com/denoland/deno_core/blob/0694f1763f4cecc84dd32e2052aa6d639b1b83ed/core/00_infra.js#L81
+const BUILT_IN_V8_ERRORS = [
+  "Error",
+  "RangeError",
+  "ReferenceError",
+  "SyntaxError",
+  "TypeError",
+  "URIError",
+];
+
+/**
+ * Define and register multiple custom error classes by name.
+ * Ensures class names are unique in the given array and are not built-in v8 errors.
+ *
+ * @param {string[]} names - Array of error class names to define.
+ * @returns {Record<string, typeof Error>} An object mapping error names to their constructors.
+ */
+export const registerErrorClasses = (names) => {
+  const uniqueNames = [...new Set(names)];
+  const entries = uniqueNames.map((name) => {
+    if (typeof name !== "string" || name.length === 0) {
+      throw new TypeError("Error class name must be a non-empty string");
+    }
+
+    if (BUILT_IN_V8_ERRORS.includes(name)) {
+      throw new TypeError(`Error class name ${name} is a built-in v8 error`);
+    }
+
+    const ErrorClass = class extends Error {
+      constructor(message) {
+        super(message);
+        this.name = name;
+      }
+    };
+    core.registerErrorClass(name, ErrorClass);
+    return [name, ErrorClass];
+  });
+
+  return Object.fromEntries(entries);
+};

--- a/crates/jstz_runtime/src/ext/jstz_main/mod.rs
+++ b/crates/jstz_runtime/src/ext/jstz_main/mod.rs
@@ -90,7 +90,7 @@ mod test {
             }
             let id = runtime.execute_main_module(&s).await.unwrap();
             let error = runtime.call_default_handler(id, &[]).await.unwrap_err();
-            assert_eq!(error.to_string(), "NotSupported: 'setTimeout()' is not supported\n    at ext:jstz_main/98_global_scope.js:198:11\n    at handler (file://jstz/accounts/root:1:21)");
+            assert_eq!(error.to_string(), "NotSupported: 'setTimeout()' is not supported\n    at ext:jstz_main/98_global_scope.js:209:11\n    at handler (file://jstz/accounts/root:1:21)");
         });
     }
 
@@ -108,7 +108,7 @@ mod test {
         let error = runtime.call_default_handler(id, &[]).await.unwrap_err();
         // FIXME: Do not show line number stacktrace to users
         // https://linear.app/tezos/issue/JSTZ-665
-        assert_eq!(error.to_string(), "NotSupported: 'setInterval()' is not supported\n    at ext:jstz_main/98_global_scope.js:194:11\n    at handler (file://jstz/accounts/root:1:21)");
+        assert_eq!(error.to_string(), "NotSupported: 'setInterval()' is not supported\n    at ext:jstz_main/98_global_scope.js:205:11\n    at handler (file://jstz/accounts/root:1:21)");
       });
     }
 
@@ -124,7 +124,7 @@ mod test {
             }
             let id = runtime.execute_main_module(&s).await.unwrap();
             let error = runtime.call_default_handler(id, &[]).await.unwrap_err();
-            assert_eq!(error.to_string(), "NotSupported: 'clearTimeout()' is not supported\n    at ext:jstz_main/98_global_scope.js:185:11\n    at handler (file://jstz/accounts/root:1:21)");
+            assert_eq!(error.to_string(), "NotSupported: 'clearTimeout()' is not supported\n    at ext:jstz_main/98_global_scope.js:196:11\n    at handler (file://jstz/accounts/root:1:21)");
         });
     }
 
@@ -140,7 +140,25 @@ mod test {
             }
             let id = runtime.execute_main_module(&s).await.unwrap();
             let error = runtime.call_default_handler(id, &[]).await.unwrap_err();
-            assert_eq!(error.to_string(), "NotSupported: 'clearInterval()' is not supported\n    at ext:jstz_main/98_global_scope.js:181:11\n    at handler (file://jstz/accounts/root:1:21)");
+            assert_eq!(error.to_string(), "NotSupported: 'clearInterval()' is not supported\n    at ext:jstz_main/98_global_scope.js:192:11\n    at handler (file://jstz/accounts/root:1:21)");
+        });
+    }
+
+    #[test]
+    pub fn runtime_error_is_supported() {
+        TOKIO_MULTI_THREAD.block_on(async {
+            let code = r#"let handler = () => {throw new RuntimeError("boom")};
+                    export default handler;"#;
+            init_test_setup! {
+                  runtime = runtime;
+                  specifier = (s, code);
+            }
+            let id = runtime.execute_main_module(&s).await.unwrap();
+            let error = runtime.call_default_handler(id, &[]).await.unwrap_err();
+            assert_eq!(
+                error.to_string(),
+                "RuntimeError: boom\n    at handler (file://jstz/accounts/root:1:28)"
+            );
         });
     }
 }

--- a/crates/jstz_runtime/src/runtime.rs
+++ b/crates/jstz_runtime/src/runtime.rs
@@ -254,8 +254,6 @@ impl JstzRuntime {
         };
         // Note: [`call_with_args`] wraps the scope with TryCatch for us and converts
         // any exception into an error
-        // FIXME(ryan): If user code throws an uncaught exception, the original
-        // exception is lost and replaced with Uncaught undefined
         let fut = self.call_with_args(&default_fn, args);
         let result = self.with_event_loop_future(fut, Default::default()).await;
         Ok(result?)


### PR DESCRIPTION
# Context

Close: [922](https://linear.app/tezos/issue/JSTZ-922/non-built-in-errors-dont-propagate-to-the-receipt)

The op function didn't recognize the custom rust error. This is because we didn't register the error on js side. This PR fixes that.
# Description

* Introduced custom errors in ext/jstz_main (RuntimeError)
* 01_error.js now exposes a function that registers custom error given an array of error class name in string
* Removed `ProtocolError` as it is overlapping w `RuntimeError`.
* Fixed `JstzDate.protoype.constructor` typo.
* Added`CompileModuleErr` error.

# Manually testing the PR
* Fix/added unit tests

* Manual tests
   Made fetch return a `RuntimeError` immediately. This used to return undefined but now the error is being returned and that error is an `instanceof` `RuntimeError` and `Error` 
