### PR TITLE
fix: remove optional dependency from cli npm package temporarily

### DIFF
--- a/packages/cli/main/install.js
+++ b/packages/cli/main/install.js
@@ -40,11 +40,12 @@ try {
 
   if (packageName != null) {
     try {
-      import.meta.resolveSync(`${packageName}/package.json`);
-      console.log(
-        `Found optional dependency: ${packageName}. Skipping download.`,
-      );
-      process.exit(0);
+      // FIXME(https://linear.app/tezos/issue/JSTZ-924/release-platform-specific-cli-binaries-to-npm)
+      // import.meta.resolveSync(`${packageName}/package.json`);
+      // console.log(
+      //   `Found optional dependency: ${packageName}. Skipping download.`,
+      // );
+      // process.exit(0);
     } catch (e) {}
   }
 

--- a/packages/cli/main/package.json
+++ b/packages/cli/main/package.json
@@ -21,11 +21,6 @@
   "devDependencies": {
     "prettier": "^3.5.3"
   },
-  "optionalDependencies": {
-    "@jstz-dev/cli-darwin-arm64": "0.1.1-alpha.3",
-    "@jstz-dev/cli-linux-arm64": "0.1.1-alpha.3",
-    "@jstz-dev/cli-linux-x64": "0.1.1-alpha.3"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/jstz-dev/jstz.git"


### PR DESCRIPTION
# Context
Forcing resolution of optional dependencies that do not exists fails in `yarn add`. See https://tezos.slack.com/archives/C084FG0R466/p1757407576584279 

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description
Remove optional dependencies and comment out dependency resolution lines
<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
`yarn global add file:/<path-to-jstz>/packages/cli/main`
`npm install -g file:/<path-to-jstz>/packages/cli/main`

<!-- Describe how reviewers and approvers can test this PR. -->
