### PR TITLE
feat(cli): set default network

### DIFF
--- a/crates/jstz_cli/src/network.rs
+++ b/crates/jstz_cli/src/network.rs
@@ -2,9 +2,11 @@ use crate::{
     config::{Config, Network},
     error::{bail_user_error, Result},
 };
+use anyhow::Context;
 use clap::{Args, Subcommand};
 use log::info;
 use prettytable::{format::consts::FORMAT_DEFAULT, Cell, Row, Table};
+use std::str::FromStr;
 
 #[derive(Args, Debug)]
 #[group(required = true, multiple = true)]
@@ -52,6 +54,12 @@ pub enum Command {
     },
     /// Retrieve the default network.
     GetDefault,
+    /// Set default network.
+    SetDefault {
+        /// Name of the network to be used as the default network.
+        #[arg(value_name = "NETWORK_NAME")]
+        name: String,
+    },
 }
 
 pub async fn exec(command: Command) -> Result<()> {
@@ -176,6 +184,21 @@ pub async fn exec(command: Command) -> Result<()> {
                 }
                 None => info!("Default network is not set."),
             };
+            Ok(())
+        }
+        Command::SetDefault { name } => {
+            let network = crate::config::NetworkName::from_str(&name)
+                .context("failed to parse network name")?;
+            let short_name = trim_long_string(&name, 20);
+            if let crate::config::NetworkName::Custom(_) = &network {
+                if !cfg.networks.networks.contains_key(&name) {
+                    bail_user_error!("Network '{short_name}' does not exist.")
+                }
+            }
+
+            cfg.networks.default_network.replace(network);
+            cfg.save()?;
+            info!("Using network '{short_name}' as the default network.");
             Ok(())
         }
     }


### PR DESCRIPTION
# Context

Part of JSTZ-783.
[JSTZ-783](https://linear.app/tezos/issue/JSTZ-783/support-jstz-network-addupdatedelete)

# Description

Added one command `network set-default` to CLI to set the current default network.

Example:
```sh
$ jstz network list
  +------+--------------------+--------------------+
  | Name | Octez RPC endpoint | Jstz node endpoint |
  +======+====================+====================+
  | bar  | http://c.com       | http://d.com       |
  +------+--------------------+--------------------+

$ jstz network get-default
Default network is not set.
$ jstz network set-default bar
Using network 'bar' as the default network.
$ jstz network get-default    
bar
$ jstz network set-default dev
Using network 'dev' as the default network.
$ jstz network get-default    
dev
```

# Manually testing the PR

* Integration test: added one test
