### PR TITLE
feat(cli): get default network

### DIFF
--- a/crates/jstz_cli/src/network.rs
+++ b/crates/jstz_cli/src/network.rs
@@ -165,10 +165,10 @@ pub async fn exec(command: Command) -> Result<()> {
                 Some(v) => {
                     let name = v.to_string();
                     let size = name.len();
-                    if size > 30 {
+                    if size > 50 {
                         info!(
                             "{} (long network name truncated)",
-                            trim_long_string(&name, 30),
+                            trim_long_string(&name, 50),
                         );
                     } else {
                         info!("{name}")

--- a/crates/jstz_cli/src/network.rs
+++ b/crates/jstz_cli/src/network.rs
@@ -50,6 +50,8 @@ pub enum Command {
         #[arg(value_name = "NETWORK_NAME")]
         name: String,
     },
+    /// Retrieve the default network.
+    GetDefault,
 }
 
 pub async fn exec(command: Command) -> Result<()> {
@@ -156,6 +158,24 @@ pub async fn exec(command: Command) -> Result<()> {
 
             cfg.save()?;
             info!("Deleted network '{short_name}'.");
+            Ok(())
+        }
+        Command::GetDefault => {
+            match cfg.networks.default_network {
+                Some(v) => {
+                    let name = v.to_string();
+                    let size = name.len();
+                    if size > 30 {
+                        info!(
+                            "{} (long network name truncated)",
+                            trim_long_string(&name, 30),
+                        );
+                    } else {
+                        info!("{name}")
+                    }
+                }
+                None => info!("Default network is not set."),
+            };
             Ok(())
         }
     }

--- a/crates/jstz_cli/tests/network.rs
+++ b/crates/jstz_cli/tests/network.rs
@@ -441,7 +441,7 @@ fn get_default_network() {
         .expect("should create file");
     serde_json::to_writer(
         file,
-        &serde_json::json!({"default_network": "a".repeat(50)}),
+        &serde_json::json!({"default_network": "a".repeat(80)}),
     )
     .expect("should write config file");
     Command::cargo_bin("jstz")
@@ -450,7 +450,7 @@ fn get_default_network() {
         .args(["network", "get-default"])
         .assert()
         .stderr(predicates::str::contains(
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaa... (long network name truncated)",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa... (long network name truncated)",
         ))
         .success();
 }


### PR DESCRIPTION
# Context

Part of JSTZ-783.
[JSTZ-783](https://linear.app/tezos/issue/JSTZ-783/support-jstz-network-addupdatedelete)

# Description

Added one command `network get-default` to CLI to retrieve the current default network from the config file.


# Manually testing the PR

* Integration test: added one test
