### PR TITLE
fix(proto): add test_utils flag

### DIFF
--- a/crates/jstz_proto/Cargo.toml
+++ b/crates/jstz_proto/Cargo.toml
@@ -47,7 +47,7 @@ url.workspace = true
 [dev-dependencies]
 bincode.workspace = true
 jstz_mock = { path = "../jstz_mock" }
-jstz_utils = { path = "../jstz_utils" }
+jstz_utils = { path = "../jstz_utils", features = ["test_utils"] }
 tezos-smart-rollup-mock.workspace = true
 tokio.workspace = true
 

--- a/crates/jstz_utils/src/lib.rs
+++ b/crates/jstz_utils/src/lib.rs
@@ -110,13 +110,11 @@ pub mod test_util {
             self.inner.clone()
         }
 
-        #[cfg(feature = "v2_runtime")]
         pub fn str_content(&self) -> String {
             let buf = self.inner.lock().unwrap();
             String::from_utf8(buf.to_vec()).unwrap()
         }
 
-        #[cfg(feature = "v2_runtime")]
         pub fn lines(&self) -> Vec<String> {
             let str_content = self.str_content();
             str_content.split("\n").map(|s| s.to_string()).collect()

--- a/crates/kernels/jstz_kernel/Cargo.toml
+++ b/crates/kernels/jstz_kernel/Cargo.toml
@@ -40,7 +40,7 @@ anyhow.workspace = true
 [dev-dependencies]
 anyhow.workspace = true
 jstz_mock = { path = "../../jstz_mock" }
-jstz_utils = { path = "../../jstz_utils" }
+jstz_utils = { path = "../../jstz_utils", features = ["test_utils"]  }
 http.workspace = true
 serde_json.workspace = true
 tokio.workspace = true


### PR DESCRIPTION
# Context
Due to changes in #1332, a test fails due to unresolved import since the test_util feature does not propagate when only a single package is tested.

# Description
Adds test_utils feature as a dependency to jstz_kernel and jstz_proto. 
Additionally it removes gating on v2_runtime for some DebugLogSink, which isn't needed anymore and is anyway gated on test_utils feature. 

# Manual testing
```make```
```cargo nextest run -p jstz_proto --features v2_runtime```