### PR TITLE
fix(test): update dependency of sequencer integration tests

### DIFF
--- a/crates/jstz_node/Cargo.toml
+++ b/crates/jstz_node/Cargo.toml
@@ -66,6 +66,7 @@ pretty_assertions.workspace = true
 warp.workspace = true
 http.workspace = true
 jstz_mock = { path = "../jstz_mock" }
+jstz_utils = { path = "../jstz_utils", features = ["test_utils"] }
 
 [[bin]]
 name = "jstz-node"


### PR DESCRIPTION
# Context

[Nightly test](https://github.com/jstz-dev/jstz/actions/runs/18119000488/job/51560749626) failed due to changes in #1332.

# Description

Added `jstz_utils/test_utils` as a dependency for sequencer integration tests.

# Manually testing the PR

```
cargo test --test sequencer run_riscv_sequencer --features riscv_test --release
```
