### PR TITLE
fix: update jstz_sdk dependency version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22048,13 +22048,13 @@
       "version": "0.0.0",
       "dependencies": {
         "@jstz-dev/jstz-client": "0.1.1-alpha.4",
-        "jstz_sdk": "0.1.1-alpha.4"
+        "jstz_sdk": "0.1.1-alpha.4.1"
       }
     },
     "packages/sdk/node_modules/jstz_sdk": {
-      "version": "0.1.1-alpha.4",
-      "resolved": "https://registry.npmjs.org/jstz_sdk/-/jstz_sdk-0.1.1-alpha.4.tgz",
-      "integrity": "sha512-P+uFb4lRaMR34YFRRsh4Po2WtAmwzLrVjS0xbtyoFXR6xj4qQ2J0WwPHKraiXSUNDXy0m46WrKOOizhcTYyUfg=="
+      "version": "0.1.1-alpha.4.1",
+      "resolved": "https://registry.npmjs.org/jstz_sdk/-/jstz_sdk-0.1.1-alpha.4.1.tgz",
+      "integrity": "sha512-rxQK60MYBSRbEw4bQE16iSE6ARQxWKQxvgMbWrdvEzU4m0lLR+She8wCfVZkqSy8TkqHBT66f1DPp695V5E2Qg=="
     },
     "packages/types": {
       "name": "@jstz-dev/types",
@@ -24938,13 +24938,13 @@
       "version": "file:packages/sdk",
       "requires": {
         "@jstz-dev/jstz-client": "0.1.1-alpha.4",
-        "jstz_sdk": "0.1.1-alpha.4"
+        "jstz_sdk": "0.1.1-alpha.4.1"
       },
       "dependencies": {
         "jstz_sdk": {
-          "version": "0.1.1-alpha.4",
-          "resolved": "https://registry.npmjs.org/jstz_sdk/-/jstz_sdk-0.1.1-alpha.4.tgz",
-          "integrity": "sha512-P+uFb4lRaMR34YFRRsh4Po2WtAmwzLrVjS0xbtyoFXR6xj4qQ2J0WwPHKraiXSUNDXy0m46WrKOOizhcTYyUfg=="
+          "version": "0.1.1-alpha.4.1",
+          "resolved": "https://registry.npmjs.org/jstz_sdk/-/jstz_sdk-0.1.1-alpha.4.1.tgz",
+          "integrity": "sha512-rxQK60MYBSRbEw4bQE16iSE6ARQxWKQxvgMbWrdvEzU4m0lLR+She8wCfVZkqSy8TkqHBT66f1DPp695V5E2Qg=="
         }
       }
     },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -10,6 +10,6 @@
   },
   "dependencies": {
     "@jstz-dev/jstz-client": "0.1.1-alpha.4",
-    "jstz_sdk": "0.1.1-alpha.4"
+    "jstz_sdk": "0.1.1-alpha.4.1"
   }
 }


### PR DESCRIPTION
# Context
`jstz_sdk@0.1.1-alpha.4` was recently pulled from npm and bumped to `alpha4.1` which causes ["Build Documentation" ci step](https://github.com/jstz-dev/jstz/actions/runs/18321588556/job/52175824323) to fail. This PR fixes that 

<!-- Why is this change required? What problem does it solve? -->

<!-- If it closes an Asana Task, please link to the task here. -->
<!-- **Related Tasks**: [Task name](Task url) -->

# Description

<!-- Describe your changes in detail. -->

<!-- If this PR has dependencies, please link them here. -->
<!-- **Dependencies**: -->

# Manually testing the PR
`npm ci`
<!-- Describe how reviewers and approvers can test this PR. -->
