### PR TITLE
feat(test): send notification when nightly test fails

### DIFF
--- a/.github/workflows/test-nightly-post-run.yml
+++ b/.github/workflows/test-nightly-post-run.yml
@@ -1,0 +1,24 @@
+name: Nightly test post-run actions
+
+on:
+  workflow_run:
+    workflows: ["Run nightly long-running tests"]
+    types:
+      - completed
+    branches: [main]
+
+jobs:
+  notify-on-failure:
+    # Failed re-run attempts will not trigger new notifications.
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt == 1 }}
+    name: Send notification when run fails
+    runs-on: ubuntu-latest
+    steps:
+      - name: Push slack message
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.NIGHTLY_TEST_SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            "source": "GitHub",
+            "message": "Nightly test failed. ${{ github.event.workflow_run.html_url }}",


### PR DESCRIPTION
# Context

Completes JSTZ-925.
[JSTZ-925](https://linear.app/tezos/issue/JSTZ-925/post-on-slack-when-nightly-test-fails)

# Description

Added one workflow that runs after the nightly test workflow completes. This workflow sends a slack message when the nightly test workflow fails.

# Manually testing the PR

[Test run](https://github.com/huancheng-trili/test-workflow-fail/actions/runs/18189877696)
Sample slack message:
<img width="710" height="131" alt="image" src="https://github.com/user-attachments/assets/d485e366-02da-456f-9c52-1df0882d173c" />

